### PR TITLE
Path ownership bugfix when changing NB_UID

### DIFF
--- a/base-notebook/start.sh
+++ b/base-notebook/start.sh
@@ -9,7 +9,7 @@ if [ $UID == 0 ] ; then
     # Change UID of NB_USER to NB_UID if it does not match
     if [ "$NB_UID" != $(id -u $NB_USER) ] ; then
         usermod -u $NB_UID $NB_USER
-        chown -R $NB_UID $CONDA_DIR .
+        chown -R $NB_UID $CONDA_DIR ..
     fi
 
     # Enable sudo if requested


### PR DESCRIPTION
Currently if I'm a user that has a UID that is not 1000 I'm getting the following permissions error when trying to start the notebook container and retain file ownership to my workstation's UID. 

```bash
> docker run -it  -p 127.0.0.1:8888:8888 -v $HOME/ipython:/home/jovyan/work -e NB_UID=$(id -u $USER) -e GRANT_SUDO=yes --user root jupyter/datascience-notebook
Traceback (most recent call last):
  File "/opt/conda/lib/python3.5/site-packages/traitlets/traitlets.py", line 501, in get
    value = obj._trait_values[self.name]
KeyError: 'runtime_dir'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/opt/conda/bin/jupyter-notebook", line 6, in <module>
    sys.exit(notebook.notebookapp.main())
  File "/opt/conda/lib/python3.5/site-packages/jupyter_core/application.py", line 267, in launch_instance
    return super(JupyterApp, cls).launch_instance(argv=argv, **kwargs)
  File "/opt/conda/lib/python3.5/site-packages/traitlets/config/application.py", line 595, in launch_instance
    app.initialize(argv)
  File "<decorator-gen-7>", line 2, in initialize
  File "/opt/conda/lib/python3.5/site-packages/traitlets/config/application.py", line 74, in catch_config_error
    return method(app, *args, **kwargs)
  File "/opt/conda/lib/python3.5/site-packages/notebook/notebookapp.py", line 1069, in initialize
    self.init_configurables()
  File "/opt/conda/lib/python3.5/site-packages/notebook/notebookapp.py", line 842, in init_configurables
    connection_dir=self.runtime_dir,
  File "/opt/conda/lib/python3.5/site-packages/traitlets/traitlets.py", line 529, in __get__
    return self.get(obj, cls)
  File "/opt/conda/lib/python3.5/site-packages/traitlets/traitlets.py", line 508, in get
    value = self._validate(obj, dynamic_default())
  File "/opt/conda/lib/python3.5/site-packages/jupyter_core/application.py", line 99, in _runtime_dir_default
    ensure_dir_exists(rd, mode=0o700)
  File "/opt/conda/lib/python3.5/site-packages/ipython_genutils/path.py", line 167, in ensure_dir_exists
    os.makedirs(path, mode=mode)
  File "/opt/conda/lib/python3.5/os.py", line 241, in makedirs
    mkdir(name, mode)
PermissionError: [Errno 13] Permission denied: '/home/jovyan/.local/share/jupyter/runtime'
```

Note: A more stable option for this fix might be to `chown -R $NB_UID $CONDA_DIR $(eval echo ~$NB_USER)` current patch should work unless WORKDIR changes.