### PR TITLE
Preserve notebook ownership on host

### DIFF
--- a/minimal-notebook/start-notebook.sh
+++ b/minimal-notebook/start-notebook.sh
@@ -11,8 +11,7 @@ if [ -z "$user_exists" ] ; then
     useradd -m -s /bin/bash -u ${NB_UID:-1000} $NB_USER
 
     # Setup a work directory rooted in the NB_USER home
-    mkdir -p $NB_WORK
-    chown -R $NB_USER.$NB_USER $NB_HOME
+    mkdir $NB_WORK && chown $NB_USER.$NB_USER $NB_WORK
 
     # Allow NB_USER group to update conda root env
     chown -R root.$NB_USER $CONDA_DIR

--- a/minimal-notebook/start-notebook.sh
+++ b/minimal-notebook/start-notebook.sh
@@ -22,8 +22,7 @@ fi
 # Copy skeleton files if useradd didn't do it (e.g., volume mounted dir
 # residing in NB_HOME prevented it)
 if [ ! -d $NB_HOME/.jupyter ]; then
-    cp -r /etc/skel/. $NB_HOME
-    chown -R $NB_USER.$NB_USER $NB_HOME
+    sudo -u jovyan cp -r /etc/skel/. $NB_HOME
 fi
 
 # Enable sudo if requested

--- a/minimal-notebook/start-notebook.sh
+++ b/minimal-notebook/start-notebook.sh
@@ -21,6 +21,7 @@ fi
 # Copy skeleton files if useradd didn't do it (e.g., volume mounted dir
 # residing in NB_HOME prevented it)
 if [ ! -d $NB_HOME/.jupyter ]; then
+    chown $NB_USER.$NB_USER $NB_HOME
     sudo -u jovyan cp -r /etc/skel/. $NB_HOME
 fi
 


### PR DESCRIPTION
This is an effort to prevent the container from changing the ownership of my host's notebook directory and files when it is mounted to `/home/jovyan/work` .