### PR TITLE
Allow notebook patch release to vary

### DIFF
--- a/minimal-notebook/Dockerfile
+++ b/minimal-notebook/Dockerfile
@@ -1,3 +1,4 @@
+# Copyright (c) Jupyter Development Team.
 FROM debian:jessie
 
 MAINTAINER Jupyter Project <jupyter@googlegroups.com>
@@ -52,7 +53,7 @@ WORKDIR $WORK
 
 # Install Jupyter notebook
 RUN conda install --yes \
-    ipython-notebook==3.2 \
+    'ipython-notebook=3.2*' \
     terminado \
     && conda clean -yt
 


### PR DESCRIPTION
Noticed that r-notebook was installing ipython 3.2.1 while the base image already had 3.2.0. Updated minimal-notebook conda command to allow patch to vary.
