### PR TITLE
Make use of available environment variables

### DIFF
--- a/all-spark-notebook/Dockerfile
+++ b/all-spark-notebook/Dockerfile
@@ -17,7 +17,7 @@ RUN apt-get update && \
     gcc && apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-USER jovyan
+USER $NB_USER
 
 # R packages
 RUN conda config --add channels r && \

--- a/base-notebook/Dockerfile
+++ b/base-notebook/Dockerfile
@@ -42,10 +42,10 @@ ENV LANGUAGE en_US.UTF-8
 
 # Create jovyan user with UID=1000 and in the 'users' group
 RUN useradd -m -s /bin/bash -N -u $NB_UID $NB_USER && \
-    mkdir -p /opt/conda && \
-    chown jovyan /opt/conda
+    mkdir -p $CONDA_DIR && \
+    chown $NB_USER $CONDA_DIR
 
-USER jovyan
+USER $NB_USER
 
 # Setup jovyan home directory
 RUN mkdir /home/$NB_USER/work && \
@@ -87,4 +87,4 @@ COPY jupyter_notebook_config.py /home/$NB_USER/.jupyter/
 RUN chown -R $NB_USER:users /home/$NB_USER/.jupyter
 
 # Switch back to jovyan to avoid accidental container runs as root
-USER jovyan
+USER $NB_USER

--- a/datascience-notebook/Dockerfile
+++ b/datascience-notebook/Dockerfile
@@ -21,7 +21,7 @@ RUN apt-get update && \
     libnettle4 && apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-USER jovyan
+USER $NB_USER
 
 # R packages including IRKernel which gets installed globally.
 RUN conda config --add channels r && \
@@ -55,5 +55,5 @@ RUN julia -e 'Pkg.add("IJulia")' && \
 
 # Show Julia where conda libraries are
 # Add essential packages
-RUN echo 'push!(Sys.DL_LOAD_PATH, "/opt/conda/lib")' > /home/$NB_USER/.juliarc.jl && \
+RUN echo "push!(Sys.DL_LOAD_PATH, \"$CONDA_DIR/lib\")" > /home/$NB_USER/.juliarc.jl && \
     julia -e 'Pkg.add("Gadfly")' && julia -e 'Pkg.add("RDatasets")' && julia -F -e 'Pkg.add("HDF5")'

--- a/minimal-notebook/Dockerfile
+++ b/minimal-notebook/Dockerfile
@@ -28,4 +28,4 @@ RUN apt-get update && apt-get install -yq --no-install-recommends \
     rm -rf /var/lib/apt/lists/*
 
 # Switch back to jovyan to avoid accidental container runs as root
-USER jovyan
+USER $NB_USER

--- a/pyspark-notebook/Dockerfile
+++ b/pyspark-notebook/Dockerfile
@@ -39,7 +39,7 @@ ENV PYTHONPATH $SPARK_HOME/python:$SPARK_HOME/python/lib/py4j-0.9-src.zip
 ENV MESOS_NATIVE_LIBRARY /usr/local/lib/libmesos.so
 ENV SPARK_OPTS --driver-java-options=-Xms1024M --driver-java-options=-Xmx4096M --driver-java-options=-Dlog4j.logLevel=info
 
-USER jovyan
+USER $NB_USER
 
 # Install Python 3 packages
 RUN conda install --quiet --yes \

--- a/r-notebook/Dockerfile
+++ b/r-notebook/Dockerfile
@@ -14,7 +14,7 @@ RUN apt-get update && \
     gcc && apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-USER jovyan
+USER $NB_USER
 
 # R packages
 RUN conda config --add channels r && \

--- a/scipy-notebook/Dockerfile
+++ b/scipy-notebook/Dockerfile
@@ -12,7 +12,7 @@ RUN apt-get update && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-USER jovyan
+USER $NB_USER
 
 # Install Python 3 packages
 RUN conda install --quiet --yes \
@@ -69,4 +69,4 @@ USER root
 # switching at runtime.
 RUN $CONDA_DIR/envs/python2/bin/python -m ipykernel install
 
-USER jovyan
+USER $NB_USER


### PR DESCRIPTION
base-notebook defines environment variables for the Conda install path and the
notebook user. However, in some instances, these locations were still hardcoded.
Let’s use the variables instead.