### PR TITLE
Prevent r-irkernel from downgrading to ipython 3.2.1

### DIFF
--- a/all-spark-notebook/Dockerfile
+++ b/all-spark-notebook/Dockerfile
@@ -79,10 +79,23 @@ RUN $CONDA_DIR/envs/python2/bin/python \
 # R packages
 RUN conda config --add channels r
 RUN conda install --yes \
-    'r-base=3.1*' \
-    'r-irkernel=0.4*' \
+    'r-base=3.2*' \
     'r-ggplot2=1.0*' \
     'r-rcurl=1.95*' && conda clean -yt
+
+# Issue #17: R downgrades ipython to 3.2.1
+# Workaround until packaging reqs update
+RUN conda install --yes -f 'r-irkernel=0.4*' && conda clean -yt
+RUN conda install --yes \
+    'r-base64enc' \
+    'r-irdisplay' \
+    'r-repr' \
+    'r-rzmq' \
+    'r-evaluate' \
+    'r-jsonlite' \
+    'r-magrittr' \
+    'r-stringi' \
+    'r-uuid' && conda clean -yt
 
 # Scala Spark kernel spec
 RUN mkdir -p $HOME/.ipython/kernels/scala

--- a/r-notebook/Dockerfile
+++ b/r-notebook/Dockerfile
@@ -17,7 +17,6 @@ USER jovyan
 RUN conda config --add channels r
 RUN conda install --yes \
     'r-base=3.2*' \
-    'r-irkernel=0.4*' \
     'r-plyr=1.8*' \
     'r-devtools=1.8*' \
     'r-dplyr=0.4*' \
@@ -33,6 +32,16 @@ RUN conda install --yes \
     'r-caret=6.0*' \
     'r-rcurl=1.95*' \
     'r-randomforest=4.6*' && conda clean -yt
+
+# Issue #17: R downgrades ipython to 3.2.1
+# Workaround until packaging reqs update
+RUN conda install --yes -f 'r-irkernel=0.4*' && conda clean -yt
+RUN conda install --yes \
+    'r-base64enc' \
+    'r-irdisplay' \
+    'r-repr' \
+    'r-rzmq' \
+    'r-uuid' && conda clean -yt
 
 # Switch back to root so that supervisord runs under that user
 USER root


### PR DESCRIPTION
Workaround for issue #17.  

Force irkernel to install without deps, then install the irkernel deps. Manually built and tested locally with some notebooks to see if irkernel is minimally functional at least.

@rgbkrk OK as a workaround? IMHO, better than having 4.0 tagged images out there that are really 3.2.1. (Surprise! :tada:) 