### PR TITLE
Added shell for accessing odbc to supply data to Jupyter.  Fixed a fe…

### DIFF
--- a/base-notebook/Dockerfile
+++ b/base-notebook/Dockerfile
@@ -64,6 +64,11 @@ RUN cd /tmp && \
     $CONDA_DIR/bin/conda config --system --add channels conda-forge && \
     conda clean -tipsy
 
+# Fix the graphing issue with ggplot2
+# from: https://github.com/jupyter/docker-stacks/issues/210
+RUN mkdir -p $CONDA_DIR/conda-meta && \
+    echo "jpeg 8*" >> $CONDA_DIR/conda-meta/pinned
+
 # Install Jupyter notebook as jovyan
 RUN conda install --quiet --yes \
     'notebook=4.2*' \

--- a/datascience-notebook/Dockerfile
+++ b/datascience-notebook/Dockerfile
@@ -94,12 +94,12 @@ RUN echo "[ODBC Data Sources]" >> ~/.odbc.ini && \
     echo "Driver           = /home/jovyan/odbcdriver/lib/libtdsodbc.so" >> ~/.odbc.ini && \
     echo "Trace            = No" >> ~/.odbc.ini && \
     echo "TraceFile        = /home/jovyan/prodms.log" >> ~/.odbc.ini && \
-    echo "Server           = MachineIPAddress >> ~/.odbc.ini && \
-    echo "Host             = MachineHostName >> ~/.odbc.ini && \
+    echo "Server           = MachineIPAddress" >> ~/.odbc.ini && \
+    echo "Host             = MachineHostName" >> ~/.odbc.ini && \
     echo "Port             = MachineDBPort" >> ~/.odbc.ini && \
     echo "Database         = DatabaseInstanceName" >> ~/.odbc.ini && \
     echo "UID              = DatabaseUserName" >> ~/.odbc.ini && \
-    echo "PWD              = DatabasePassword >> ~/.odbc.ini && \
+    echo "PWD              = DatabasePassword" >> ~/.odbc.ini && \
     echo "Protocol         =" >> ~/.odbc.ini && \
     echo "ReadOnly         = No" >> ~/.odbc.ini && \
     echo "RowVersioning    = No" >> ~/.odbc.ini && \

--- a/datascience-notebook/Dockerfile
+++ b/datascience-notebook/Dockerfile
@@ -27,12 +27,14 @@ RUN apt-get update && \
 
 USER jovyan
 
-# R packages including IRKernel which gets installed globally.
+# Fix the version of rpy2 since the 2.7 is broken.
 # Note that there is a bug with rpy2 where the %R and %%R don't work.
-# We need an newer version not yet available on conda to fix this so uninstall and install new version at end.
+# We need an newer version not yet available on the default for conda to fix this.
+RUN conda install -c bioconda rpy2=2.7.8
+
+# R packages including IRKernel which gets installed globally.
 RUN conda config --add channels r && \
     conda install --quiet --yes \
-    'rpy2=2.7*' \
     'r-base=3.2*' \
     'r-irkernel=0.5*' \
     'r-plyr=1.8*' \
@@ -69,11 +71,6 @@ RUN julia -e 'Pkg.add("IJulia")' && \
 RUN echo 'push!(Sys.DL_LOAD_PATH, "/opt/conda/lib")' > /home/$NB_USER/.juliarc.jl && \
 julia -e 'Pkg.add("Gadfly")' && julia -e 'Pkg.add("RDatasets")' && julia -F -e 'Pkg.add("HDF5")'
 
-# Fix the graphing issue with ggplot2
-# from: https://github.com/jupyter/docker-stacks/issues/210
-RUN echo "jpeg 8*" >> /opt/conda/conda-meta/pinned
-RUN conda update --all -y
-
 # Add odbc drivers to the install
 RUN cd /home/jovyan && \
     wget ftp://ftp.freetds.org/pub/freetds/stable/freetds-patched.tar.gz && \
@@ -108,14 +105,4 @@ RUN echo "[ODBC Data Sources]" >> ~/.odbc.ini && \
     echo "FakeOidIndex     = No" >> ~/.odbc.ini && \
     echo "ConnSettings     =" >> ~/.odbc.ini && \
     echo "TDS_Version      = 7.0" >> ~/.odbc.ini 
-
-# Fix the version of rpy2 since the 2.7 is broken.  See note above
-RUN conda uninstall rpy2 && \
-    conda install -c bioconda rpy2=2.7.8
-
-# Fix the ipywidgets since the base image has an older version of ipywidgets.
-# This older version works with the Python2 instance but not the Python3 instance.
-# Installing a newer version allows the widgets to work with both Python versions.
-RUN conda uninstall ipywidgets && \
-    conda install -c conda-forge ipywidgets=5.1.5
 

--- a/datascience-notebook/Dockerfile
+++ b/datascience-notebook/Dockerfile
@@ -18,6 +18,9 @@ RUN apt-get update && \
     gcc && apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
+# Python pyodbc
+RUN pip install pyodbc
+
 # Julia dependencies
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \

--- a/datascience-notebook/Dockerfile
+++ b/datascience-notebook/Dockerfile
@@ -27,15 +27,18 @@ RUN apt-get update && \
 
 USER jovyan
 
+# R packages including IRKernel which gets installed globally.
+RUN conda config --add channels r && \
+    conda install --quiet --yes \
+    'r-base=3.2*' 
+
 # Fix the version of rpy2 since the 2.7 is broken.
 # Note that there is a bug with rpy2 where the %R and %%R don't work.
 # We need an newer version not yet available on the default for conda to fix this.
 RUN conda install -c bioconda rpy2=2.7.8
 
 # R packages including IRKernel which gets installed globally.
-RUN conda config --add channels r && \
-    conda install --quiet --yes \
-    'r-base=3.2*' \
+RUN conda install --quiet --yes \
     'r-irkernel=0.5*' \
     'r-plyr=1.8*' \
     'r-devtools=1.9*' \

--- a/datascience-notebook/Dockerfile
+++ b/datascience-notebook/Dockerfile
@@ -57,8 +57,8 @@ RUN conda install --quiet --yes \
     'r-nycflights13=0.1*' \
     'r-caret=6.0*' \
     'r-rcurl=1.95*' \
-    'r-dbi=*' \
-    'r-scales=*' \
+    'r-dbi=0.3*' \
+    'r-scales=0.3*' \
     'r-randomforest=4.6*' && conda clean -tipsy
 
 # Install additional non-conda R packages

--- a/datascience-notebook/Dockerfile
+++ b/datascience-notebook/Dockerfile
@@ -78,8 +78,8 @@ RUN echo "push!(Sys.DL_LOAD_PATH, \"$CONDA_DIR/lib\")" > /home/$NB_USER/.juliarc
 
 # Add odbc drivers to the install
 RUN cd /home/jovyan && \
-    wget ftp://ftp.freetds.org/pub/freetds/stable/freetds-patched.tar.gz && \
-    echo "8dbcc50fd1cc3bc9aeab85667bd3516d16c9891381b92cf53eb5547bc8299323  freetds-patched.tar.gz" | sha256sum -c - && \
+    wget ftp://ftp.freetds.org/pub/freetds/stable/freetds-1.00.9.tar.gz && \
+    echo "dcd5e7589f955ced31269de63fb554562806da0133cb7f930b117588313eaf18  freetds-1.00.9.tar.gz" | sha256sum -c - && \
     tar xvzf freetds-patched.tar.gz && \
     cd /home/jovyan/freetds-1.00.6 && \
     ./configure --prefix=/home/jovyan/odbcdriver && \

--- a/datascience-notebook/Dockerfile
+++ b/datascience-notebook/Dockerfile
@@ -79,9 +79,9 @@ RUN echo "push!(Sys.DL_LOAD_PATH, \"$CONDA_DIR/lib\")" > /home/$NB_USER/.juliarc
 # Add odbc drivers to the install
 RUN cd /home/jovyan && \
     wget ftp://ftp.freetds.org/pub/freetds/stable/freetds-1.00.9.tar.gz && \
-    echo "dcd5e7589f955ced31269de63fb554562806da0133cb7f930b117588313eaf18  freetds-1.00.9.tar.gz" | sha256sum -c - && \
-    tar xvzf freetds-patched.tar.gz && \
-    cd /home/jovyan/freetds-1.00.6 && \
+    echo "dcd5e7589f955ced31269de63fb554562806da0133cb7f930b117588313eaf18 freetds-1.00.9.tar.gz" | sha256sum -c - && \
+    tar xvzf freetds-1.00.9.tar.gz && \
+    cd /home/jovyan/freetds-1.00.9 && \
     ./configure --prefix=/home/jovyan/odbcdriver && \
     make && \
     make install

--- a/datascience-notebook/Dockerfile
+++ b/datascience-notebook/Dockerfile
@@ -80,6 +80,7 @@ julia -e 'Pkg.add("Gadfly")' && julia -e 'Pkg.add("RDatasets")' && julia -F -e '
 # Add odbc drivers to the install
 RUN cd /home/jovyan && \
     wget ftp://ftp.freetds.org/pub/freetds/stable/freetds-patched.tar.gz && \
+    echo "8dbcc50fd1cc3bc9aeab85667bd3516d16c9891381b92cf53eb5547bc8299323  freetds-patched.tar.gz" | sha256sum -c - && \
     tar xvzf freetds-patched.tar.gz && \
     cd /home/jovyan/freetds-1.00.6 && \
     ./configure --prefix=/home/jovyan/odbcdriver && \

--- a/datascience-notebook/Dockerfile
+++ b/datascience-notebook/Dockerfile
@@ -11,6 +11,10 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends \
     fonts-dejavu \
     gfortran \
+    unixodbc-dev \
+    libtool-bin \
+    autoconf \
+    automake \
     gcc && apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
@@ -24,6 +28,8 @@ RUN apt-get update && \
 USER jovyan
 
 # R packages including IRKernel which gets installed globally.
+# Note that there is a bug with rpy2 where the %R and %%R don't work.
+# We need an newer version not yet available on conda to fix this so uninstall and install new version at end.
 RUN conda config --add channels r && \
     conda install --quiet --yes \
     'rpy2=2.7*' \
@@ -43,7 +49,12 @@ RUN conda config --add channels r && \
     'r-nycflights13=0.1*' \
     'r-caret=6.0*' \
     'r-rcurl=1.95*' \
+    'r-dbi=*' \
+    'r-scales=*' \
     'r-randomforest=4.6*' && conda clean -tipsy
+
+# Install additional non-conda R packages
+RUN R -e 'install.packages(c("ggthemes", "RODBC", "sendmailR", "tis"), repos="http://cran.utstat.utoronto.ca/")'
 
 # Install IJulia packages as jovyan and then move the kernelspec out
 # to the system share location. Avoids problems with runtime UID change not
@@ -56,4 +67,55 @@ RUN julia -e 'Pkg.add("IJulia")' && \
 # Show Julia where conda libraries are
 # Add essential packages
 RUN echo 'push!(Sys.DL_LOAD_PATH, "/opt/conda/lib")' > /home/$NB_USER/.juliarc.jl && \
-    julia -e 'Pkg.add("Gadfly")' && julia -e 'Pkg.add("RDatasets")' && julia -F -e 'Pkg.add("HDF5")'
+julia -e 'Pkg.add("Gadfly")' && julia -e 'Pkg.add("RDatasets")' && julia -F -e 'Pkg.add("HDF5")'
+
+# Fix the graphing issue with ggplot2
+# from: https://github.com/jupyter/docker-stacks/issues/210
+RUN echo "jpeg 8*" >> /opt/conda/conda-meta/pinned
+RUN conda update --all -y
+
+# Add odbc drivers to the install
+RUN cd /home/jovyan && \
+    wget ftp://ftp.freetds.org/pub/freetds/stable/freetds-patched.tar.gz && \
+    tar xvzf freetds-patched.tar.gz && \
+    cd /home/jovyan/freetds-1.00.6 && \
+    ./configure --prefix=/home/jovyan/odbcdriver && \
+    make && \
+    make install
+
+# Add ODBC configuration file
+RUN echo "[ODBC Data Sources]" >> ~/.odbc.ini && \
+    echo "SQL_DB = Sample Database Configuration" >> ~/.odbc.ini && \
+    echo "" >> ~/.odbc.ini && \
+    echo "[Default]" >> ~/.odbc.ini && \
+    echo "" >> ~/.odbc.ini && \
+    echo "[SQL_DB]" >> ~/.odbc.ini && \
+    echo "Description      = Sample Database Configuration" >> ~/.odbc.ini && \
+    echo "Driver           = /home/jovyan/odbcdriver/lib/libtdsodbc.so" >> ~/.odbc.ini && \
+    echo "Trace            = No" >> ~/.odbc.ini && \
+    echo "TraceFile        = /home/jovyan/prodms.log" >> ~/.odbc.ini && \
+    echo "Server           = MachineIPAddress >> ~/.odbc.ini && \
+    echo "Host             = MachineHostName >> ~/.odbc.ini && \
+    echo "Port             = MachineDBPort" >> ~/.odbc.ini && \
+    echo "Database         = DatabaseInstanceName" >> ~/.odbc.ini && \
+    echo "UID              = DatabaseUserName" >> ~/.odbc.ini && \
+    echo "PWD              = DatabasePassword >> ~/.odbc.ini && \
+    echo "Protocol         =" >> ~/.odbc.ini && \
+    echo "ReadOnly         = No" >> ~/.odbc.ini && \
+    echo "RowVersioning    = No" >> ~/.odbc.ini && \
+    echo "ShowSystemTables = No" >> ~/.odbc.ini && \
+    echo "ShowOidColumn    = No" >> ~/.odbc.ini && \
+    echo "FakeOidIndex     = No" >> ~/.odbc.ini && \
+    echo "ConnSettings     =" >> ~/.odbc.ini && \
+    echo "TDS_Version      = 7.0" >> ~/.odbc.ini 
+
+# Fix the version of rpy2 since the 2.7 is broken.  See note above
+RUN conda uninstall rpy2 && \
+    conda install -c bioconda rpy2=2.7.8
+
+# Fix the ipywidgets since the base image has an older version of ipywidgets.
+# This older version works with the Python2 instance but not the Python3 instance.
+# Installing a newer version allows the widgets to work with both Python versions.
+RUN conda uninstall ipywidgets && \
+    conda install -c conda-forge ipywidgets=5.1.5
+

--- a/scipy-notebook/Dockerfile
+++ b/scipy-notebook/Dockerfile
@@ -14,9 +14,13 @@ RUN apt-get update && \
 
 USER jovyan
 
+# Fix the ipywidgets since the base image has an older version of ipywidgets.
+# The older version works with the Python2 instance but not the Python3 instance.
+# Installing a newer version allows the widgets to work with both Python versions.
+RUN conda install -c conda-forge ipywidgets=5.1.5
+
 # Install Python 3 packages
 RUN conda install --quiet --yes \
-    'ipywidgets=5.1*' \
     'pandas=0.17*' \
     'numexpr=2.5*' \
     'matplotlib=1.5*' \


### PR DESCRIPTION
Added shell for accessing odbc to supply data to Jupyter.  Fixed a few issues by pulling in newer versions of rpy2 and ipywidgets.

1) Added freetds to allow access to database instances using odbc.
2) Create a shell .odbc.ini file that can be filled out to access a database instance.
3) Updated the version of rpy2 since the %R and %%R magic wouldn't work from the Python kernels so that R can be used in cells within a Python sheet.
4) Updated ipywidgets so that the widgets can be used within a Python3 sheet. Without this update it wouldn't show the controls in a Python3 sheet after running the sheet
5) Pinned the conda to jpeg 8 since the ggplot2 graphs wouldn't showup in R sheets.  See https://github.com/jupyter/docker-stacks/issues/210
