### PR TITLE
Switch to Mesos Jessie repository, and upgrade to 0.25

### DIFF
--- a/all-spark-notebook/Dockerfile
+++ b/all-spark-notebook/Dockerfile
@@ -22,17 +22,12 @@ RUN cd /tmp && \
         rm spark-${APACHE_SPARK_VERSION}-bin-hadoop2.6.tgz
 RUN cd /usr/local && ln -s spark-${APACHE_SPARK_VERSION}-bin-hadoop2.6 spark
 
-# Mesos dependencies
-# Currently, Mesos is not available from Debian Jessie.
-# So, we are installing it from Debian Wheezy. Once it
-# becomes available for Debian Jessie. We should switch
-# over to using that instead.
 RUN apt-key adv --keyserver keyserver.ubuntu.com --recv E56151BF && \
     DISTRO=debian && \
-    CODENAME=wheezy && \
+    CODENAME=jessie && \
     echo "deb http://repos.mesosphere.io/${DISTRO} ${CODENAME} main" > /etc/apt/sources.list.d/mesosphere.list && \
     apt-get -y update && \
-    apt-get --no-install-recommends -y --force-yes install mesos=0.22.1-1.0.debian78 && \
+    apt-get --no-install-recommends -y --force-yes install mesos=0.25.0-0.2.70.debian81 && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Fixes https://github.com/jupyter/docker-stacks/issues/137

Hi! It would be really useful to upgrade the Mesos client to version 0.25. The client in this notebook is old, and it does not allow to connect to newer high availability Mesos clusters, since the name of an entry in ZooKeeper changed. Also right now Mesosphere provides a Jessie package, and you should switch to that one.

I tested my branch and it works good. I would be really useful to merge this.

Cheers
Marco