### PR TITLE
[WIP] Generate READMEs from jinja templates

### DIFF
--- a/all-spark-notebook/README.md
+++ b/all-spark-notebook/README.md
@@ -18,12 +18,11 @@
 * A [start.sh](../base-notebook/start.sh) script useful for running alternative commands in the container (e.g. `ipython`, `jupyter kernelgateway`, `jupyter lab`)
 * Options for HTTPS, password auth, and passwordless `sudo`
 
-
 ## Basic Use
 
 The following command starts a container with the Notebook server listening for HTTP connections on port 8888 without authentication configured.
 
-```
+```bash
 docker run -d -p 8888:8888 jupyter/all-spark-notebook
 ```
 
@@ -37,7 +36,7 @@ This configuration is nice for using Spark on small, local data.
 1. Open a Python 2 or 3 notebook.
 2. Create a `SparkContext` configured for local mode.
 
-For example, the first few cells in a notebook might read:
+For example, the first few cells in the notebook might read:
 
 ```python
 import pyspark
@@ -88,9 +87,9 @@ This configuration allows your compute cluster to scale with your data.
 
 0. [Deploy Spark on Mesos](http://spark.apache.org/docs/latest/running-on-mesos.html).
 1. Configure each slave with [the `--no-switch_user` flag](https://open.mesosphere.com/reference/mesos-slave/) or create the `jovyan` user on every slave node.
-2. Run the Docker container with `--net=host` in a location that is network addressable by all of your Spark workers. (This is a [Spark networking requirement](http://spark.apache.org/docs/latest/cluster-overview.html#components).)
+2. Ensure any libraries you wish to use in your Spark lambda functions are installed on your Spark workers.
+3. Run the Docker container with `--net=host` in a location that is network addressable by all of your Spark workers. (This is a [Spark networking requirement](http://spark.apache.org/docs/latest/cluster-overview.html#components).)
     * NOTE: When using `--net=host`, you must also use the flags `--pid=host -e TINI_SUBREAPER=true`. See https://github.com/jupyter/docker-stacks/issues/64 for details.
-3. Follow the language specific instructions below.
 
 ### In a Python Notebook
 
@@ -112,7 +111,7 @@ conf = pyspark.SparkConf()
 conf.setMaster("mesos://10.10.10.10:5050")
 # point to spark binary package in HDFS or on local filesystem on all slave
 # nodes (e.g., file:///opt/spark/spark-1.6.0-bin-hadoop2.6.tgz)
-conf.set("spark.executor.uri", "hdfs://10.10.10.10/spark/spark-1.6.0-bin-hadoop2.6.tgz")
+conf.set("spark.executor.uri", "hdfs://10.122.193.209/spark/spark-1.6.0-bin-hadoop2.6.tgz")
 # set other options as desired
 conf.set("spark.executor.memory", "8g")
 conf.set("spark.core.connection.ack.wait.timeout", "1200")
@@ -184,12 +183,13 @@ println(sc.master)
 val rdd = sc.parallelize(0 to 99999999)
 rdd.sum()
 ```
-## Connecting to a Spark Cluster on Standalone Mode
 
-Connection to Spark Cluster on Standalone Mode requires the following set of steps:
+## Connecting to a Spark Cluster in Standalone Mode
 
-0. Verify that the docker image (check the Dockerfile) and the Spark Cluster which is being deployed, run the same version of Spark.
-1. [Deploy Spark on Standalone Mode](http://spark.apache.org/docs/latest/spark-standalone.html).
+Connection to Spark Cluster in Standalone Mode requires the following set of steps:
+
+0. Verify that the docker image (check the Dockerfile) and the Spark Cluster run the same version of Spark.
+1. [Deploy Spark in Standalone Mode](http://spark.apache.org/docs/latest/spark-standalone.html).
 2. Run the Docker container with `--net=host` in a location that is network addressable by all of your Spark workers. (This is a [Spark networking requirement](http://spark.apache.org/docs/latest/cluster-overview.html#components).)
     * NOTE: When using `--net=host`, you must also use the flags `--pid=host -e TINI_SUBREAPER=true`. See https://github.com/jupyter/docker-stacks/issues/64 for details.
 3. The language specific instructions are almost same as mentioned above for Mesos, only the master url would now be something like spark://10.10.10.10:7077
@@ -214,7 +214,7 @@ You can sidestep the `start-notebook.sh` script and run your own commands in the
 
 ## Docker Options
 
-You may customize the execution of the Docker container and the Notebook server it contains with the following optional arguments.
+You may customize the execution of the Docker container and the command it is running with the following optional arguments.
 
 * `-e PASSWORD="YOURPASS"` - Configures Jupyter Notebook to require the given plain-text password. Should be combined with `USE_HTTPS` on untrusted networks. **Note** that this option is not as secure as passing a pre-hashed password on the command line as shown above.
 * `-e USE_HTTPS=yes` - Configures Jupyter Notebook to accept encrypted HTTPS connections. If a `pem` file containing a SSL certificate and key is not provided (see below), the container will generate a self-signed certificate for you.
@@ -233,7 +233,7 @@ If you have your key and certificate(s) as separate files, you must concatenate 
 For additional information about using SSL, see the following:
 
 * The [docker-stacks/examples](https://github.com/jupyter/docker-stacks/tree/master/examples) for information about how to use [Let's Encrypt](https://letsencrypt.org/) certificates when you run these stacks on a publicly visible domain.
-* The [jupyter_notebook_config.py](jupyter_notebook_config.py) file for how this Docker image generates a self-signed certificate.
+* The [jupyter_notebook_config.py](../base-notebook/jupyter_notebook_config.py) file for how this Docker image generates a self-signed certificate.
 * The [Jupyter Notebook documentation](http://jupyter-notebook.readthedocs.io/en/latest/public_server.html#using-ssl-for-encrypted-communication) for best practices about running a public notebook server in general, most of which are encoded in this image.
 
 ## Conda Environments

--- a/base-notebook/README.md
+++ b/base-notebook/README.md
@@ -19,7 +19,7 @@ Small base image for defining your own stack
 
 The following command starts a container with the Notebook server listening for HTTP connections on port 8888 without authentication configured.
 
-```
+```bash
 docker run -d -p 8888:8888 jupyter/base-notebook
 ```
 
@@ -61,7 +61,7 @@ If you have your key and certificate(s) as separate files, you must concatenate 
 For additional information about using SSL, see the following:
 
 * The [docker-stacks/examples](https://github.com/jupyter/docker-stacks/tree/master/examples) for information about how to use [Let's Encrypt](https://letsencrypt.org/) certificates when you run these stacks on a publicly visible domain.
-* The [jupyter_notebook_config.py](jupyter_notebook_config.py) file for how this Docker image generates a self-signed certificate.
+* The [jupyter_notebook_config.py](./jupyter_notebook_config.py) file for how this Docker image generates a self-signed certificate.
 * The [Jupyter Notebook documentation](http://jupyter-notebook.readthedocs.io/en/latest/public_server.html#using-ssl-for-encrypted-communication) for best practices about running a public notebook server in general, most of which are encoded in this image.
 
 ## Conda Environment

--- a/datascience-notebook/README.md
+++ b/datascience-notebook/README.md
@@ -20,7 +20,7 @@
 
 The following command starts a container with the Notebook server listening for HTTP connections on port 8888 without authentication configured.
 
-```
+```bash
 docker run -d -p 8888:8888 jupyter/datascience-notebook
 ```
 
@@ -44,7 +44,7 @@ You can sidestep the `start-notebook.sh` script and run your own commands in the
 
 ## Docker Options
 
-You may customize the execution of the Docker container and the Notebook server it contains with the following optional arguments.
+You may customize the execution of the Docker container and the command it is running with the following optional arguments.
 
 * `-e PASSWORD="YOURPASS"` - Configures Jupyter Notebook to require the given plain-text password. Should be combined with `USE_HTTPS` on untrusted networks. **Note** that this option is not as secure as passing a pre-hashed password on the command line as shown above.
 * `-e USE_HTTPS=yes` - Configures Jupyter Notebook to accept encrypted HTTPS connections. If a `pem` file containing a SSL certificate and key is not provided (see below), the container will generate a self-signed certificate for you.
@@ -62,7 +62,7 @@ If you have your key and certificate(s) as separate files, you must concatenate 
 For additional information about using SSL, see the following:
 
 * The [docker-stacks/examples](https://github.com/jupyter/docker-stacks/tree/master/examples) for information about how to use [Let's Encrypt](https://letsencrypt.org/) certificates when you run these stacks on a publicly visible domain.
-* The [jupyter_notebook_config.py](jupyter_notebook_config.py) file for how this Docker image generates a self-signed certificate.
+* The [jupyter_notebook_config.py](../base-notebook/jupyter_notebook_config.py) file for how this Docker image generates a self-signed certificate.
 * The [Jupyter Notebook documentation](http://jupyter-notebook.readthedocs.io/en/latest/public_server.html#using-ssl-for-encrypted-communication) for best practices about running a public notebook server in general, most of which are encoded in this image.
 
 ## Conda Environments

--- a/docs/all-spark-notebook.md
+++ b/docs/all-spark-notebook.md
@@ -1,0 +1,126 @@
+{%- set stack_name='all-spark-notebook' %}
+{%- set base_path='../base-notebook' %}
+{%- include 'partial/badges.md' %}
+
+# Jupyter Notebook Python, Scala, R, Spark, Mesos Stack
+
+## What it Gives You
+
+* Jupyter Notebook 4.2.x
+* Conda Python 3.x and Python 2.7.x environments
+* Conda R 3.3.x environment
+* Scala 2.10.x
+* pyspark, pandas, matplotlib, scipy, seaborn, scikit-learn pre-installed for Python
+* ggplot2, rcurl preinstalled for R
+* Spark 1.6.0 for use in local mode or to connect to a cluster of Spark workers
+* Mesos client 0.22 binary that can communicate with a Mesos master
+{% include 'partial/gives.md' with context %}
+
+{% include 'partial/basic_use.md' with context %}
+
+{% include 'partial/pyspark_local.md' %}
+
+### In a R Notebook
+
+0. Run the container as shown above.
+1. Open a R notebook.
+2. Initialize `sparkR` for local mode.
+3. Initialize `sparkRSQL`.
+
+For example, the first few cells in a R notebook might read:
+
+```
+library(SparkR)
+
+sc <- sparkR.init("local[*]")
+sqlContext <- sparkRSQL.init(sc)
+
+# do something to prove it works
+data(iris)
+df <- createDataFrame(sqlContext, iris)
+head(filter(df, df$Petal_Width > 0.2))
+```
+
+### In an Apache Toree (Scala) Notebook
+
+0. Run the container as shown above.
+1. Open an Apache Toree (Scala) notebook.
+2. Use the pre-configured `SparkContext` in variable `sc`.
+
+For example:
+
+```
+val rdd = sc.parallelize(0 to 999)
+rdd.takeSample(false, 5)
+```
+
+{% include 'partial/pyspark_mesos.md' %}
+
+### In a R Notebook
+
+0. Run the container as shown above.
+1. Open a R notebook.
+2. Initialize `sparkR` Mesos master node (or Zookeeper instance) and Spark binary package location.
+3. Initialize `sparkRSQL`.
+
+For example, the first few cells in a R notebook might read:
+
+```
+library(SparkR)
+
+# point to mesos master or zookeeper entry (e.g., zk://10.10.10.10:2181/mesos)\
+# as the first argument
+# point to spark binary package in HDFS or on local filesystem on all slave
+# nodes (e.g., file:///opt/spark/spark-1.6.0-bin-hadoop2.6.tgz) in sparkEnvir
+# set other options in sparkEnvir
+sc <- sparkR.init("mesos://10.10.10.10:5050", sparkEnvir=list(
+    spark.executor.uri="hdfs://10.10.10.10/spark/spark-1.6.0-bin-hadoop2.6.tgz",
+    spark.executor.memory="8g"
+    )
+)
+sqlContext <- sparkRSQL.init(sc)
+
+# do something to prove it works
+data(iris)
+df <- createDataFrame(sqlContext, iris)
+head(filter(df, df$Petal_Width > 0.2))
+```
+
+### In an Apache Toree (Scala) Notebook
+
+0. Open a terminal via *New -> Terminal* in the notebook interface.
+1. Add information about your cluster to the `SPARK_OPTS` environment variable when running the container.
+2. Open an Apache Toree (Scala) notebook.
+3. Use the pre-configured `SparkContext` in variable `sc`.
+
+The Apache Toree kernel automatically creates a `SparkContext` when it starts based on configuration information from its command line arguments and environment variables. You can pass information about your Mesos cluster via the `SPARK_OPTS` environment variable when you spawn a container.
+
+For instance, to pass information about a Mesos master, Spark binary location in HDFS, and an executor options, you could start the container like so:
+
+`docker run -d -p 8888:8888 -e SPARK_OPTS '--master=mesos://10.10.10.10:5050 \
+    --spark.executor.uri=hdfs://10.10.10.10/spark/spark-1.6.0-bin-hadoop2.6.tgz \
+    --spark.executor.memory=8g' jupyter/all-spark-notebook`
+
+Note that this is the same information expressed in a notebook in the Python case above. Once the kernel spec has your cluster information, you can test your cluster in an Apache Toree notebook like so:
+
+```
+// should print the value of --master in the kernel spec
+println(sc.master)
+
+// do something to prove it works
+val rdd = sc.parallelize(0 to 99999999)
+rdd.sum()
+```
+
+{% include 'partial/spark_standalone.md' %}
+
+{% include 'partial/notebook_options.md' %}
+
+{% include 'partial/docker_options.md' %}
+* `-p 4040:4040` - Opens the port for the [Spark Monitoring and Instrumentation UI](http://spark.apache.org/docs/latest/monitoring.html). Note every new spark context that is created is put onto an incrementing port (ie. 4040, 4041, 4042, etc.), and it might be necessary to open multiple ports. `docker run -d -p 8888:8888 -p 4040:4040 -p 4041:4041 jupyter/all-spark-notebook`
+
+{% include 'partial/ssl_certificates.md' with context %}
+
+{% include 'partial/conda_py23_env.md' %}
+
+{% include 'partial/alternative_commands.md' with context %}

--- a/docs/base-notebook.md
+++ b/docs/base-notebook.md
@@ -1,0 +1,26 @@
+{%- set stack_name='base-notebook' %}
+{%- set base_path='.' %}
+{%- include 'partial/badges.md' %}
+
+# Base Jupyter Notebook Stack
+
+Small base image for defining your own stack
+
+## What it Gives You
+
+* Minimally-functional Jupyter Notebook 4.2.x (e.g., no pandoc for document conversion)
+* Miniconda Python 3.x
+* No preinstalled scientific computing packages
+{% include 'partial/gives.md' with context %}
+
+{% include 'partial/basic_use.md' with context %}
+
+{% include 'partial/notebook_options.md' %}
+
+{% include 'partial/docker_options.md' %}
+
+{% include 'partial/ssl_certificates.md' with context %}
+
+{% include 'partial/conda_py3_env.md' with context %}
+
+{% include 'partial/alternative_commands.md' with context %}

--- a/docs/datascience-notebook.md
+++ b/docs/datascience-notebook.md
@@ -1,0 +1,27 @@
+{%- set stack_name='datascience-notebook' %}
+{%- set base_path='../base-notebook' %}
+{%- include 'partial/badges.md' %}
+
+# Jupyter Notebook Data Science Stack
+
+## What it Gives You
+
+* Jupyter Notebook 4.2.x
+* Conda Python 3.x and Python 2.7.x environments
+* pandas, matplotlib, scipy, seaborn, scikit-learn, scikit-image, sympy, cython, patsy, statsmodel, cloudpickle, dill, numba, bokeh pre-installed
+* Conda R v3.3.x and channel
+* plyr, devtools, dplyr, ggplot2, tidyr, shiny, rmarkdown, forecast, stringr, rsqlite, reshape2, nycflights13, caret, rcurl, and randomforest pre-installed
+* Julia v0.3.x with Gadfly, RDatasets and HDF5 pre-installed
+{% include 'partial/gives.md' with context %}
+
+{% include 'partial/basic_use.md' with context %}
+
+{% include 'partial/notebook_options.md' %}
+
+{% include 'partial/docker_options.md' %}
+
+{% include 'partial/ssl_certificates.md' with context %}
+
+{% include 'partial/conda_py23_env.md' %}
+
+{% include 'partial/alternative_commands.md' with context %}

--- a/docs/generate.py
+++ b/docs/generate.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+import os
+import glob
+from jinja2 import FileSystemLoader, Environment
+
+env = Environment(loader=FileSystemLoader(searchpath='.'),
+                  trim_blocks=False, lstrip_blocks=True)
+
+for fn in glob.glob('*.md'):
+    name, _ = fn.split(os.extsep)
+    tmpl = env.get_template(fn)
+    md = tmpl.render()
+    out_fn = os.path.join('../{}/README.md'.format(name))
+    with open(out_fn, 'w') as f:
+        f.write(md)
+

--- a/docs/minimal-notebook.md
+++ b/docs/minimal-notebook.md
@@ -1,0 +1,26 @@
+{%- set stack_name='minimal-notebook' %}
+{%- set base_path='../base-notebook' %}
+{%- include 'partial/badges.md' %}
+
+# Minimal Jupyter Notebook Stack
+
+Small image for working in the notebook and installing your own libraries
+
+## What it Gives You
+
+* Fully-functional Jupyter Notebook 4.2.x
+* Miniconda Python 3.x
+* No preinstalled scientific computing packages
+{% include 'partial/gives.md' with context %}
+
+{% include 'partial/basic_use.md' with context %}
+
+{% include 'partial/notebook_options.md' %}
+
+{% include 'partial/docker_options.md' %}
+
+{% include 'partial/ssl_certificates.md' with context %}
+
+{% include 'partial/conda_py3_env.md' with context %}
+
+{% include 'partial/alternative_commands.md' with context %}

--- a/docs/partial/alternative_commands.md
+++ b/docs/partial/alternative_commands.md
@@ -1,0 +1,29 @@
+## Alternative Commands
+
+### start-singleuser.sh
+
+[JupyterHub](https://jupyterhub.readthedocs.org) requires a single-user instance of the Jupyter Notebook server per user.   To use this stack with JupyterHub and [DockerSpawner](https://github.com/jupyter/dockerspawner), you must specify the container image name and override the default container run command in your `jupyterhub_config.py`:
+
+```python
+# Spawn user containers from this image
+c.DockerSpawner.container_image = 'jupyter/{{stack_name}}'
+
+# Have the Spawner override the Docker run command
+c.DockerSpawner.extra_create_kwargs.update({
+	'command': '/usr/local/bin/start-singleuser.sh'
+})
+```
+
+### start.sh
+
+The `start.sh` script supports the same features as the default `start-notebook.sh` script (e.g., `GRANT_SUDO`), but allows you to specify an arbitrary command to execute. For example, to run the text-based `ipython` console in a container, do the following:
+
+```
+docker run -it --rm jupyter/{{stack_name}} start.sh ipython
+```
+
+This script is particularly useful when you derive a new Dockerfile from this image and install additional Jupyter applications with subcommands like `jupyter console`, `jupyter kernelgateway`, and `jupyter lab`.
+
+### Others
+
+You can bypass the provided scripts and specify your an arbitrary start command. If you do, keep in mind that certain features documented above will not function (e.g., `GRANT_SUDO`).

--- a/docs/partial/badges.md
+++ b/docs/partial/badges.md
@@ -1,0 +1,1 @@
+![docker pulls](https://img.shields.io/docker/pulls/jupyter/{{stack_name}}.svg) ![docker stars](https://img.shields.io/docker/stars/jupyter/{{stack_name}}.svg)

--- a/docs/partial/basic_use.md
+++ b/docs/partial/basic_use.md
@@ -1,0 +1,7 @@
+## Basic Use
+
+The following command starts a container with the Notebook server listening for HTTP connections on port 8888 without authentication configured.
+
+```bash
+docker run -d -p 8888:8888 jupyter/{{stack_name}}
+```

--- a/docs/partial/conda_py23_env.md
+++ b/docs/partial/conda_py23_env.md
@@ -1,0 +1,25 @@
+## Conda Environments
+
+The default Python 3.x [Conda environment](http://conda.pydata.org/docs/using/envs.html) resides in `/opt/conda`. A second Python 2.x Conda environment exists in `/opt/conda/envs/python2`. You can [switch to the python2 environment](http://conda.pydata.org/docs/using/envs.html#change-environments-activate-deactivate) in a shell by entering the following:
+
+```
+source activate python2
+```
+
+You can return to the default environment with this command:
+
+```
+source deactivate
+```
+
+The commands `jupyter`, `ipython`, `python`, `pip`, `easy_install`, and `conda` (among others) are available in both environments. For convenience, you can install packages into either environment regardless of what environment is currently active using commands like the following:
+
+```
+# install a package into the python2 environment
+pip2 install some-package
+conda install -n python2 some-package
+
+# install a package into the default (python 3.x) environment
+pip3 install some-package
+conda install -n python3 some-package
+```

--- a/docs/partial/conda_py3_env.md
+++ b/docs/partial/conda_py3_env.md
@@ -1,0 +1,3 @@
+## Conda Environment
+
+The default Python 3.x [Conda environment](http://conda.pydata.org/docs/using/envs.html) resides in `/opt/conda`. The commands `ipython`, `python`, `pip`, `easy_install`, and `conda` (among others) are available in this environment.

--- a/docs/partial/docker_options.md
+++ b/docs/partial/docker_options.md
@@ -1,0 +1,10 @@
+## Docker Options
+
+You may customize the execution of the Docker container and the command it is running with the following optional arguments.
+
+* `-e PASSWORD="YOURPASS"` - Configures Jupyter Notebook to require the given plain-text password. Should be combined with `USE_HTTPS` on untrusted networks. **Note** that this option is not as secure as passing a pre-hashed password on the command line as shown above.
+* `-e USE_HTTPS=yes` - Configures Jupyter Notebook to accept encrypted HTTPS connections. If a `pem` file containing a SSL certificate and key is not provided (see below), the container will generate a self-signed certificate for you.
+* `-e NB_UID=1000` - Specify the uid of the `jovyan` user. Useful to mount host volumes with specific file ownership. For this option to take effect, you must run the container with `--user root`. (The `start-notebook.sh` script will `su jovyan` after adjusting the user id.)
+* `-e GRANT_SUDO=yes` - Gives the `jovyan` user passwordless `sudo` capability. Useful for installing OS packages. For this option to take effect, you must run the container with `--user root`. (The `start-notebook.sh` script will `su jovyan` after adding `jovyan` to sudoers.) **You should only enable `sudo` if you trust the user or if the container is running on an isolated host.**
+* `-v /some/host/folder/for/work:/home/jovyan/work` - Host mounts the default working directory on the host to preserve work even when the container is destroyed and recreated (e.g., during an upgrade).
+* `-v /some/host/folder/for/server.pem:/home/jovyan/.local/share/jupyter/notebook.pem` - Mounts a SSL certificate plus key for `USE_HTTPS`. Useful if you have a real certificate for the domain under which you are running the Notebook server.

--- a/docs/partial/gives.md
+++ b/docs/partial/gives.md
@@ -1,0 +1,5 @@
+* Unprivileged user `jovyan` (uid=1000, configurable, see options) in group `users` (gid=100) with ownership over `/home/jovyan` and `/opt/conda`
+* [tini](https://github.com/krallin/tini) as the container entrypoint and [start-notebook.sh]({{base_path}}/start-notebook.sh) as the default command
+* A [start-singleuser.sh]({{base_path}}/start-singleuser.sh) script useful for running a single-user instance of the Notebook server, as required by JupyterHub
+* A [start.sh]({{base_path}}/start.sh) script useful for running alternative commands in the container (e.g. `ipython`, `jupyter kernelgateway`, `jupyter lab`)
+* Options for HTTPS, password auth, and passwordless `sudo`

--- a/docs/partial/notebook_options.md
+++ b/docs/partial/notebook_options.md
@@ -1,0 +1,17 @@
+## Notebook Options
+
+The Docker container executes a [`start-notebook.sh` script]({{base_path}}/start-notebook.sh) script by default. The `start-notebook.sh` script handles the `NB_UID` and `GRANT_SUDO` features documented in the next section, and then executes the `jupyter notebook`.
+
+You can pass [Jupyter command line options](http://jupyter.readthedocs.org/en/latest/config.html#command-line-arguments) through the `start-notebook.sh` script when launching the container. For example, to secure the Notebook server with a password hashed using `IPython.lib.passwd()`, run the following:
+
+```
+docker run -d -p 8888:8888 jupyter/{{stack_name}} start-notebook.sh --NotebookApp.password='sha1:74ba40f8a388:c913541b7ee99d15d5ed31d4226bf7838f83a50e'
+```
+
+For example, to set the base URL of the notebook server, run the following:
+
+```
+docker run -d -p 8888:8888 jupyter/{{stack_name}} start-notebook.sh --NotebookApp.base_url=/some/path
+```
+
+You can sidestep the `start-notebook.sh` script and run your own commands in the container. See the *Alternative Commands* section later in this document for more information.

--- a/docs/partial/pyspark_local.md
+++ b/docs/partial/pyspark_local.md
@@ -1,0 +1,20 @@
+## Using Spark Local Mode
+
+This configuration is nice for using Spark on small, local data.
+
+### In a Python Notebook
+
+0. Run the container as shown above.
+1. Open a Python 2 or 3 notebook.
+2. Create a `SparkContext` configured for local mode.
+
+For example, the first few cells in the notebook might read:
+
+```python
+import pyspark
+sc = pyspark.SparkContext('local[*]')
+
+# do something to prove it works
+rdd = sc.parallelize(range(1000))
+rdd.takeSample(False, 5)
+```

--- a/docs/partial/pyspark_mesos.md
+++ b/docs/partial/pyspark_mesos.md
@@ -1,0 +1,46 @@
+## Connecting to a Spark Cluster on Mesos
+
+This configuration allows your compute cluster to scale with your data.
+
+0. [Deploy Spark on Mesos](http://spark.apache.org/docs/latest/running-on-mesos.html).
+1. Configure each slave with [the `--no-switch_user` flag](https://open.mesosphere.com/reference/mesos-slave/) or create the `jovyan` user on every slave node.
+2. Ensure any libraries you wish to use in your Spark lambda functions are installed on your Spark workers.
+3. Run the Docker container with `--net=host` in a location that is network addressable by all of your Spark workers. (This is a [Spark networking requirement](http://spark.apache.org/docs/latest/cluster-overview.html#components).)
+    * NOTE: When using `--net=host`, you must also use the flags `--pid=host -e TINI_SUBREAPER=true`. See https://github.com/jupyter/docker-stacks/issues/64 for details.
+
+### In a Python Notebook
+
+0. Open a Python 2 or 3 notebook.
+1. Create a `SparkConf` instance in a new notebook pointing to your Mesos master node (or Zookeeper instance) and Spark binary package location.
+2. Create a `SparkContext` using this configuration.
+
+For example, the first few cells in a Python 3 notebook might read:
+
+```python
+import os
+# make sure pyspark tells workers to use python3 not 2 if both are installed
+os.environ['PYSPARK_PYTHON'] = '/usr/bin/python3'
+
+import pyspark
+conf = pyspark.SparkConf()
+
+# point to mesos master or zookeeper entry (e.g., zk://10.10.10.10:2181/mesos)
+conf.setMaster("mesos://10.10.10.10:5050")
+# point to spark binary package in HDFS or on local filesystem on all slave
+# nodes (e.g., file:///opt/spark/spark-1.6.0-bin-hadoop2.6.tgz)
+conf.set("spark.executor.uri", "hdfs://10.122.193.209/spark/spark-1.6.0-bin-hadoop2.6.tgz")
+# set other options as desired
+conf.set("spark.executor.memory", "8g")
+conf.set("spark.core.connection.ack.wait.timeout", "1200")
+
+# create the context
+sc = pyspark.SparkContext(conf=conf)
+
+# do something to prove it works
+rdd = sc.parallelize(range(100000000))
+rdd.sumApprox(3)
+```
+
+To use Python 2 in the notebook and on the workers, change the `PYSPARK_PYTHON` environment variable to point to the location of the Python 2.x interpreter binary. If you leave this environment variable unset, it defaults to `python`.
+
+Of course, all of this can be hidden in an [IPython kernel startup script](http://ipython.org/ipython-doc/stable/development/config.html?highlight=startup#startup-files), but "explicit is better than implicit." :)

--- a/docs/partial/spark_standalone.md
+++ b/docs/partial/spark_standalone.md
@@ -1,0 +1,9 @@
+## Connecting to a Spark Cluster in Standalone Mode
+
+Connection to Spark Cluster in Standalone Mode requires the following set of steps:
+
+0. Verify that the docker image (check the Dockerfile) and the Spark Cluster run the same version of Spark.
+1. [Deploy Spark in Standalone Mode](http://spark.apache.org/docs/latest/spark-standalone.html).
+2. Run the Docker container with `--net=host` in a location that is network addressable by all of your Spark workers. (This is a [Spark networking requirement](http://spark.apache.org/docs/latest/cluster-overview.html#components).)
+    * NOTE: When using `--net=host`, you must also use the flags `--pid=host -e TINI_SUBREAPER=true`. See https://github.com/jupyter/docker-stacks/issues/64 for details.
+3. The language specific instructions are almost same as mentioned above for Mesos, only the master url would now be something like spark://10.10.10.10:7077

--- a/docs/partial/ssl_certificates.md
+++ b/docs/partial/ssl_certificates.md
@@ -1,0 +1,11 @@
+## SSL Certificates
+
+The notebook server configuration in this Docker image expects the `notebook.pem` file mentioned above to contain a base64 encoded SSL key and at least one base64 encoded SSL certificate. The file may contain additional certificates (e.g., intermediate and root certificates).
+
+If you have your key and certificate(s) as separate files, you must concatenate them together into the single expected PEM file. Alternatively, you can build your own configuration and Docker image in which you pass the key and certificate separately.
+
+For additional information about using SSL, see the following:
+
+* The [docker-stacks/examples](https://github.com/jupyter/docker-stacks/tree/master/examples) for information about how to use [Let's Encrypt](https://letsencrypt.org/) certificates when you run these stacks on a publicly visible domain.
+* The [jupyter_notebook_config.py]({{base_path}}/jupyter_notebook_config.py) file for how this Docker image generates a self-signed certificate.
+* The [Jupyter Notebook documentation](http://jupyter-notebook.readthedocs.io/en/latest/public_server.html#using-ssl-for-encrypted-communication) for best practices about running a public notebook server in general, most of which are encoded in this image.

--- a/docs/pyspark-notebook.md
+++ b/docs/pyspark-notebook.md
@@ -1,0 +1,33 @@
+{%- set stack_name='pyspark-notebook' %}
+{%- set base_path='../base-notebook' %}
+{%- include 'partial/badges.md' %}
+
+# Jupyter Notebook Python, Spark, Mesos Stack
+
+## What it Gives You
+
+* Jupyter Notebook 4.2.x
+* Conda Python 3.x and Python 2.7.x environments
+* pyspark, pandas, matplotlib, scipy, seaborn, scikit-learn pre-installed
+* Spark 1.6.0 for use in local mode or to connect to a cluster of Spark workers
+* Mesos client 0.22 binary that can communicate with a Mesos master
+{% include 'partial/gives.md' with context %}
+
+{% include 'partial/basic_use.md' with context %}
+
+{% include 'partial/pyspark_local.md' %}
+
+{% include 'partial/pyspark_mesos.md' %}
+
+{% include 'partial/spark_standalone.md' %}
+
+{% include 'partial/notebook_options.md' %}
+
+{% include 'partial/docker_options.md' %}
+* `-p 4040:4040` - Opens the port for the [Spark Monitoring and Instrumentation UI](http://spark.apache.org/docs/latest/monitoring.html). Note every new spark context that is created is put onto an incrementing port (ie. 4040, 4041, 4042, etc.), and it might be necessary to open multiple ports. `docker run -d -p 8888:8888 -p 4040:4040 -p 4041:4041 jupyter/pyspark-notebook`
+
+{% include 'partial/ssl_certificates.md' with context %}
+
+{% include 'partial/conda_py23_env.md' %}
+
+{% include 'partial/alternative_commands.md' with context %}

--- a/docs/r-notebook.md
+++ b/docs/r-notebook.md
@@ -1,0 +1,22 @@
+{%- set stack_name='r-notebook' %}
+{%- set base_path='../base-notebook' %}
+{%- include 'partial/badges.md' %}
+
+# Jupyter Notebook R Stack
+
+## What it Gives You
+
+* Jupyter Notebook 4.2.x
+* Conda R v3.3.x and channel
+* plyr, devtools, dplyr, ggplot2, tidyr, shiny, rmarkdown, forecast, stringr, rsqlite, reshape2, nycflights13, caret, rcurl, and randomforest pre-installed
+{% include 'partial/gives.md' with context %}
+
+{% include 'partial/basic_use.md' with context %}
+
+{% include 'partial/notebook_options.md' %}
+
+{% include 'partial/docker_options.md' %}
+
+{% include 'partial/ssl_certificates.md' with context %}
+
+{% include 'partial/alternative_commands.md' with context %}

--- a/docs/scipy-notebook.md
+++ b/docs/scipy-notebook.md
@@ -1,0 +1,24 @@
+{%- set stack_name='scipy-notebook' %}
+{%- set base_path='../base-notebook' %}
+{%- include 'partial/badges.md' %}
+
+# Jupyter Notebook Scientific Python Stack
+
+## What it Gives You
+
+* Jupyter Notebook 4.2.x
+* Conda Python 3.x and Python 2.7.x environments
+* pandas, matplotlib, scipy, seaborn, scikit-learn, scikit-image, sympy, cython, patsy, statsmodel, cloudpickle, dill, numba, bokeh pre-installed
+{% include 'partial/gives.md' with context %}
+
+{% include 'partial/basic_use.md' with context %}
+
+{% include 'partial/notebook_options.md' %}
+
+{% include 'partial/docker_options.md' %}
+
+{% include 'partial/ssl_certificates.md' with context %}
+
+{% include 'partial/conda_py23_env.md' %}
+
+{% include 'partial/alternative_commands.md' with context %}

--- a/minimal-notebook/README.md
+++ b/minimal-notebook/README.md
@@ -19,7 +19,7 @@ Small image for working in the notebook and installing your own libraries
 
 The following command starts a container with the Notebook server listening for HTTP connections on port 8888 without authentication configured.
 
-```
+```bash
 docker run -d -p 8888:8888 jupyter/minimal-notebook
 ```
 
@@ -43,7 +43,7 @@ You can sidestep the `start-notebook.sh` script and run your own commands in the
 
 ## Docker Options
 
-You may customize the execution of the Docker container and the Notebook server it contains with the following optional arguments.
+You may customize the execution of the Docker container and the command it is running with the following optional arguments.
 
 * `-e PASSWORD="YOURPASS"` - Configures Jupyter Notebook to require the given plain-text password. Should be combined with `USE_HTTPS` on untrusted networks. **Note** that this option is not as secure as passing a pre-hashed password on the command line as shown above.
 * `-e USE_HTTPS=yes` - Configures Jupyter Notebook to accept encrypted HTTPS connections. If a `pem` file containing a SSL certificate and key is not provided (see below), the container will generate a self-signed certificate for you.
@@ -61,7 +61,7 @@ If you have your key and certificate(s) as separate files, you must concatenate 
 For additional information about using SSL, see the following:
 
 * The [docker-stacks/examples](https://github.com/jupyter/docker-stacks/tree/master/examples) for information about how to use [Let's Encrypt](https://letsencrypt.org/) certificates when you run these stacks on a publicly visible domain.
-* The [jupyter_notebook_config.py](jupyter_notebook_config.py) file for how this Docker image generates a self-signed certificate.
+* The [jupyter_notebook_config.py](../base-notebook/jupyter_notebook_config.py) file for how this Docker image generates a self-signed certificate.
 * The [Jupyter Notebook documentation](http://jupyter-notebook.readthedocs.io/en/latest/public_server.html#using-ssl-for-encrypted-communication) for best practices about running a public notebook server in general, most of which are encoded in this image.
 
 ## Conda Environment

--- a/pyspark-notebook/README.md
+++ b/pyspark-notebook/README.md
@@ -19,7 +19,7 @@
 
 The following command starts a container with the Notebook server listening for HTTP connections on port 8888 without authentication configured.
 
-```
+```bash
 docker run -d -p 8888:8888 jupyter/pyspark-notebook
 ```
 
@@ -27,9 +27,11 @@ docker run -d -p 8888:8888 jupyter/pyspark-notebook
 
 This configuration is nice for using Spark on small, local data.
 
+### In a Python Notebook
+
 0. Run the container as shown above.
-2. Open a Python 2 or 3 notebook.
-3. Create a `SparkContext` configured for local mode.
+1. Open a Python 2 or 3 notebook.
+2. Create a `SparkContext` configured for local mode.
 
 For example, the first few cells in the notebook might read:
 
@@ -48,12 +50,15 @@ This configuration allows your compute cluster to scale with your data.
 
 0. [Deploy Spark on Mesos](http://spark.apache.org/docs/latest/running-on-mesos.html).
 1. Configure each slave with [the `--no-switch_user` flag](https://open.mesosphere.com/reference/mesos-slave/) or create the `jovyan` user on every slave node.
-2. Ensure Python 2.x and/or 3.x and any Python libraries you wish to use in your Spark lambda functions are installed on your Spark workers.
+2. Ensure any libraries you wish to use in your Spark lambda functions are installed on your Spark workers.
 3. Run the Docker container with `--net=host` in a location that is network addressable by all of your Spark workers. (This is a [Spark networking requirement](http://spark.apache.org/docs/latest/cluster-overview.html#components).)
     * NOTE: When using `--net=host`, you must also use the flags `--pid=host -e TINI_SUBREAPER=true`. See https://github.com/jupyter/docker-stacks/issues/64 for details.
-4. Open a Python 2 or 3 notebook.
-5. Create a `SparkConf` instance in a new notebook pointing to your Mesos master node (or Zookeeper instance) and Spark binary package location.
-6. Create a `SparkContext` using this configuration.
+
+### In a Python Notebook
+
+0. Open a Python 2 or 3 notebook.
+1. Create a `SparkConf` instance in a new notebook pointing to your Mesos master node (or Zookeeper instance) and Spark binary package location.
+2. Create a `SparkContext` using this configuration.
 
 For example, the first few cells in a Python 3 notebook might read:
 
@@ -86,12 +91,12 @@ To use Python 2 in the notebook and on the workers, change the `PYSPARK_PYTHON` 
 
 Of course, all of this can be hidden in an [IPython kernel startup script](http://ipython.org/ipython-doc/stable/development/config.html?highlight=startup#startup-files), but "explicit is better than implicit." :)
 
-## Connecting to a Spark Cluster on Standalone Mode
+## Connecting to a Spark Cluster in Standalone Mode
 
-Connection to Spark Cluster on Standalone Mode requires the following set of steps:
+Connection to Spark Cluster in Standalone Mode requires the following set of steps:
 
-0. Verify that the docker image (check the Dockerfile) and the Spark Cluster which is being deployed, run the same version of Spark.
-1. [Deploy Spark on Standalone Mode](http://spark.apache.org/docs/latest/spark-standalone.html).
+0. Verify that the docker image (check the Dockerfile) and the Spark Cluster run the same version of Spark.
+1. [Deploy Spark in Standalone Mode](http://spark.apache.org/docs/latest/spark-standalone.html).
 2. Run the Docker container with `--net=host` in a location that is network addressable by all of your Spark workers. (This is a [Spark networking requirement](http://spark.apache.org/docs/latest/cluster-overview.html#components).)
     * NOTE: When using `--net=host`, you must also use the flags `--pid=host -e TINI_SUBREAPER=true`. See https://github.com/jupyter/docker-stacks/issues/64 for details.
 3. The language specific instructions are almost same as mentioned above for Mesos, only the master url would now be something like spark://10.10.10.10:7077
@@ -116,7 +121,7 @@ You can sidestep the `start-notebook.sh` script and run your own commands in the
 
 ## Docker Options
 
-You may customize the execution of the Docker container and the Notebook server it contains with the following optional arguments.
+You may customize the execution of the Docker container and the command it is running with the following optional arguments.
 
 * `-e PASSWORD="YOURPASS"` - Configures Jupyter Notebook to require the given plain-text password. Should be combined with `USE_HTTPS` on untrusted networks. **Note** that this option is not as secure as passing a pre-hashed password on the command line as shown above.
 * `-e USE_HTTPS=yes` - Configures Jupyter Notebook to accept encrypted HTTPS connections. If a `pem` file containing a SSL certificate and key is not provided (see below), the container will generate a self-signed certificate for you.
@@ -135,7 +140,7 @@ If you have your key and certificate(s) as separate files, you must concatenate 
 For additional information about using SSL, see the following:
 
 * The [docker-stacks/examples](https://github.com/jupyter/docker-stacks/tree/master/examples) for information about how to use [Let's Encrypt](https://letsencrypt.org/) certificates when you run these stacks on a publicly visible domain.
-* The [jupyter_notebook_config.py](jupyter_notebook_config.py) file for how this Docker image generates a self-signed certificate.
+* The [jupyter_notebook_config.py](../base-notebook/jupyter_notebook_config.py) file for how this Docker image generates a self-signed certificate.
 * The [Jupyter Notebook documentation](http://jupyter-notebook.readthedocs.io/en/latest/public_server.html#using-ssl-for-encrypted-communication) for best practices about running a public notebook server in general, most of which are encoded in this image.
 
 ## Conda Environments

--- a/r-notebook/README.md
+++ b/r-notebook/README.md
@@ -17,7 +17,7 @@
 
 The following command starts a container with the Notebook server listening for HTTP connections on port 8888 without authentication configured.
 
-```
+```bash
 docker run -d -p 8888:8888 jupyter/r-notebook
 ```
 
@@ -41,7 +41,7 @@ You can sidestep the `start-notebook.sh` script and run your own commands in the
 
 ## Docker Options
 
-You may customize the execution of the Docker container and the Notebook server it contains with the following optional arguments.
+You may customize the execution of the Docker container and the command it is running with the following optional arguments.
 
 * `-e PASSWORD="YOURPASS"` - Configures Jupyter Notebook to require the given plain-text password. Should be combined with `USE_HTTPS` on untrusted networks. **Note** that this option is not as secure as passing a pre-hashed password on the command line as shown above.
 * `-e USE_HTTPS=yes` - Configures Jupyter Notebook to accept encrypted HTTPS connections. If a `pem` file containing a SSL certificate and key is not provided (see below), the container will generate a self-signed certificate for you.
@@ -59,7 +59,7 @@ If you have your key and certificate(s) as separate files, you must concatenate 
 For additional information about using SSL, see the following:
 
 * The [docker-stacks/examples](https://github.com/jupyter/docker-stacks/tree/master/examples) for information about how to use [Let's Encrypt](https://letsencrypt.org/) certificates when you run these stacks on a publicly visible domain.
-* The [jupyter_notebook_config.py](jupyter_notebook_config.py) file for how this Docker image generates a self-signed certificate.
+* The [jupyter_notebook_config.py](../base-notebook/jupyter_notebook_config.py) file for how this Docker image generates a self-signed certificate.
 * The [Jupyter Notebook documentation](http://jupyter-notebook.readthedocs.io/en/latest/public_server.html#using-ssl-for-encrypted-communication) for best practices about running a public notebook server in general, most of which are encoded in this image.
 
 ## Alternative Commands

--- a/scipy-notebook/README.md
+++ b/scipy-notebook/README.md
@@ -17,7 +17,7 @@
 
 The following command starts a container with the Notebook server listening for HTTP connections on port 8888 without authentication configured.
 
-```
+```bash
 docker run -d -p 8888:8888 jupyter/scipy-notebook
 ```
 
@@ -39,10 +39,9 @@ docker run -d -p 8888:8888 jupyter/scipy-notebook start-notebook.sh --NotebookAp
 
 You can sidestep the `start-notebook.sh` script and run your own commands in the container. See the *Alternative Commands* section later in this document for more information.
 
-
 ## Docker Options
 
-You may customize the execution of the Docker container and the Notebook server it contains with the following optional arguments.
+You may customize the execution of the Docker container and the command it is running with the following optional arguments.
 
 * `-e PASSWORD="YOURPASS"` - Configures Jupyter Notebook to require the given plain-text password. Should be combined with `USE_HTTPS` on untrusted networks. **Note** that this option is not as secure as passing a pre-hashed password on the command line as shown above.
 * `-e USE_HTTPS=yes` - Configures Jupyter Notebook to accept encrypted HTTPS connections. If a `pem` file containing a SSL certificate and key is not provided (see below), the container will generate a self-signed certificate for you.
@@ -60,7 +59,7 @@ If you have your key and certificate(s) as separate files, you must concatenate 
 For additional information about using SSL, see the following:
 
 * The [docker-stacks/examples](https://github.com/jupyter/docker-stacks/tree/master/examples) for information about how to use [Let's Encrypt](https://letsencrypt.org/) certificates when you run these stacks on a publicly visible domain.
-* The [jupyter_notebook_config.py](jupyter_notebook_config.py) file for how this Docker image generates a self-signed certificate.
+* The [jupyter_notebook_config.py](../base-notebook/jupyter_notebook_config.py) file for how this Docker image generates a self-signed certificate.
 * The [Jupyter Notebook documentation](http://jupyter-notebook.readthedocs.io/en/latest/public_server.html#using-ssl-for-encrypted-communication) for best practices about running a public notebook server in general, most of which are encoded in this image.
 
 ## Conda Environments


### PR DESCRIPTION
The docs/generate.py script renders the jinja templated markdown files 
in docs/ into the README.md files in all of the other folders.

Things left to do:
- [ ] `make docs`
- [ ] CONTRIBUTING.md describing what folks need to do to add to or update the READMEs
- [ ] prefix generated READMEs with a note that warns they are **generated**
- [ ] run doc gen on travis to make sure it works

For issue #203.
