### PR TITLE
Workaround for the linux filesystem issue

### DIFF
--- a/base-notebook/Dockerfile
+++ b/base-notebook/Dockerfile
@@ -50,7 +50,6 @@ USER $NB_USER
 # Setup jovyan home directory
 RUN mkdir /home/$NB_USER/work && \
     mkdir /home/$NB_USER/.jupyter && \
-    mkdir -p -m 700 /home/$NB_USER/.local/share/jupyter && \
     echo "cacert=/etc/ssl/certs/ca-certificates.crt" > /home/$NB_USER/.curlrc
 
 # Install conda as jovyan

--- a/base-notebook/start.sh
+++ b/base-notebook/start.sh
@@ -4,12 +4,14 @@
 
 set -e
 
+mkdir -p -m 700 /home/$NB_USER/.local/share/jupyter
+
 # Handle special flags if we're root
 if [ $UID == 0 ] ; then
     # Change UID of NB_USER to NB_UID if it does not match
     if [ "$NB_UID" != $(id -u $NB_USER) ] ; then
         usermod -u $NB_UID $NB_USER
-        chown -R $NB_UID $CONDA_DIR .
+        chown -R $NB_USER. $CONDA_DIR /home/$NB_USER/.local .
     fi
 
     # Enable sudo if requested


### PR DESCRIPTION
This is a workaround for #269. OverlayFS - the linux union filesystem had a bug that look up lower-layer perms before upper-layer perms and it was fixed on https://github.com/torvalds/linux/commit/38b78a5f18584db6fa7441e0f4531b283b0e6725 (kernel 4.6 and later). Same bug of AUFS was also fixed on https://github.com/sfjro/aufs4-linux/commit/625634d1dc3e6a0d03fbd918c074912797f5903b. But these patch isn't attached yet on most linux distros, e.g. Ubuntu Server 16.04, RHEL/CentOS 7.2 and Docker for Mac. 