### PR TITLE
Update README.md

### DIFF
--- a/datascience-notebook/README.md
+++ b/datascience-notebook/README.md
@@ -38,7 +38,7 @@ You can sidestep the `start-notebook.sh` script entirely by specifying a command
 You may customize the execution of the Docker container and the Notebook server it contains with the following optional arguments.
 
 * `-e PASSWORD="YOURPASS"` - Configures Jupyter Notebook to require the given password. Should be conbined with `USE_HTTPS` on untrusted networks.
-* `-e USE_HTTPS=yes` - Configures Jupyter Notebook to accept encrypted HTTPS connections. If a `pem` file containing a SSL certificate and key is not found in `/home/jovyan/.ipython/profile_default/security/notebook.pem`, the container will generate a self-signed certificate for you.
+* `-e USE_HTTPS=yes` - Configures Jupyter Notebook to accept encrypted HTTPS connections. If a `pem` file containing a SSL certificate and key is not provided (see below), the container will generate a self-signed certificate for you.
 * `-e NB_UID=1000` - Specify the uid of the `jovyan` user. Useful to mount host volumes with specific file ownership. For this option to take effect, you must run the container with `--user root`. (The `start-notebook.sh` script will `su jovyan` after adjusting the user id.)
 * `-e GRANT_SUDO=yes` - Gives the `jovyan` user passwordless `sudo` capability. Useful for installing OS packages. For this option to take effect, you must run the container with `--user root`. (The `start-notebook.sh` script will `su jovyan` after adding `jovyan` to sudoers.) **You should only enable `sudo` if you trust the user or if the container is running on an isolated host.**
 * `-v /some/host/folder/for/work:/home/jovyan/work` - Host mounts the default working directory on the host to preserve work even when the container is destroyed and recreated (e.g., during an upgrade).


### PR DESCRIPTION
Fixes https://github.com/jupyter/docker-stacks/issues/190

Fixes inconcistent PEM path (described as being `/home/jovyan/.local/share/jupyter/notebook.pem` and not `/home/jovyan/.ipython/profile_default/security/notebook.pem`).

Merges with README of https://github.com/jupyter/docker-stacks/tree/master/minimal-notebook