### PR TITLE
WIP: Makefile: Refresh images using git sha tag too

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,7 @@ push/%:
 refresh/%:
 # skip if error: a stack might not be on dockerhub yet
 	-docker pull $(OWNER)/$(notdir $@):latest
+	-docker pull $(OWNER)/$(notdir $@):$(GIT_MASTER_HEAD_SHA)
 
 refresh-all: $(patsubst %,refresh/%, $(ALL_STACKS))
 


### PR DESCRIPTION
When performing refresh, it is possible that user wants the image that matches the git sha tag. This makes sure to pull in that image, but continues to pull in latest as was done before.