### PR TITLE
Support on-demand creation of mounted work directory

### DIFF
--- a/base-notebook/start-notebook.sh
+++ b/base-notebook/start-notebook.sh
@@ -5,7 +5,7 @@ if [ $UID == 0 ] ; then
     # Change UID of NB_USER to NB_UID if it does not match
     if [ "$NB_UID" != $(id -u $NB_USER) ] ; then
         usermod -u $NB_UID $NB_USER
-        chown -R $NB_UID $CONDA_DIR
+        chown -R $NB_UID $CONDA_DIR .
     fi
 
     # Enable sudo if requested


### PR DESCRIPTION
When a notebook container is started (as root/sudo) with a host mount (for a different user) as work directory like
    root> docker run -it --rm -v ~someuser/mynotebooks:/home/jovyan/work -e NB_UID=someuid --user=root jupyter/minimal-notebook
and the host directory ~someuser/mynotebooks does not exist, it is created on-demand by docker run but will not be writable for the notebook user, so all attempts to create a notebook will fail.
This can be avoided by adding the current directory (container work directory) to the chown call.