### PR TITLE
Remove build deps from minimal-kernel image

### DIFF
--- a/minimal-kernel/Dockerfile
+++ b/minimal-kernel/Dockerfile
@@ -8,21 +8,22 @@ USER root
 # Install all OS dependencies for fully functional notebook server
 ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update && apt-get install -yq --no-install-recommends \
-    wget \
-    python3-dev \
-    build-essential \
     python3-pip \
     python3-zmq \
     && apt-get clean
 
 # Install Tini
-RUN wget --quiet https://github.com/krallin/tini/releases/download/v0.6.0/tini && \
+RUN apt-get update && \
+    apt-get install -yq --no-install-recommends wget && \
+    wget --quiet https://github.com/krallin/tini/releases/download/v0.6.0/tini && \
     echo "d5ed732199c36a1189320e6c4859f0169e950692f451c03e7854243b95f4234b *tini" | sha256sum -c - && \
     mv tini /usr/local/bin/tini && \
-    chmod +x /usr/local/bin/tini
+    chmod +x /usr/local/bin/tini && \
+    apt-get remove --purge -y wget && \
+    apt-get autoremove -y && \
+    apt-get clean
 
 # Configure environment
-ENV SHELL /bin/bash
 ENV KG_USER jovyan
 ENV KG_UID 1000
 
@@ -30,10 +31,14 @@ ENV KG_UID 1000
 RUN useradd -m -s /bin/bash -N -u $KG_UID $KG_USER
 
 # Install Kernel Gateway
-RUN pip3 install jupyter_kernel_gateway==0.2.0
+RUN apt-get update && \
+    apt-get install -yq --no-install-recommends build-essential python3-dev && \
+    pip3 install jupyter_kernel_gateway==0.2.0 && \
+    apt-get remove --purge -y build-essential python3-dev && \
+    apt-get autoremove -y && \
+    apt-get clean
 
 # Configure container startup
-USER nobody
 EXPOSE 8888
 WORKDIR /tmp
 ENTRYPOINT ["tini", "--", "jupyter", "kernelgateway"]

--- a/minimal-kernel/Dockerfile
+++ b/minimal-kernel/Dockerfile
@@ -8,6 +8,7 @@ USER root
 # Install all OS dependencies for fully functional notebook server
 ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update && apt-get install -yq --no-install-recommends \
+    python3-setuptools \
     python3-zmq \
     && apt-get clean
 
@@ -29,14 +30,12 @@ RUN useradd -m -s /bin/bash -N -u $KG_UID $KG_USER
 RUN apt-get update && \
     apt-get install -yq --no-install-recommends \
         build-essential \
-        python3-dev \
-        python3-setuptools && \
+        python3-dev && \
     easy_install3 pip && \
     pip install jupyter_kernel_gateway==0.2.0 && \
     apt-get remove --purge -y \
         build-essential \
-        python3-dev \
-        python3-setuptools && \
+        python3-dev && \
     apt-get autoremove -y && \
     apt-get clean
 

--- a/minimal-kernel/Dockerfile
+++ b/minimal-kernel/Dockerfile
@@ -8,20 +8,15 @@ USER root
 # Install all OS dependencies for fully functional notebook server
 ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update && apt-get install -yq --no-install-recommends \
-    python3-pip \
     python3-zmq \
     && apt-get clean
 
 # Install Tini
-RUN apt-get update && \
-    apt-get install -yq --no-install-recommends wget && \
-    wget --quiet https://github.com/krallin/tini/releases/download/v0.6.0/tini && \
+RUN python3 -c 'from urllib.request import urlretrieve; \
+urlretrieve("https://github.com/krallin/tini/releases/download/v0.6.0/tini", "tini")' && \
     echo "d5ed732199c36a1189320e6c4859f0169e950692f451c03e7854243b95f4234b *tini" | sha256sum -c - && \
     mv tini /usr/local/bin/tini && \
-    chmod +x /usr/local/bin/tini && \
-    apt-get remove --purge -y wget && \
-    apt-get autoremove -y && \
-    apt-get clean
+    chmod +x /usr/local/bin/tini
 
 # Configure environment
 ENV KG_USER jovyan
@@ -30,11 +25,18 @@ ENV KG_UID 1000
 # Create jovyan user with UID=1000
 RUN useradd -m -s /bin/bash -N -u $KG_UID $KG_USER
 
-# Install Kernel Gateway
+# Install modern pip then kernel gateway
 RUN apt-get update && \
-    apt-get install -yq --no-install-recommends build-essential python3-dev && \
-    pip3 install jupyter_kernel_gateway==0.2.0 && \
-    apt-get remove --purge -y build-essential python3-dev && \
+    apt-get install -yq --no-install-recommends \
+        build-essential \
+        python3-dev \
+        python3-setuptools && \
+    easy_install3 pip && \
+    pip install jupyter_kernel_gateway==0.2.0 && \
+    apt-get remove --purge -y \
+        build-essential \
+        python3-dev \
+        python3-setuptools && \
     apt-get autoremove -y && \
     apt-get clean
 


### PR DESCRIPTION
* Remove SHELL env var and leftover USER nobody
* Install wget for tini then immediately uninstall it
* Install build-essentials and python3-dev for tornado speed up
  then immediately uninstall them

Before these changes:

`jupyter/minimal-kernel         e7c2515ad9b2        9bd715cba589        56 minutes ago      485.3 MB`

After:

`jupyter/minimal-kernel                            latest              206fd7939811        2 minutes ago       240.5 MB`

So the image size is cut in half. The downside is that anyone looking to extend the image (e.g., add more Python libs, add new kernels, etc.) probably needs to add build-essentials and other build deps back in. 

I think minimization is the correct path for kernel images like this one in contrast to what we did in notebook images. Here, I expect the user to be inheriting `FROM` this image to build a new docker image with their specific kernel dependencies. In the notebook stacks, I expect a user to want to pip/conda install things on-demand and just expect them to work from within a running Jupyter notebook server.

@rgbkrk opinion? @poplav?