### PR TITLE
Upgrade to Jupyter Notebook 4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ Note: Branches / tags reflect the version of the primary process in each contain
 
 | Docker Hub repo | GitHub source | Git Branch &rarr; Docker Tag |
 | --------------- | ------------- | ---------------------------- |
-| [jupyter/minimal-notebook](https://hub.docker.com/r/jupyter/minimal-notebook/) | [minimal-notebook](./minimal-notebook) | master &rarr; latest <br /> 3.2.x &rarr; 3.2 |
-| [jupyter/scipy-notebook](https://hub.docker.com/r/jupyter/scipy-notebook/) | [scipy-notebook](./scipy-notebook) | master &rarr; latest <br /> 3.2.x &rarr; 3.2 |
-| [jupyter/r-notebook](https://hub.docker.com/r/jupyter/r-notebook/) | [r-notebook](./r-notebook) | master &rarr; latest <br /> 3.2.x &rarr; 3.2 |
-| [jupyter/all-spark-notebook](https://hub.docker.com/r/jupyter/all-spark-notebook/) | [all-spark-notebook](./all-spark-notebook) | master &rarr; latest <br /> 3.2.x &rarr; 3.2 |
-| [jupyter/pyspark-notebook](https://hub.docker.com/r/jupyter/pyspark-notebook/) | [pyspark-notebook](./pyspark-notebook) | master &rarr; latest <br /> 3.2.x &rarr; 3.2 |
+| [jupyter/minimal-notebook](https://hub.docker.com/r/jupyter/minimal-notebook/) | [minimal-notebook](./minimal-notebook) | master &rarr; latest <br /> 4.0.x &rarr; 4.0 <br /> 3.2.x &rarr; 3.2 |
+| [jupyter/scipy-notebook](https://hub.docker.com/r/jupyter/scipy-notebook/) | [scipy-notebook](./scipy-notebook) | master &rarr; latest <br /> 4.0.x &rarr; 4.0 <br /> 3.2.x &rarr; 3.2 |
+| [jupyter/r-notebook](https://hub.docker.com/r/jupyter/r-notebook/) | [r-notebook](./r-notebook) | master &rarr; latest <br /> 4.0.x &rarr; 4.0 <br /> 3.2.x &rarr; 3.2 |
+| [jupyter/all-spark-notebook](https://hub.docker.com/r/jupyter/all-spark-notebook/) | [all-spark-notebook](./all-spark-notebook) | master &rarr; latest <br /> 4.0.x &rarr; 4.0 <br /> 3.2.x &rarr; 3.2 |
+| [jupyter/pyspark-notebook](https://hub.docker.com/r/jupyter/pyspark-notebook/) | [pyspark-notebook](./pyspark-notebook) | master &rarr; latest <br /> 4.0.x &rarr; 4.0 <br /> 3.2.x &rarr; 3.2 |

--- a/all-spark-notebook/Dockerfile
+++ b/all-spark-notebook/Dockerfile
@@ -1,6 +1,5 @@
-# Copyright (c) IPython Development Team.
-# (c) Copyright IBM Corp. 2015
-FROM jupyter/minimal-notebook
+# Copyright (c) Jupyter Development Team.
+FROM jupyter/minimal-notebook:4.0
 
 MAINTAINER Jupyter Project <jupyter@googlegroups.com>
 
@@ -54,6 +53,7 @@ ENV MESOS_NATIVE_LIBRARY /usr/local/lib/libmesos.so
 
 # Install Python 3 packages
 RUN conda install --yes \
+    'ipywidgets=4.0*' \
     'pandas=0.16*' \
     'matplotlib=1.4*' \
     'scipy=0.15*' \
@@ -63,7 +63,8 @@ RUN conda install --yes \
 
 # Install Python 2 packages and kernel spec
 RUN conda create -p $CONDA_DIR/envs/python2 python=2.7 \
-    'ipython=3.2*' \
+    'ipython=4.0*' \
+    'ipywidgets=4.0*' \
     'pandas=0.16*' \
     'matplotlib=1.4*' \
     'scipy=0.15*' \

--- a/all-spark-notebook/README.md
+++ b/all-spark-notebook/README.md
@@ -2,7 +2,7 @@
 
 ## What it Gives You
 
-* Jupyter Notebook server v3.2.x
+* Jupyter Notebook server (v4.0.x or v3.2.x, see tag)
 * Conda Python 3.4.x and Python 2.7.x environments
 * Conda R 3.1.x environment
 * Scala 2.10.x
@@ -205,6 +205,7 @@ You may customize the execution of the Docker container and the Notebook server 
 * `-e USE_HTTPS=yes` - Configures Jupyter Notebook to accept encrypted HTTPS connections. If a `pem` file containing a SSL certificate and key is not found in `/home/jovyan/.ipython/profile_default/security/notebook.pem`, the container will generate a self-signed certificate for you.
 * `-e GRANT_SUDO=yes` - Gives the `jovyan` user passwordless `sudo` capability. Useful for installing OS packages. **You should only enable `sudo` if you trust the user or if the container is running on an isolated host.**
 * `-v /some/host/folder/for/work:/home/jovyan/work` - Host mounts the default working directory on the host to preserve work even when the container is destroyed and recreated (e.g., during an upgrade).
-* `-v /some/host/folder/for/server.pem:/home/jovyan/.ipython/profile_default/security/notebook.pem` - Mounts a SSL certificate plus key for `USE_HTTPS`. Useful if you have a real certificate for the domain under which you are running the Notebook server.
+* **(v3.2.x)** `-v /some/host/folder/for/server.pem:/home/jovyan/.ipython/profile_default/security/notebook.pem` - Mounts a SSL certificate plus key for `USE_HTTPS`. Useful if you have a real certificate for the domain under which you are running the Notebook server.
+* **(v4.0.x)** `-v /some/host/folder/for/server.pem:/home/jovyan/.local/share/jupyter/notebook.pem` - Mounts a SSL certificate plus key for `USE_HTTPS`. Useful if you have a real certificate for the domain under which you are running the Notebook server.
 * `-e INTERFACE=10.10.10.10` - Configures Jupyter Notebook to listen on the given interface. Defaults to '*', all interfaces, which is appropriate when running using default bridged Docker networking. When using Docker's `--net=host`, you may wish to use this option to specify a particular network interface.
 * `-e PORT=8888` - Configures Jupyter Notebook to listen on the given port. Defaults to 8888, which is the port exposed within the Dockerfile for the image. When using Docker's `--net=host`, you may wish to use this option to specify a particular port.

--- a/minimal-notebook/Dockerfile
+++ b/minimal-notebook/Dockerfile
@@ -53,12 +53,12 @@ WORKDIR $WORK
 
 # Install Jupyter notebook
 RUN conda install --yes \
-    'ipython-notebook=3.2*' \
+    'notebook=4.0*' \
     terminado \
     && conda clean -yt
 
 # Configure Jupyter
-RUN ipython profile create
+RUN jupyter notebook --generate-config
 
 # Configure container startup
 EXPOSE 8888
@@ -66,7 +66,7 @@ USER root
 CMD ["supervisord", "-n", "-c", "/etc/supervisor/supervisord.conf"]
 
 # Add local files as late as possible to avoid cache busting
-COPY ipython_notebook_config.py $HOME/.ipython/profile_default/
+COPY jupyter_notebook_config.py $HOME/.jupyter/
 COPY notebook.conf /etc/supervisor/conf.d/
 COPY enable_sudo.sh /usr/local/bin/
-RUN chown $NB_USER:$NB_USER $HOME/.ipython/profile_default/ipython_notebook_config.py
+RUN chown $NB_USER:$NB_USER $HOME/.jupyter/jupyter_notebook_config.py

--- a/minimal-notebook/README.md
+++ b/minimal-notebook/README.md
@@ -2,7 +2,7 @@
 
 ## What it Gives You
 
-* Jupyter Notebook server v3.2.x
+* Jupyter Notebook server (v4.0.x or v3.2.x, see tag)
 * Conda Python 3.4.x
 * No preinstalled scientific computing packages
 * Options for HTTPS, password auth, and passwordless `sudo`
@@ -20,9 +20,10 @@ docker run -d -p 8888:8888 jupyter/minimal-notebook
 You may customize the execution of the Docker container and the Notebook server it contains with the following optional arguments.
 
 * `-e PASSWORD="YOURPASS"` - Configures Jupyter Notebook to require the given password. Should be conbined with `USE_HTTPS` on untrusted networks.
-* `-e USE_HTTPS=yes` - Configures Jupyter Notebook to accept encrypted HTTPS connections. If a `pem` file containing a SSL certificate and key is not found in `/home/jovyan/.ipython/profile_default/security/notebook.pem`, the container will generate a self-signed certificate for you.
+* `-e USE_HTTPS=yes` - Configures Jupyter Notebook to accept encrypted HTTPS connections. If a `pem` file containing a SSL certificate and key is not provided (see below), the container will generate a self-signed certificate for you.
 * `-e GRANT_SUDO=yes` - Gives the `jovyan` user passwordless `sudo` capability. Useful for installing OS packages. **You should only enable `sudo` if you trust the user or if the container is running on an isolated host.**
 * `-v /some/host/folder/for/work:/home/jovyan/work` - Host mounts the default working directory on the host to preserve work even when the container is destroyed and recreated (e.g., during an upgrade).
-* `-v /some/host/folder/for/server.pem:/home/jovyan/.ipython/profile_default/security/notebook.pem` - Mounts a SSL certificate plus key for `USE_HTTPS`. Useful if you have a real certificate for the domain under which you are running the Notebook server.
+* **(v3.2.x)** `-v /some/host/folder/for/server.pem:/home/jovyan/.ipython/profile_default/security/notebook.pem` - Mounts a SSL certificate plus key for `USE_HTTPS`. Useful if you have a real certificate for the domain under which you are running the Notebook server.
+* **(v4.0.x)** `-v /some/host/folder/for/server.pem:/home/jovyan/.local/share/jupyter/notebook.pem` - Mounts a SSL certificate plus key for `USE_HTTPS`. Useful if you have a real certificate for the domain under which you are running the Notebook server.
 * `-e INTERFACE=10.10.10.10` - Configures Jupyter Notebook to listen on the given interface. Defaults to '*', all interfaces, which is appropriate when running using default bridged Docker networking. When using Docker's `--net=host`, you may wish to use this option to specify a particular network interface.
 * `-e PORT=8888` - Configures Jupyter Notebook to listen on the given port. Defaults to 8888, which is the port exposed within the Dockerfile for the image. When using Docker's `--net=host`, you may wish to use this option to specify a particular port.

--- a/minimal-notebook/jupyter_notebook_config.py
+++ b/minimal-notebook/jupyter_notebook_config.py
@@ -1,9 +1,9 @@
-# Copyright (c) IPython Development Team.
-# (c) Copyright IBM Corp. 2015
+# Copyright (c) Jupyter Development Team.
+from jupyter_core.paths import jupyter_data_dir
 import subprocess
 import os
 
-PEM_FILE = os.path.join(os.path.dirname(__file__), 'security/notebook.pem')
+PEM_FILE = os.path.join(jupyter_data_dir(), 'notebook.pem')
 
 c = get_config()
 c.NotebookApp.ip = os.getenv('INTERFACE', '') or '*'

--- a/pyspark-notebook/Dockerfile
+++ b/pyspark-notebook/Dockerfile
@@ -1,6 +1,5 @@
-# Copyright (c) IPython Development Team.
-# (c) Copyright IBM Corp. 2015
-FROM jupyter/minimal-notebook
+# Copyright (c) Jupyter Development Team.
+FROM jupyter/minimal-notebook:4.0
 
 MAINTAINER Jupyter Project <jupyter@googlegroups.com>
 
@@ -32,6 +31,7 @@ ENV MESOS_NATIVE_LIBRARY /usr/local/lib/libmesos.so
 
 # Install Python 3 packages
 RUN conda install --yes \
+    'ipywidgets=4.0*' \
     'pandas=0.16*' \
     'matplotlib=1.4*' \
     'scipy=0.15*' \
@@ -41,7 +41,8 @@ RUN conda install --yes \
 
 # Install Python 2 packages and kernel spec
 RUN conda create -p $CONDA_DIR/envs/python2 python=2.7 \
-    'ipython=3.2*' \
+    'ipython=4.0*' \
+    'ipywidgets=4.0*' \
     'pandas=0.16*' \
     'matplotlib=1.4*' \
     'scipy=0.15*' \

--- a/pyspark-notebook/README.md
+++ b/pyspark-notebook/README.md
@@ -2,7 +2,7 @@
 
 ## What it Gives You
 
-* Jupyter Notebook server v3.2.x
+* Jupyter Notebook server (v4.0.x or v3.2.x, see tag)
 * Conda Python 3.4.x and Python 2.7.x environments
 * pyspark, pandas, matplotlib, scipy, seaborn, scikit-learn pre-installed
 * Spark 1.4.1 for use in local mode or to connect to a cluster of Spark workers
@@ -95,6 +95,7 @@ You may customize the execution of the Docker container and the Notebook server 
 * `-e USE_HTTPS=yes` - Configures Jupyter Notebook to accept encrypted HTTPS connections. If a `pem` file containing a SSL certificate and key is not found in `/home/jovyan/.ipython/profile_default/security/notebook.pem`, the container will generate a self-signed certificate for you.
 * `-e GRANT_SUDO=yes` - Gives the `jovyan` user passwordless `sudo` capability. Useful for installing OS packages. **You should only enable `sudo` if you trust the user or if the container is running on an isolated host.**
 * `-v /some/host/folder/for/work:/home/jovyan/work` - Host mounts the default working directory on the host to preserve work even when the container is destroyed and recreated (e.g., during an upgrade).
-* `-v /some/host/folder/for/server.pem:/home/jovyan/.ipython/profile_default/security/notebook.pem` - Mounts a SSL certificate plus key for `USE_HTTPS`. Useful if you have a real certificate for the domain under which you are running the Notebook server.
+* **(v3.2.x)** `-v /some/host/folder/for/server.pem:/home/jovyan/.ipython/profile_default/security/notebook.pem` - Mounts a SSL certificate plus key for `USE_HTTPS`. Useful if you have a real certificate for the domain under which you are running the Notebook server.
+* **(v4.0.x)** `-v /some/host/folder/for/server.pem:/home/jovyan/.local/share/jupyter/notebook.pem` - Mounts a SSL certificate plus key for `USE_HTTPS`. Useful if you have a real certificate for the domain under which you are running the Notebook server.
 * `-e INTERFACE=10.10.10.10` - Configures Jupyter Notebook to listen on the given interface. Defaults to '*', all interfaces, which is appropriate when running using default bridged Docker networking. When using Docker's `--net=host`, you may wish to use this option to specify a particular network interface.
 * `-e PORT=8888` - Configures Jupyter Notebook to listen on the given port. Defaults to 8888, which is the port exposed within the Dockerfile for the image. When using Docker's `--net=host`, you may wish to use this option to specify a particular port.

--- a/r-notebook/Dockerfile
+++ b/r-notebook/Dockerfile
@@ -1,5 +1,5 @@
 # Copyright (c) Jupyter Development Team.
-FROM jupyter/minimal-notebook
+FROM jupyter/minimal-notebook:4.0
 
 MAINTAINER Jupyter Project <jupyter@googlegroups.com>
 

--- a/r-notebook/README.md
+++ b/r-notebook/README.md
@@ -2,7 +2,7 @@
 
 ## What it Gives You
 
-* Jupyter Notebook server v3.2.x
+* Jupyter Notebook server (v4.0.x or v3.2.x, see tag)
 * Conda R v3.2.x and channel
 * plyr, devtools, dplyr, ggplot2, tidyr, shiny, rmarkdown, forecast, stringr, rsqlite, reshape2, nycflights13, caret, rcurl, and randomforest pre-installed
 * Options for HTTPS, password auth, and passwordless `sudo`
@@ -23,6 +23,7 @@ You may customize the execution of the Docker container and the Notebook server 
 * `-e USE_HTTPS=yes` - Configures Jupyter Notebook to accept encrypted HTTPS connections. If a `pem` file containing a SSL certificate and key is not found in `/home/jovyan/.ipython/profile_default/security/notebook.pem`, the container will generate a self-signed certificate for you.
 * `-e GRANT_SUDO=yes` - Gives the `jovyan` user passwordless `sudo` capability. Useful for installing OS packages. **You should only enable `sudo` if you trust the user or if the container is running on an isolated host.**
 * `-v /some/host/folder/for/work:/home/jovyan/work` - Host mounts the default working directory on the host to preserve work even when the container is destroyed and recreated (e.g., during an upgrade).
-* `-v /some/host/folder/for/server.pem:/home/jovyan/.ipython/profile_default/security/notebook.pem` - Mounts a SSL certificate plus key for `USE_HTTPS`. Useful if you have a real certificate for the domain under which you are running the Notebook server.
+* **(v3.2.x)** `-v /some/host/folder/for/server.pem:/home/jovyan/.ipython/profile_default/security/notebook.pem` - Mounts a SSL certificate plus key for `USE_HTTPS`. Useful if you have a real certificate for the domain under which you are running the Notebook server.
+* **(v4.0.x)** `-v /some/host/folder/for/server.pem:/home/jovyan/.local/share/jupyter/notebook.pem` - Mounts a SSL certificate plus key for `USE_HTTPS`. Useful if you have a real certificate for the domain under which you are running the Notebook server.
 * `-e INTERFACE=10.10.10.10` - Configures Jupyter Notebook to listen on the given interface. Defaults to '*', all interfaces, which is appropriate when running using default bridged Docker networking. When using Docker's `--net=host`, you may wish to use this option to specify a particular network interface.
 * `-e PORT=8888` - Configures Jupyter Notebook to listen on the given port. Defaults to 8888, which is the port exposed within the Dockerfile for the image. When using Docker's `--net=host`, you may wish to use this option to specify a particular port.

--- a/scipy-notebook/Dockerfile
+++ b/scipy-notebook/Dockerfile
@@ -1,4 +1,5 @@
-FROM jupyter/minimal-notebook
+# Copyright (c) Jupyter Development Team.
+FROM jupyter/minimal-notebook:4.0
 
 MAINTAINER Jupyter Project <jupyter@googlegroups.com>
 
@@ -6,6 +7,7 @@ USER jovyan
 
 # Install Python 3 packages
 RUN conda install --yes \
+    'ipywidgets=4.0*' \
     'pandas=0.16*' \
     'matplotlib=1.4*' \
     'scipy=0.15*' \
@@ -24,7 +26,8 @@ RUN conda install --yes \
 
 # Install Python 2 packages and kernel spec
 RUN conda create -p $CONDA_DIR/envs/python2 python=2.7 \
-    'ipython=3.2*' \
+    'ipython=4.0*' \
+    'ipywidgets=4.0*' \
     'pandas=0.16*' \
     'matplotlib=1.4*' \
     'scipy=0.15*' \

--- a/scipy-notebook/README.md
+++ b/scipy-notebook/README.md
@@ -2,7 +2,7 @@
 
 ## What it Gives You
 
-* Jupyter Notebook server v3.2.x
+* Jupyter Notebook server (v4.0.x or v3.2.x, see tag)
 * Conda Python 3.4.x and Python 2.7.x environments
 * pandas, matplotlib, scipy, seaborn, scikit-learn, scikit-image, sympy, cython, patsy, statsmodel, cloudpickle, dill, numba, bokeh pre-installed
 * Options for HTTPS, password auth, and passwordless `sudo`
@@ -23,6 +23,7 @@ You may customize the execution of the Docker container and the Notebook server 
 * `-e USE_HTTPS=yes` - Configures Jupyter Notebook to accept encrypted HTTPS connections. If a `pem` file containing a SSL certificate and key is not found in `/home/jovyan/.ipython/profile_default/security/notebook.pem`, the container will generate a self-signed certificate for you.
 * `-e GRANT_SUDO=yes` - Gives the `jovyan` user passwordless `sudo` capability. Useful for installing OS packages. **You should only enable `sudo` if you trust the user or if the container is running on an isolated host.**
 * `-v /some/host/folder/for/work:/home/jovyan/work` - Host mounts the default working directory on the host to preserve work even when the container is destroyed and recreated (e.g., during an upgrade).
-* `-v /some/host/folder/for/server.pem:/home/jovyan/.ipython/profile_default/security/notebook.pem` - Mounts a SSL certificate plus key for `USE_HTTPS`. Useful if you have a real certificate for the domain under which you are running the Notebook server.
+* **(v3.2.x)** `-v /some/host/folder/for/server.pem:/home/jovyan/.ipython/profile_default/security/notebook.pem` - Mounts a SSL certificate plus key for `USE_HTTPS`. Useful if you have a real certificate for the domain under which you are running the Notebook server.
+* **(v4.0.x)** `-v /some/host/folder/for/server.pem:/home/jovyan/.local/share/jupyter/notebook.pem` - Mounts a SSL certificate plus key for `USE_HTTPS`. Useful if you have a real certificate for the domain under which you are running the Notebook server.
 * `-e INTERFACE=10.10.10.10` - Configures Jupyter Notebook to listen on the given interface. Defaults to '*', all interfaces, which is appropriate when running using default bridged Docker networking. When using Docker's `--net=host`, you may wish to use this option to specify a particular network interface.
 * `-e PORT=8888` - Configures Jupyter Notebook to listen on the given port. Defaults to 8888, which is the port exposed within the Dockerfile for the image. When using Docker's `--net=host`, you may wish to use this option to specify a particular port.


### PR DESCRIPTION
* Change minimal-notebook to install notebook=4.0*
* Change config and pem file paths for jupyter 
* Install ipywidgets in all containers that have a Python stack
* Update all READMEs to describe v3.2 and v4.0 since Docker Hub only shows one README for all tags

Doing this all in a 4.0.x branch first to check how it builds on Docker Hub under a 4.0 tag. If all goes well, will merge to master here and latest there.