### PR TITLE
Build spark kernel from specific SHA

### DIFF
--- a/all-spark-notebook/Dockerfile
+++ b/all-spark-notebook/Dockerfile
@@ -29,6 +29,7 @@ RUN cd /tmp && \
     git clone https://github.com/ibm-et/spark-kernel.git && \
     apt-get install -yq --force-yes --no-install-recommends sbt && \
     cd spark-kernel && \
+    git checkout 29856a785a && \
     sbt compile -Xms1024M \
         -Xmx2048M \
         -Xss1M \


### PR DESCRIPTION
Allows rebuilds against git SHAs in docker-stacks

Fix #65