### PR TITLE
Add dockerignores

### DIFF
--- a/all-spark-notebook/.dockerignore
+++ b/all-spark-notebook/.dockerignore
@@ -1,0 +1,2 @@
+# Documentation
+README.md

--- a/datascience-notebook/.dockerignore
+++ b/datascience-notebook/.dockerignore
@@ -1,0 +1,2 @@
+# Documentation
+README.md

--- a/minimal-kernel/.dockerignore
+++ b/minimal-kernel/.dockerignore
@@ -1,0 +1,2 @@
+# Documentation
+README.md

--- a/minimal-notebook/.dockerignore
+++ b/minimal-notebook/.dockerignore
@@ -1,0 +1,2 @@
+# Documentation
+README.md

--- a/pyspark-notebook/.dockerignore
+++ b/pyspark-notebook/.dockerignore
@@ -1,0 +1,2 @@
+# Documentation
+README.md

--- a/r-notebook/.dockerignore
+++ b/r-notebook/.dockerignore
@@ -1,0 +1,2 @@
+# Documentation
+README.md

--- a/scipy-notebook/.dockerignore
+++ b/scipy-notebook/.dockerignore
@@ -1,0 +1,2 @@
+# Documentation
+README.md


### PR DESCRIPTION
Fixes https://github.com/jupyter/docker-stacks/issues/142

Don't think this solves our issue on Travis CI with `COPY` busting the cache, but it does avoid having the READMEs enter the context.