### PR TITLE
README: Add badge for Travis CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # docker-stacks
 
+[![Build Status](https://travis-ci.org/jupyter/docker-stacks.svg?branch=master)](https://travis-ci.org/jupyter/docker-stacks)
 [![Join the chat at https://gitter.im/jupyter/jupyter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/jupyter/jupyter?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 Opinionated stacks of ready-to-run Jupyter applications in Docker.


### PR DESCRIPTION
This adds a status badge for Travis CI. Also, it will be a nice test of the build system. As a release was just completed, this should use the cache the entire way.