### PR TITLE
Clean apt-get list

### DIFF
--- a/all-spark-notebook/Dockerfile
+++ b/all-spark-notebook/Dockerfile
@@ -7,13 +7,14 @@ MAINTAINER Jupyter Project <jupyter@googlegroups.com>
 USER root
 
 # Util to help with kernel spec later
-RUN apt-get -y update && apt-get -y install jq && apt-get clean
+RUN apt-get -y update && apt-get -y install jq && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Spark dependencies
 ENV APACHE_SPARK_VERSION 1.6.0
 RUN apt-get -y update && \
     apt-get install -y --no-install-recommends openjdk-7-jre-headless && \
-    apt-get clean
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 RUN cd /tmp && \
         wget -q http://d3kbcqa49mib13.cloudfront.net/spark-${APACHE_SPARK_VERSION}-bin-hadoop2.6.tgz && \
         echo "439fe7793e0725492d3d36448adcd1db38f438dd1392bffd556b58bb9a3a2601 *spark-${APACHE_SPARK_VERSION}-bin-hadoop2.6.tgz" | sha256sum -c - && \
@@ -32,7 +33,8 @@ RUN apt-key adv --keyserver keyserver.ubuntu.com --recv E56151BF && \
     echo "deb http://repos.mesosphere.io/${DISTRO} ${CODENAME} main" > /etc/apt/sources.list.d/mesosphere.list && \
     apt-get -y update && \
     apt-get --no-install-recommends -y --force-yes install mesos=0.22.1-1.0.debian78 && \
-    apt-get clean
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
 # Scala Spark kernel (build and cleanup)
 RUN cd /tmp && \
@@ -50,7 +52,8 @@ RUN cd /tmp && \
     rm -rf ~/.sbt && \
     rm -rf /tmp/incubator-toree && \
     apt-get remove -y sbt && \
-    apt-get clean
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
 # Spark and Mesos pointers
 ENV SPARK_HOME /usr/local/spark
@@ -64,7 +67,8 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends \
     fonts-dejavu \
     gfortran \
-    gcc && apt-get clean
+    gcc && apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
 USER jovyan
 

--- a/datascience-notebook/Dockerfile
+++ b/datascience-notebook/Dockerfile
@@ -12,18 +12,21 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends \
     fonts-dejavu \
     gfortran \
-    gcc && apt-get clean
+    gcc && apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
 # Julia dependencies
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
     julia \
-    libnettle4 && apt-get clean
+    libnettle4 && apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
 # libav-tools for matplotlib anim
 RUN apt-get update && \
     apt-get install -y --no-install-recommends libav-tools && \
-    apt-get clean
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
 USER jovyan
 

--- a/minimal-kernel/Dockerfile
+++ b/minimal-kernel/Dockerfile
@@ -13,7 +13,8 @@ ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update && apt-get install -yq --no-install-recommends \
     python3-setuptools \
     python3-zmq \
-    && apt-get clean
+    && apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
 # Install Tini
 RUN python3 -c 'from urllib.request import urlretrieve; \
@@ -40,7 +41,8 @@ RUN apt-get update && \
         build-essential \
         python3-dev && \
     apt-get autoremove -y && \
-    apt-get clean
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
 # Configure container startup
 EXPOSE 8888

--- a/minimal-notebook/Dockerfile
+++ b/minimal-notebook/Dockerfile
@@ -31,7 +31,8 @@ RUN apt-get update && apt-get install -yq --no-install-recommends \
     sudo \
     locales \
     libxrender1 \
-    && apt-get clean
+    && apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
 RUN echo "en_US.UTF-8 UTF-8" > /etc/locale.gen && \
     locale-gen

--- a/pyspark-notebook/Dockerfile
+++ b/pyspark-notebook/Dockerfile
@@ -7,13 +7,14 @@ MAINTAINER Jupyter Project <jupyter@googlegroups.com>
 USER root
 
 # Util to help with kernel spec later
-RUN apt-get -y update && apt-get -y install jq && apt-get clean
+RUN apt-get -y update && apt-get -y install jq && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Spark dependencies
 ENV APACHE_SPARK_VERSION 1.6.0
 RUN apt-get -y update && \
     apt-get install -y --no-install-recommends openjdk-7-jre-headless && \
-    apt-get clean
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 RUN cd /tmp && \
         wget -q http://d3kbcqa49mib13.cloudfront.net/spark-${APACHE_SPARK_VERSION}-bin-hadoop2.6.tgz && \
         echo "439fe7793e0725492d3d36448adcd1db38f438dd1392bffd556b58bb9a3a2601 *spark-${APACHE_SPARK_VERSION}-bin-hadoop2.6.tgz" | sha256sum -c - && \
@@ -32,7 +33,8 @@ RUN apt-key adv --keyserver keyserver.ubuntu.com --recv E56151BF && \
     echo "deb http://repos.mesosphere.io/${DISTRO} ${CODENAME} main" > /etc/apt/sources.list.d/mesosphere.list && \
     apt-get -y update && \
     apt-get --no-install-recommends -y --force-yes install mesos=0.22.1-1.0.debian78 && \
-    apt-get clean
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
 # Spark and Mesos pointers
 ENV SPARK_HOME /usr/local/spark

--- a/r-notebook/Dockerfile
+++ b/r-notebook/Dockerfile
@@ -11,7 +11,8 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends \
     fonts-dejavu \
     gfortran \
-    gcc && apt-get clean
+    gcc && apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
 USER jovyan
 

--- a/scipy-notebook/Dockerfile
+++ b/scipy-notebook/Dockerfile
@@ -9,7 +9,8 @@ USER root
 # libav-tools for matplotlib anim
 RUN apt-get update && \
     apt-get install -y --no-install-recommends libav-tools && \
-    apt-get clean
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
 USER jovyan
 


### PR DESCRIPTION
Related: https://github.com/jupyter/docker-stacks/issues/62

Simply empties `/var/lib/apt/lists/` of contents. This directory is repopulated on any call to `apt-get update` so it is not a problem to remove it. All it serves as is a cache. Should save a little bit more space for each image (~10MB).

Refs:
* ( http://unix.stackexchange.com/a/217371 )
* ( http://askubuntu.com/questions/179955/var-lib-apt-lists-huge-in-12-04/179992#179992 )