### PR TITLE
Bump kernel gateway to 0.3.1

### DIFF
--- a/minimal-kernel/Dockerfile
+++ b/minimal-kernel/Dockerfile
@@ -33,7 +33,7 @@ RUN apt-get update && \
         build-essential \
         python3-dev && \
     easy_install3 pip && \
-    pip install jupyter_kernel_gateway==0.2.0 && \
+    pip install jupyter_kernel_gateway==0.3.1 && \
     apt-get remove --purge -y \
         build-essential \
         python3-dev && \
@@ -43,8 +43,8 @@ RUN apt-get update && \
 # Configure container startup
 EXPOSE 8888
 WORKDIR /tmp
-ENTRYPOINT ["tini", "--", "jupyter", "kernelgateway"]
-CMD ["--KernelGatewayApp.ip=0.0.0.0"]
+ENTRYPOINT ["tini", "--"]
+CMD ["jupyter", "kernelgateway", "--KernelGatewayApp.ip=0.0.0.0"]
 
 # Run container as jovyan
 USER jovyan


### PR DESCRIPTION
Also change CMD vs ENTRYPOINT to match what minimal-notebook
and some major official Docker images do (redis, mysql, nginx, ...)
by having the jupyter kernelgateway in the CMD, and just tini --
in the entrypoint
