### PR TITLE
Install libxrender1 to appease matplotlib et al.

### DIFF
--- a/all-spark-notebook/Dockerfile
+++ b/all-spark-notebook/Dockerfile
@@ -49,7 +49,6 @@ ENV SPARK_OPTS --driver-java-options=-Xms1024M --driver-java-options=-Xmx4096M -
 # R pre-requisites
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-    libxrender1 \
     fonts-dejavu \
     gfortran \
     gcc && apt-get clean

--- a/datascience-notebook/Dockerfile
+++ b/datascience-notebook/Dockerfile
@@ -7,7 +7,6 @@ USER root
 # R pre-requisites
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-    libxrender1 \
     fonts-dejavu \
     gfortran \
     gcc && apt-get clean

--- a/minimal-notebook/Dockerfile
+++ b/minimal-notebook/Dockerfile
@@ -24,6 +24,7 @@ RUN apt-get update && apt-get install -yq --no-install-recommends \
     texlive-fonts-recommended \
     sudo \
     locales \
+    libxrender1 \
     && apt-get clean
 RUN echo "en_US.UTF-8 UTF-8" > /etc/locale.gen && \
     locale-gen

--- a/r-notebook/Dockerfile
+++ b/r-notebook/Dockerfile
@@ -8,7 +8,6 @@ USER root
 # R pre-requisites
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-    libxrender1 \
     fonts-dejavu \
     gfortran \
     gcc && apt-get clean


### PR DESCRIPTION
Bite the bullet and preinstall it so that plotting libs that default
to using desktop rendering just work (matplotlib, ggplot, ...)
out of the box without having to get configuration right beforehand
(e.g., %matplotlib inline ahead of matplotlib import)

Only adds ~100k to the minimal-notebook image size