### PR TITLE
Bump to pandas 0.17

### DIFF
--- a/all-spark-notebook/Dockerfile
+++ b/all-spark-notebook/Dockerfile
@@ -63,9 +63,9 @@ USER jovyan
 # Install Python 3 packages
 RUN conda install --yes \
     'ipywidgets=4.0*' \
-    'pandas=0.16*' \
+    'pandas=0.17*' \
     'matplotlib=1.4*' \
-    'scipy=0.15*' \
+    'scipy=0.16*' \
     'seaborn=0.6*' \
     'scikit-learn=0.16*' \
     && conda clean -yt
@@ -74,9 +74,9 @@ RUN conda install --yes \
 RUN conda create -p $CONDA_DIR/envs/python2 python=2.7 \
     'ipython=4.0*' \
     'ipywidgets=4.0*' \
-    'pandas=0.16*' \
+    'pandas=0.17*' \
     'matplotlib=1.4*' \
-    'scipy=0.15*' \
+    'scipy=0.16*' \
     'seaborn=0.6*' \
     'scikit-learn=0.16*' \
     pyzmq \

--- a/datascience-notebook/Dockerfile
+++ b/datascience-notebook/Dockerfile
@@ -23,9 +23,9 @@ USER jovyan
 # Install Python 3 packages
 RUN conda install --yes \
     'ipywidgets=4.0*' \
-    'pandas=0.16*' \
+    'pandas=0.17*' \
     'matplotlib=1.4*' \
-    'scipy=0.15*' \
+    'scipy=0.16*' \
     'seaborn=0.6*' \
     'scikit-learn=0.16*' \
     'scikit-image=0.11*' \
@@ -43,9 +43,9 @@ RUN conda install --yes \
 RUN conda create -p $CONDA_DIR/envs/python2 python=2.7 \
     'ipython=4.0*' \
     'ipywidgets=4.0*' \
-    'pandas=0.16*' \
+    'pandas=0.17*' \
     'matplotlib=1.4*' \
-    'scipy=0.15*' \
+    'scipy=0.16*' \
     'seaborn=0.6*' \
     'scikit-learn=0.16*' \
     'scikit-image=0.11*' \

--- a/pyspark-notebook/Dockerfile
+++ b/pyspark-notebook/Dockerfile
@@ -32,9 +32,9 @@ USER jovyan
 # Install Python 3 packages
 RUN conda install --yes \
     'ipywidgets=4.0*' \
-    'pandas=0.16*' \
+    'pandas=0.17*' \
     'matplotlib=1.4*' \
-    'scipy=0.15*' \
+    'scipy=0.16*' \
     'seaborn=0.6*' \
     'scikit-learn=0.16*' \
     && conda clean -yt
@@ -43,9 +43,9 @@ RUN conda install --yes \
 RUN conda create -p $CONDA_DIR/envs/python2 python=2.7 \
     'ipython=4.0*' \
     'ipywidgets=4.0*' \
-    'pandas=0.16*' \
+    'pandas=0.17*' \
     'matplotlib=1.4*' \
-    'scipy=0.15*' \
+    'scipy=0.16*' \
     'seaborn=0.6*' \
     'scikit-learn=0.16*' \
     pyzmq \

--- a/scipy-notebook/Dockerfile
+++ b/scipy-notebook/Dockerfile
@@ -8,9 +8,9 @@ USER jovyan
 # Install Python 3 packages
 RUN conda install --yes \
     'ipywidgets=4.0*' \
-    'pandas=0.16*' \
+    'pandas=0.17*' \
     'matplotlib=1.4*' \
-    'scipy=0.15*' \
+    'scipy=0.16*' \
     'seaborn=0.6*' \
     'scikit-learn=0.16*' \
     'scikit-image=0.11*' \
@@ -28,9 +28,9 @@ RUN conda install --yes \
 RUN conda create -p $CONDA_DIR/envs/python2 python=2.7 \
     'ipython=4.0*' \
     'ipywidgets=4.0*' \
-    'pandas=0.16*' \
+    'pandas=0.17*' \
     'matplotlib=1.4*' \
-    'scipy=0.15*' \
+    'scipy=0.16*' \
     'seaborn=0.6*' \
     'scikit-learn=0.16*' \
     'scikit-image=0.11*' \


### PR DESCRIPTION
Bump pandas to 0.17.  I had to bump scipy to 0.16 as well to satisfy conda dependencies.  I built pyspark-notebook locally:

```
Successfully built 94d9e25a74f4
```