### PR TITLE
Update stacks to current conda, python3.5, and add h5py

### DIFF
--- a/datascience-notebook/Dockerfile
+++ b/datascience-notebook/Dockerfile
@@ -23,42 +23,44 @@ USER jovyan
 
 # Install Python 3 packages
 RUN conda install --yes \
-    'ipywidgets=4.0*' \
+    'ipywidgets=4.1*' \
     'pandas=0.17*' \
-    'matplotlib=1.4*' \
-    'scipy=0.16*' \
-    'seaborn=0.6*' \
-    'scikit-learn=0.16*' \
+    'matplotlib=1.5*' \
+    'scipy=0.17*' \
+    'seaborn=0.7*' \
+    'scikit-learn=0.17*' \
     'scikit-image=0.11*' \
     'sympy=0.7*' \
-    'cython=0.22*' \
+    'cython=0.23*' \
     'patsy=0.4*' \
     'statsmodels=0.6*' \
     'cloudpickle=0.1*' \
     'dill=0.2*' \
-    'numba=0.22*' \
-    'bokeh=0.10*' \
+    'numba=0.23*' \
+    'bokeh=0.11*' \
+    'h5py=2.5*' \
     && conda clean -yt
 
 # Install Python 2 packages
 RUN conda create -p $CONDA_DIR/envs/python2 python=2.7 \
-    'ipython=4.0*' \
-    'ipywidgets=4.0*' \
+    'ipython=4.1*' \
+    'ipywidgets=4.1*' \
     'pandas=0.17*' \
-    'matplotlib=1.4*' \
-    'scipy=0.16*' \
-    'seaborn=0.6*' \
-    'scikit-learn=0.16*' \
+    'matplotlib=1.5*' \
+    'scipy=0.17*' \
+    'seaborn=0.7*' \
+    'scikit-learn=0.17*' \
     'scikit-image=0.11*' \
     'sympy=0.7*' \
-    'cython=0.22*' \
+    'cython=0.23*' \
     'patsy=0.4*' \
     'statsmodels=0.6*' \
     'cloudpickle=0.1*' \
     'dill=0.2*' \
-    'numba=0.22*' \
-    'bokeh=0.10*' \
-    pyzmq \
+    'numba=0.23*' \
+    'bokeh=0.11*' \
+    'h5py=2.5*' \
+    'pyzmq' \
     && conda clean -yt
 
 # R packages including IRKernel which gets installed globally.

--- a/datascience-notebook/Dockerfile
+++ b/datascience-notebook/Dockerfile
@@ -1,5 +1,6 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
+
 FROM jupyter/minimal-notebook
 
 MAINTAINER Jupyter Project <jupyter@googlegroups.com>
@@ -102,4 +103,5 @@ RUN $CONDA_DIR/envs/python2/bin/python \
     $CONDA_DIR/envs/python2/bin/ipython \
     kernelspec install-self
 
+# Switch back to jovyan to avoid accidental container runs as root
 USER jovyan

--- a/minimal-notebook/Dockerfile
+++ b/minimal-notebook/Dockerfile
@@ -1,5 +1,6 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
+
 FROM debian:jessie
 
 MAINTAINER Jupyter Project <jupyter@googlegroups.com>
@@ -11,6 +12,8 @@ ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update && apt-get install -yq --no-install-recommends \
     git \
     vim \
+    jed \
+    emacs \
     wget \
     build-essential \
     python-dev \
@@ -28,12 +31,13 @@ RUN apt-get update && apt-get install -yq --no-install-recommends \
     locales \
     libxrender1 \
     && apt-get clean
+
 RUN echo "en_US.UTF-8 UTF-8" > /etc/locale.gen && \
     locale-gen
 
 # Install Tini
-RUN wget --quiet https://github.com/krallin/tini/releases/download/v0.6.0/tini && \
-    echo "d5ed732199c36a1189320e6c4859f0169e950692f451c03e7854243b95f4234b *tini" | sha256sum -c - && \
+RUN wget --quiet https://github.com/krallin/tini/releases/download/v0.9.0/tini && \
+    echo "faafbfb5b079303691a939a747d7f60591f2143164093727e870b289a44d9872 *tini" | sha256sum -c - && \
     mv tini /usr/local/bin/tini && \
     chmod +x /usr/local/bin/tini
 
@@ -62,11 +66,11 @@ RUN mkdir /home/$NB_USER/work && \
 # Install conda as jovyan
 RUN cd /tmp && \
     mkdir -p $CONDA_DIR && \
-    wget --quiet https://repo.continuum.io/miniconda/Miniconda3-3.9.1-Linux-x86_64.sh && \
-    echo "6c6b44acdd0bc4229377ee10d52c8ac6160c336d9cdd669db7371aa9344e1ac3 *Miniconda3-3.9.1-Linux-x86_64.sh" | sha256sum -c - && \
-    /bin/bash Miniconda3-3.9.1-Linux-x86_64.sh -f -b -p $CONDA_DIR && \
-    rm Miniconda3-3.9.1-Linux-x86_64.sh && \
-    $CONDA_DIR/bin/conda install --yes conda==3.14.1
+    wget --quiet https://repo.continuum.io/miniconda/Miniconda3-3.19.0-Linux-x86_64.sh && \
+    echo "9ea57c0fdf481acf89d816184f969b04bc44dea27b258c4e86b1e3a25ff26aa0 *Miniconda3-3.19.0-Linux-x86_64.sh" | sha256sum -c - && \
+    /bin/bash Miniconda3-3.19.0-Linux-x86_64.sh -f -b -p $CONDA_DIR && \
+    rm Miniconda3-3.19.0-Linux-x86_64.sh && \
+    $CONDA_DIR/bin/conda install --yes conda==3.19.1
 
 # Install Jupyter notebook as jovyan
 RUN conda install --yes \


### PR DESCRIPTION
Refresh the images with more current versions of all packages as well as using current conda and Python3.5 as the default py3 environment.

I also added h5py, which is quite useful in general and necessary to be able to run [the LIGO gravitational wave analysis notebooks](http://nbviewer.jupyter.org/urls/losc.ligo.org/s/events/GW150914/GW150914_tutorial.ipynb) out of the box.

Is it correct that this repo will automatically build the images on [docker hub](https://hub.docker.com/u/jupyter)? I did test the builds locally.