### PR TITLE
Bump r-irkernel to 0.5 to fix zmq issue

### DIFF
--- a/all-spark-notebook/Dockerfile
+++ b/all-spark-notebook/Dockerfile
@@ -82,14 +82,9 @@ RUN conda create -p $CONDA_DIR/envs/python2 python=2.7 \
 RUN conda config --add channels r
 RUN conda install --yes \
     'r-base=3.2*' \
-    'r-irkernel=0.4*' \
+    'r-irkernel=0.5*' \
     'r-ggplot2=1.0*' \
     'r-rcurl=1.95*' && conda clean -yt
-
-# WORKAROUND: symlink version of zmq required by latest rzmq back into conda lib
-# https://github.com/jupyter/docker-stacks/issues/55
-RUN ln -s /opt/conda/pkgs/zeromq-4.0.*/lib/libzmq.so.4.* /opt/conda/lib/libzmq.so.4 
-RUN ln -s /opt/conda/pkgs/libsodium-0.4.*/lib/libsodium.so.4.* /opt/conda/lib/libsodium.so.4
 
 # Scala Spark kernel spec
 RUN mkdir -p /opt/conda/share/jupyter/kernels/scala

--- a/datascience-notebook/Dockerfile
+++ b/datascience-notebook/Dockerfile
@@ -65,7 +65,7 @@ RUN conda config --add channels r
 RUN conda install --yes \
     'rpy2=2.7*' \
     'r-base=3.2*' \
-    'r-irkernel=0.4*' \
+    'r-irkernel=0.5*' \
     'r-plyr=1.8*' \
     'r-devtools=1.9*' \
     'r-dplyr=0.4*' \
@@ -81,11 +81,6 @@ RUN conda install --yes \
     'r-caret=6.0*' \
     'r-rcurl=1.95*' \
     'r-randomforest=4.6*' && conda clean -yt
-
-# WORKAROUND: symlink version of zmq required by latest rzmq back into conda lib
-# https://github.com/jupyter/docker-stacks/issues/55
-RUN ln -s /opt/conda/pkgs/zeromq-4.0.*/lib/libzmq.so.4.* /opt/conda/lib/libzmq.so.4 
-RUN ln -s /opt/conda/pkgs/libsodium-0.4.*/lib/libsodium.so.4.* /opt/conda/lib/libsodium.so.4
 
 # Install IJulia packages as jovyan and then move the kernelspec out
 # to the system share location. Avoids problems with runtime UID change not 

--- a/r-notebook/Dockerfile
+++ b/r-notebook/Dockerfile
@@ -19,14 +19,14 @@ USER jovyan
 RUN conda config --add channels r
 RUN conda install --yes \
     'r-base=3.2*' \
-    'r-irkernel=0.4*' \
+    'r-irkernel=0.5*' \
     'r-plyr=1.8*' \
-    'r-devtools=1.8*' \
+    'r-devtools=1.9*' \
     'r-dplyr=0.4*' \
     'r-ggplot2=1.0*' \
-    'r-tidyr=0.2*' \
+    'r-tidyr=0.3*' \
     'r-shiny=0.12*' \
-    'r-rmarkdown=0.7*' \
+    'r-rmarkdown=0.8*' \
     'r-forecast=5.8*' \
     'r-stringr=0.6*' \
     'r-rsqlite=1.0*' \
@@ -35,10 +35,5 @@ RUN conda install --yes \
     'r-caret=6.0*' \
     'r-rcurl=1.95*' \
     'r-randomforest=4.6*' && conda clean -yt
-
-# WORKAROUND: symlink version of zmq required by latest rzmq back into conda lib
-# https://github.com/jupyter/docker-stacks/issues/55
-RUN ln -s /opt/conda/pkgs/zeromq-4.0.*/lib/libzmq.so.4.* /opt/conda/lib/libzmq.so.4 
-RUN ln -s /opt/conda/pkgs/libsodium-0.4.*/lib/libsodium.so.4.* /opt/conda/lib/libsodium.so.4
 
 USER root


### PR DESCRIPTION
Requires r-rmarkdown=0.8, r-devtools=1.9, r-tidyr=0.3 in r-notebook

Fixes #55 and makes it possible to build stacks with R again!