### PR TITLE
Fix datascience-notebook build after pandas bump

### DIFF
--- a/datascience-notebook/Dockerfile
+++ b/datascience-notebook/Dockerfile
@@ -31,12 +31,12 @@ RUN conda install --yes \
     'scikit-image=0.11*' \
     'sympy=0.7*' \
     'cython=0.22*' \
-    'patsy=0.3*' \
+    'patsy=0.4*' \
     'statsmodels=0.6*' \
     'cloudpickle=0.1*' \
     'dill=0.2*' \
-    'numba=0.20*' \
-    'bokeh=0.9*' \
+    'numba=0.22*' \
+    'bokeh=0.10*' \
     && conda clean -yt
 
 # Install Python 2 packages
@@ -51,12 +51,12 @@ RUN conda create -p $CONDA_DIR/envs/python2 python=2.7 \
     'scikit-image=0.11*' \
     'sympy=0.7*' \
     'cython=0.22*' \
-    'patsy=0.3*' \
+    'patsy=0.4*' \
     'statsmodels=0.6*' \
     'cloudpickle=0.1*' \
     'dill=0.2*' \
-    'numba=0.20*' \
-    'bokeh=0.9*' \
+    'numba=0.22*' \
+    'bokeh=0.10*' \
     pyzmq \
     && conda clean -yt
 


### PR DESCRIPTION
patsy, numba, bokeh all need upgrade to satisfy conda constraints

Ref #69, same as #71 in another image