### PR TITLE
use current command for Python 2 kernel install

### DIFF
--- a/scipy-notebook/Dockerfile
+++ b/scipy-notebook/Dockerfile
@@ -60,8 +60,6 @@ USER root
 
 # Install Python 2 kernel spec globally to avoid permission problems when NB_UID
 # switching at runtime.
-RUN $CONDA_DIR/envs/python2/bin/python \
-    $CONDA_DIR/envs/python2/bin/ipython \
-    kernelspec install-self
+RUN $CONDA_DIR/envs/python2/bin/python -m ipykernel install
 
 USER jovyan


### PR DESCRIPTION
`ipython kernelspec install-self` was deprecated in 4.0. Use `ipython kernel install` aka `python -m ipykernel install` instead.