### PR TITLE
Added ubuntu:14.04 locale fix

### DIFF
--- a/ubuntu_14_04_locale_fix/Dockerfile
+++ b/ubuntu_14_04_locale_fix/Dockerfile
@@ -1,0 +1,1 @@
+FROM ubuntu:14.04

--- a/ubuntu_14_04_locale_fix/Dockerfile
+++ b/ubuntu_14_04_locale_fix/Dockerfile
@@ -1,1 +1,6 @@
 FROM ubuntu:14.04
+
+# Setting the language and encoding won't work without this tweak.
+# See bug here ( https://bugs.launchpad.net/ubuntu/+bug/920601 ).
+RUN DEBIAN_FRONTEND=noninteractive locale-gen en_US.UTF-8 && \
+    DEBIAN_FRONTEND=noninteractive dpkg-reconfigure locales


### PR DESCRIPTION
Sorry this is way overdue. Added locale fixes for ubuntu:14.04 so that we can get CI running as was mentioned here. ( https://github.com/jupyter/notebook/pull/547#issuecomment-146991682 )

Circle CI seemed like the best choice for doing CI with docker images. However, they did not allow us to change the locale. Not changing the locale caused us build issue with the `jupyter/notebook` image. Changing locale is not a problem when building on Docker Hub or locally. The image described here simply applies the needed locale change so it can act as a base image for `jupyter/notebook` and allow for CI support on that image.

ping: @parente 