### PR TITLE
Add cacert to .curlrc in home directory

### DIFF
--- a/minimal-notebook/Dockerfile
+++ b/minimal-notebook/Dockerfile
@@ -63,7 +63,8 @@ USER jovyan
 # Setup jovyan home directory
 RUN mkdir /home/$NB_USER/work && \
     mkdir /home/$NB_USER/.jupyter && \
-    mkdir /home/$NB_USER/.local
+    mkdir /home/$NB_USER/.local && \
+    echo "cacert=/etc/ssl/certs/ca-certificates.crt" > /home/$NB_USER/.curlrc
 
 # Install conda as jovyan
 RUN cd /tmp && \


### PR DESCRIPTION
Specify `cacert=/etc/ssl/certs/ca-certificates.crt` in `/home/$NB_USER/.curlrc` so curl can locate the certificates. See Issue #153 .