### PR TITLE
avoid creation of intermediate shell in start-notebook.sh

### DIFF
--- a/base-notebook/start-notebook.sh
+++ b/base-notebook/start-notebook.sh
@@ -4,4 +4,4 @@
 
 set -e
 
-start.sh jupyter notebook $*
+. /usr/local/bin/start.sh jupyter notebook $*


### PR DESCRIPTION
The new indirection via start.sh causes an intermediate shell in the process tree between tini and the notebook server. As a consequence, when the container is stopped (and not exited via Ctrl-C), the SIGTERM is not propagated to the notebook server (bash does not normally forward signals to children). So the notebook server anrd kernels are simply killed during container shutdown and not properly terminated.
This causes issues for us because we install notebook kernels that allocated remote resources outside the notebook container.

Fixed by executing start.sh in the same shell as start-notebook.sh instead of running a subprocess:

Error scenario:
> docker run -d --name foo jupyter/base-notebook
c0d26fe2df0c97022ebacee6eb40532be3d2056ccdde07266f9656fc93fb375f
> ps -ef | grep tini
okoeth   32538  2762  0 16:34 ?        00:00:00 tini -- start-notebook.sh
okoeth   32583  5873  0 16:35 pts/16   00:00:00 grep --color=auto tini
> pstree 32538
tini───start-notebook.───jupyter-noteboo
> docker stop foo
> docker logs foo 2>&1 | tail -3
[I 14:34:58.919 NotebookApp] 0 active kernels
[I 14:34:58.919 NotebookApp] The Jupyter Notebook is running at: http://[all ip addresses on your system]:8888/
[I 14:34:58.919 NotebookApp] Use Control-C to stop this server and shut down all kernels (twice to skip confirmation).
--> terminated without proper shutdown

After fix:
> docker rm foo
> docker run -d --name foo my-base-notebook
66eadc5076a084036f07e992b887079d0997630084410938226ce12afe661c09
> ps -ef | grep tini
okoeth    7800  2762  1 16:48 ?        00:00:00 tini -- start-notebook.sh
okoeth    7823  5873  0 16:48 pts/16   00:00:00 grep --color=auto tini
> pstree 7800
tini───jupyter-noteboo
> docker stop foo
foo
okoeth@okoeth-ThinkPad-W530:/scratch/spark/git/docker-stacks/base-notebook$ docker logs foo 2>&1 | tail -3
[I 14:48:19.621 NotebookApp] Use Control-C to stop this server and shut down all kernels (twice to skip confirmation).
[C 14:48:36.736 NotebookApp] received signal 15, stopping
[I 14:48:36.737 NotebookApp] Shutting down kernels

--> server shutdown executed
