### PR TITLE
Add system prereqs for R to all-spark-notebook

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,8 +27,9 @@ build/%:
 
 dev/%: ARGS?=
 dev/%: DARGS?=
+dev/%: PORT?=8888
 dev/%:
-	docker run -it --rm -p 8888:8888 $(DARGS) $(OWNER)/$(notdir $@) $(ARGS)
+	docker run -it --rm -p $(PORT):8888 $(DARGS) $(OWNER)/$(notdir $@) $(ARGS)
 
 environment-check:
 	test -e ~/.docker-stacks-builder

--- a/all-spark-notebook/Dockerfile
+++ b/all-spark-notebook/Dockerfile
@@ -49,6 +49,14 @@ ENV R_LIBS_USER $SPARK_HOME/R/lib
 ENV PYTHONPATH $SPARK_HOME/python:$SPARK_HOME/python/lib/py4j-0.8.2.1-src.zip
 ENV MESOS_NATIVE_LIBRARY /usr/local/lib/libmesos.so
 
+# R pre-requisites
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    libxrender1 \
+    fonts-dejavu \
+    gfortran \
+    gcc && apt-get clean
+
 USER jovyan
 
 # Install Python 3 packages


### PR DESCRIPTION
* Copy/paste from r-notebook
* Also add PORT option to make dev target for ease of testing

Fixes #53 and #54 
