### PR TITLE
Create jovyan in Dockerfile, reset UID at startup

### DIFF
--- a/all-spark-notebook/Dockerfile
+++ b/all-spark-notebook/Dockerfile
@@ -49,6 +49,8 @@ ENV R_LIBS_USER $SPARK_HOME/R/lib
 ENV PYTHONPATH $SPARK_HOME/python:$SPARK_HOME/python/lib/py4j-0.8.2.1-src.zip
 ENV MESOS_NATIVE_LIBRARY /usr/local/lib/libmesos.so
 
+USER jovyan
+
 # Install Python 3 packages
 RUN conda install --yes \
     'ipywidgets=4.0*' \
@@ -59,7 +61,7 @@ RUN conda install --yes \
     'scikit-learn=0.16*' \
     && conda clean -yt
 
-# Install Python 2 packages and kernel spec
+# Install Python 2 packages
 RUN conda create -p $CONDA_DIR/envs/python2 python=2.7 \
     'ipython=4.0*' \
     'ipywidgets=4.0*' \
@@ -70,9 +72,6 @@ RUN conda create -p $CONDA_DIR/envs/python2 python=2.7 \
     'scikit-learn=0.16*' \
     pyzmq \
     && conda clean -yt
-RUN $CONDA_DIR/envs/python2/bin/python \
-    $CONDA_DIR/envs/python2/bin/ipython \
-    kernelspec install-self
 
 # R packages
 RUN conda config --add channels r
@@ -83,5 +82,13 @@ RUN conda install --yes \
     'r-rcurl=1.95*' && conda clean -yt
 
 # Scala Spark kernel spec
-RUN mkdir -p /usr/local/share/jupyter/kernels/scala
-COPY kernel.json /usr/local/share/jupyter/kernels/scala/
+RUN mkdir -p /opt/conda/share/jupyter/kernels/scala
+COPY kernel.json /opt/conda/share/jupyter/kernels/scala/
+
+USER root
+
+# Install Python 2 kernel spec globally to avoid permission problems when NB_UID
+# switching at runtime.
+RUN $CONDA_DIR/envs/python2/bin/python \
+    $CONDA_DIR/envs/python2/bin/ipython \
+    kernelspec install-self

--- a/all-spark-notebook/README.md
+++ b/all-spark-notebook/README.md
@@ -10,6 +10,7 @@
 * ggplot2, rcurl preinstalled for R
 * Spark 1.4.1 for use in local mode or to connect to a cluster of Spark workers
 * Mesos client 0.22 binary that can communicate with a Mesos master
+* Unprivileged user `jovyan` (uid=1000, configurable, see options) in group `users` (gid=100) with ownership over `/home/jovyan` and `/opt/conda`
 * Options for HTTPS, password auth, and passwordless `sudo`
 
 ## Basic Use

--- a/datascience-notebook/Dockerfile
+++ b/datascience-notebook/Dockerfile
@@ -18,6 +18,8 @@ RUN apt-get update && \
     julia \
     libnettle4 && apt-get clean
 
+USER jovyan
+
 # Install Python 3 packages
 RUN conda install --yes \
     'ipywidgets=4.0*' \
@@ -37,7 +39,7 @@ RUN conda install --yes \
     'bokeh=0.9*' \
     && conda clean -yt
 
-# Install Python 2 packages and kernel spec
+# Install Python 2 packages
 RUN conda create -p $CONDA_DIR/envs/python2 python=2.7 \
     'ipython=4.0*' \
     'ipywidgets=4.0*' \
@@ -57,11 +59,8 @@ RUN conda create -p $CONDA_DIR/envs/python2 python=2.7 \
     'bokeh=0.9*' \
     pyzmq \
     && conda clean -yt
-RUN $CONDA_DIR/envs/python2/bin/python \
-    $CONDA_DIR/envs/python2/bin/ipython \
-    kernelspec install-self
 
-# R packages
+# R packages including IRKernel which gets installed globally.
 RUN conda config --add channels r
 RUN conda install --yes \
     'r-base=3.2*' \
@@ -82,6 +81,19 @@ RUN conda install --yes \
     'r-rcurl=1.95*' \
     'r-randomforest=4.6*' && conda clean -yt
 
-# IJulia and Julia packages
-RUN julia -e 'Pkg.add("IJulia")'
+# Install IJulia packages as jovyan and then move the kernelspec out
+# to the system share location. Avoids problems with runtime UID change not 
+# taking effect properly on the .local folder in the jovyan home dir.
+RUN julia -e 'Pkg.add("IJulia")' && \
+    mv /home/$NB_USER/.local/share/jupyter/kernels/* $CONDA_DIR/share/jupyter/kernels/ && \
+    chmod -R go+rx $CONDA_DIR/share/jupyter && \
+    rm -rf /home/$NB_USER/.local/share
 RUN julia -e 'Pkg.add("Gadfly")' && julia -e 'Pkg.add("RDatasets")'
+
+USER root
+
+# Install Python 2 kernel spec globally to avoid permission problems when NB_UID
+# switching at runtime.
+RUN $CONDA_DIR/envs/python2/bin/python \
+    $CONDA_DIR/envs/python2/bin/ipython \
+    kernelspec install-self

--- a/datascience-notebook/README.md
+++ b/datascience-notebook/README.md
@@ -8,6 +8,7 @@
 * Conda R v3.2.x and channel
 * plyr, devtools, dplyr, ggplot2, tidyr, shiny, rmarkdown, forecast, stringr, rsqlite, reshape2, nycflights13, caret, rcurl, and randomforest pre-installed
 * Julia v0.3.x with Gadfly and RDatasets pre-installed
+* Unprivileged user `jovyan` (uid=1000, configurable, see options) in group `users` (gid=100) with ownership over `/home/jovyan` and `/opt/conda`
 * Options for HTTPS, password auth, and passwordless `sudo`
 
 ## Basic Use

--- a/minimal-notebook/Dockerfile
+++ b/minimal-notebook/Dockerfile
@@ -34,7 +34,6 @@ ENV NB_UID 1000
 
 # Install conda
 RUN mkdir -p $CONDA_DIR && \
-    chmod g+s $CONDA_DIR && \
     echo export PATH=$CONDA_DIR/bin:'$PATH' > /etc/profile.d/conda.sh && \
     wget --quiet https://repo.continuum.io/miniconda/Miniconda3-3.9.1-Linux-x86_64.sh && \
     /bin/bash /Miniconda3-3.9.1-Linux-x86_64.sh -f -b -p $CONDA_DIR && \
@@ -50,12 +49,11 @@ RUN conda install --yes \
 # Create jovyan user with UID=1000 and in the 'users' group
 # Grant ownership over the conda dir and home dir, but stick the group as root.
 RUN useradd -m -s /bin/bash -N -u $NB_UID $NB_USER && \
-    chmod g+s /home/$NB_USER && \
     mkdir /home/$NB_USER/work && \
     mkdir /home/$NB_USER/.jupyter && \
     mkdir /home/$NB_USER/.local && \
-    chown -R $NB_USER:root $CONDA_DIR && \
-    chown -R $NB_USER:root /home/$NB_USER
+    chown -R $NB_USER:users $CONDA_DIR && \
+    chown -R $NB_USER:users /home/$NB_USER
 
 # Configure container startup
 EXPOSE 8888
@@ -65,4 +63,4 @@ CMD [ "start-notebook.sh" ]
 COPY start-notebook.sh /usr/local/bin/
 COPY notebook.conf /etc/supervisor/conf.d/
 COPY jupyter_notebook_config.py /home/$NB_USER/.jupyter/
-RUN chown -R $NB_USER:root /home/$NB_USER/.jupyter
+RUN chown -R $NB_USER:users /home/$NB_USER/.jupyter

--- a/minimal-notebook/Dockerfile
+++ b/minimal-notebook/Dockerfile
@@ -29,11 +29,15 @@ RUN apt-get update && apt-get install -yq --no-install-recommends \
 # Configure environment
 ENV CONDA_DIR /opt/conda
 ENV PATH $CONDA_DIR/bin:$PATH
+ENV NB_USER jovyan
+ENV NB_UID 1000
 
 # Install conda
-RUN echo export PATH=$CONDA_DIR/bin:'$PATH' > /etc/profile.d/conda.sh && \
+RUN mkdir -p $CONDA_DIR && \
+    chmod g+s $CONDA_DIR && \
+    echo export PATH=$CONDA_DIR/bin:'$PATH' > /etc/profile.d/conda.sh && \
     wget --quiet https://repo.continuum.io/miniconda/Miniconda3-3.9.1-Linux-x86_64.sh && \
-    /bin/bash /Miniconda3-3.9.1-Linux-x86_64.sh -b -p $CONDA_DIR && \
+    /bin/bash /Miniconda3-3.9.1-Linux-x86_64.sh -f -b -p $CONDA_DIR && \
     rm Miniconda3-3.9.1-Linux-x86_64.sh && \
     $CONDA_DIR/bin/conda install --yes conda==3.14.1
 
@@ -43,6 +47,16 @@ RUN conda install --yes \
     terminado \
     && conda clean -yt
 
+# Create jovyan user with UID=1000 and in the 'users' group
+# Grant ownership over the conda dir and home dir, but stick the group as root.
+RUN useradd -m -s /bin/bash -N -u $NB_UID $NB_USER && \
+    chmod g+s /home/$NB_USER && \
+    mkdir /home/$NB_USER/work && \
+    mkdir /home/$NB_USER/.jupyter && \
+    mkdir /home/$NB_USER/.local && \
+    chown -R $NB_USER:root $CONDA_DIR && \
+    chown -R $NB_USER:root /home/$NB_USER
+
 # Configure container startup
 EXPOSE 8888
 CMD [ "start-notebook.sh" ]
@@ -50,4 +64,5 @@ CMD [ "start-notebook.sh" ]
 # Add local files as late as possible to avoid cache busting
 COPY start-notebook.sh /usr/local/bin/
 COPY notebook.conf /etc/supervisor/conf.d/
-COPY jupyter_notebook_config.py /etc/skel/.jupyter/
+COPY jupyter_notebook_config.py /home/$NB_USER/.jupyter/
+RUN chown -R $NB_USER:root /home/$NB_USER/.jupyter

--- a/minimal-notebook/README.md
+++ b/minimal-notebook/README.md
@@ -5,6 +5,7 @@
 * Jupyter Notebook server (v4.0.x or v3.2.x, see tag)
 * Conda Python 3.4.x
 * No preinstalled scientific computing packages
+* Unprivileged user `jovyan` (uid=1000, configurable, see options) in group `users` (gid=100) with ownership over `/home/jovyan` and `/opt/conda`
 * Options for HTTPS, password auth, and passwordless `sudo`
 
 ## Basic Use

--- a/minimal-notebook/start-notebook.sh
+++ b/minimal-notebook/start-notebook.sh
@@ -1,29 +1,9 @@
 #!/bin/bash
 
-# Constants
-NB_USER=jovyan
-NB_HOME=/home/$NB_USER
-NB_WORK=$NB_HOME/work
-
-# Create non-root NB_USER if one doesn't exist
-id -u $NB_USER && user_exists=true
-if [ -z "$user_exists" ] ; then
-    useradd -m -s /bin/bash -u ${NB_UID:-1000} $NB_USER
-
-    # Setup a work directory rooted in the NB_USER home
-    mkdir -p $NB_WORK
-    chown -R $NB_USER.$NB_USER $NB_HOME
-
-    # Allow NB_USER group to update conda root env
-    chown -R root.$NB_USER $CONDA_DIR
-    chmod g+w $CONDA_DIR
-fi
-
-# Copy skeleton files if useradd didn't do it (e.g., volume mounted dir
-# residing in NB_HOME prevented it)
-if [ ! -d $NB_HOME/.jupyter ]; then
-    cp -r /etc/skel/. $NB_HOME
-    chown -R $NB_USER.$NB_USER $NB_HOME
+# Change UID of jovyan to NB_UID if it does not match
+if [ "$NB_UID" != $(id -u jovyan) ] ; then
+    usermod -u $NB_UID $NB_USER
+    chown -R $NB_UID:$NB_UID $CONDA_DIR
 fi
 
 # Enable sudo if requested

--- a/minimal-notebook/start-notebook.sh
+++ b/minimal-notebook/start-notebook.sh
@@ -3,7 +3,7 @@
 # Change UID of jovyan to NB_UID if it does not match
 if [ "$NB_UID" != $(id -u jovyan) ] ; then
     usermod -u $NB_UID $NB_USER
-    chown -R $NB_UID:$NB_UID $CONDA_DIR
+    chown -R $NB_UID $CONDA_DIR
 fi
 
 # Enable sudo if requested

--- a/pyspark-notebook/Dockerfile
+++ b/pyspark-notebook/Dockerfile
@@ -27,6 +27,8 @@ ENV SPARK_HOME /usr/local/spark
 ENV PYTHONPATH $SPARK_HOME/python:$SPARK_HOME/python/lib/py4j-0.8.2.1-src.zip
 ENV MESOS_NATIVE_LIBRARY /usr/local/lib/libmesos.so
 
+USER jovyan
+
 # Install Python 3 packages
 RUN conda install --yes \
     'ipywidgets=4.0*' \
@@ -48,6 +50,11 @@ RUN conda create -p $CONDA_DIR/envs/python2 python=2.7 \
     'scikit-learn=0.16*' \
     pyzmq \
     && conda clean -yt
+
+USER root
+
+# Install Python 2 kernel spec globally to avoid permission problems when NB_UID
+# switching at runtime.
 RUN $CONDA_DIR/envs/python2/bin/python \
     $CONDA_DIR/envs/python2/bin/ipython \
     kernelspec install-self

--- a/pyspark-notebook/README.md
+++ b/pyspark-notebook/README.md
@@ -7,6 +7,7 @@
 * pyspark, pandas, matplotlib, scipy, seaborn, scikit-learn pre-installed
 * Spark 1.4.1 for use in local mode or to connect to a cluster of Spark workers
 * Mesos client 0.22 binary that can communicate with a Mesos master
+* Unprivileged user `jovyan` (uid=1000, configurable, see options) in group `users` (gid=100) with ownership over `/home/jovyan` and `/opt/conda`
 * Options for HTTPS, password auth, and passwordless `sudo`
 
 ## Basic Use

--- a/r-notebook/Dockerfile
+++ b/r-notebook/Dockerfile
@@ -3,7 +3,7 @@ FROM jupyter/minimal-notebook
 
 MAINTAINER Jupyter Project <jupyter@googlegroups.com>
 
-USER root
+USER jovyan
 
 # R pre-requisites
 RUN apt-get update && \
@@ -33,3 +33,5 @@ RUN conda install --yes \
     'r-caret=6.0*' \
     'r-rcurl=1.95*' \
     'r-randomforest=4.6*' && conda clean -yt
+
+USER root

--- a/r-notebook/Dockerfile
+++ b/r-notebook/Dockerfile
@@ -3,7 +3,7 @@ FROM jupyter/minimal-notebook
 
 MAINTAINER Jupyter Project <jupyter@googlegroups.com>
 
-USER jovyan
+USER root
 
 # R pre-requisites
 RUN apt-get update && \
@@ -12,6 +12,8 @@ RUN apt-get update && \
     fonts-dejavu \
     gfortran \
     gcc && apt-get clean
+
+USER jovyan
 
 # R packages
 RUN conda config --add channels r

--- a/r-notebook/README.md
+++ b/r-notebook/README.md
@@ -5,6 +5,7 @@
 * Jupyter Notebook server (v4.0.x or v3.2.x, see tag)
 * Conda R v3.2.x and channel
 * plyr, devtools, dplyr, ggplot2, tidyr, shiny, rmarkdown, forecast, stringr, rsqlite, reshape2, nycflights13, caret, rcurl, and randomforest pre-installed
+* Unprivileged user `jovyan` (uid=1000, configurable, see options) in group `users` (gid=100) with ownership over `/home/jovyan` and `/opt/conda`
 * Options for HTTPS, password auth, and passwordless `sudo`
 
 ## Basic Use

--- a/scipy-notebook/Dockerfile
+++ b/scipy-notebook/Dockerfile
@@ -3,7 +3,7 @@ FROM jupyter/minimal-notebook
 
 MAINTAINER Jupyter Project <jupyter@googlegroups.com>
 
-USER root
+USER jovyan
 
 # Install Python 3 packages
 RUN conda install --yes \
@@ -24,7 +24,7 @@ RUN conda install --yes \
     'bokeh=0.9*' \
     && conda clean -yt
 
-# Install Python 2 packages and kernel spec
+# Install Python 2 packages
 RUN conda create -p $CONDA_DIR/envs/python2 python=2.7 \
     'ipython=4.0*' \
     'ipywidgets=4.0*' \
@@ -44,6 +44,11 @@ RUN conda create -p $CONDA_DIR/envs/python2 python=2.7 \
     'bokeh=0.9*' \
     pyzmq \
     && conda clean -yt
+
+USER root
+
+# Install Python 2 kernel spec globally to avoid permission problems when NB_UID
+# switching at runtime.
 RUN $CONDA_DIR/envs/python2/bin/python \
     $CONDA_DIR/envs/python2/bin/ipython \
     kernelspec install-self

--- a/scipy-notebook/README.md
+++ b/scipy-notebook/README.md
@@ -5,6 +5,7 @@
 * Jupyter Notebook server (v4.0.x or v3.2.x, see tag)
 * Conda Python 3.4.x and Python 2.7.x environments
 * pandas, matplotlib, scipy, seaborn, scikit-learn, scikit-image, sympy, cython, patsy, statsmodel, cloudpickle, dill, numba, bokeh pre-installed
+* Unprivileged user `jovyan` (uid=1000, configurable, see options) in group `users` (gid=100) with ownership over `/home/jovyan` and `/opt/conda`
 * Options for HTTPS, password auth, and passwordless `sudo`
 
 ## Basic Use


### PR DESCRIPTION
* Create user jovyan with UID=1000 in the default users group in the Dockerfile
* Set group ownership of user home and conda to root to avoid 'users' group from host access when mounted
* Set stick bit on both paths so root owns subdirs too
* Change jovyan UID if NB_UID is specified and is not the default 1000

@costerwi Can you give this a shot and see if it retains what you're looking for via the NB_UID runtime env var plus fixes the problems you were correcting in your latest PRs? Meanwhile, I'm going to see if it fixes both the bash and julia kernel install problems people have reported with the current setup.