### PR TITLE
Disable `conda` auto-update

### DIFF
--- a/base-notebook/Dockerfile
+++ b/base-notebook/Dockerfile
@@ -62,6 +62,7 @@ RUN cd /tmp && \
     rm Miniconda3-4.1.11-Linux-x86_64.sh && \
     $CONDA_DIR/bin/conda install --quiet --yes conda==4.1.11 && \
     $CONDA_DIR/bin/conda config --system --add channels conda-forge && \
+    $CONDA_DIR/bin/conda config --system --set auto_update_conda false && \
     conda clean -tipsy
 
 # Temporary workaround for https://github.com/jupyter/docker-stacks/issues/210


### PR DESCRIPTION
This configures `conda` so that it should not auto-update. Instead users will need to explicitly update it.