### PR TITLE
Build matplotlib font cache during docker build.

### DIFF
--- a/scipy-notebook/Dockerfile
+++ b/scipy-notebook/Dockerfile
@@ -76,7 +76,7 @@ RUN ln -s $CONDA_DIR/envs/python2/bin/pip $CONDA_DIR/bin/pip2 && \
 
 # Import matplotlib the first time to build the font cache.
 ENV XDG_CACHE_HOME /home/$NB_USER/.cache/
-RUN $CONDA_DIR/envs/$ENV_NAME/bin/python -c "import matplotlib.pyplot"
+RUN $CONDA_DIR/envs/python2/bin/python -c "import matplotlib.pyplot"
 
 # Configure ipython kernel to use matplotlib inline backend by default
 RUN mkdir -p $HOME/.ipython/profile_default/startup

--- a/scipy-notebook/Dockerfile
+++ b/scipy-notebook/Dockerfile
@@ -76,7 +76,7 @@ RUN ln -s $CONDA_DIR/envs/python2/bin/pip $CONDA_DIR/bin/pip2 && \
 
 # Import matplotlib the first time to build the font cache.
 ENV XDG_CACHE_HOME /home/$NB_USER/.cache/
-RUN $CONDA_DIR/envs/python2/bin/python -c "import matplotlib.pyplot"
+RUN MPLBACKEND=Agg $CONDA_DIR/envs/python2/bin/python -c "import matplotlib.pyplot"
 
 # Configure ipython kernel to use matplotlib inline backend by default
 RUN mkdir -p $HOME/.ipython/profile_default/startup

--- a/scipy-notebook/Dockerfile
+++ b/scipy-notebook/Dockerfile
@@ -74,6 +74,10 @@ RUN conda create --quiet --yes -p $CONDA_DIR/envs/python2 python=2.7 \
 RUN ln -s $CONDA_DIR/envs/python2/bin/pip $CONDA_DIR/bin/pip2 && \
     ln -s $CONDA_DIR/bin/pip $CONDA_DIR/bin/pip3
 
+# Import matplotlib the first time to build the font cache.
+ENV XDG_CACHE_HOME /home/$NB_USER/.cache/
+RUN $CONDA_DIR/envs/$ENV_NAME/bin/python -c "import matplotlib.pyplot"
+
 # Configure ipython kernel to use matplotlib inline backend by default
 RUN mkdir -p $HOME/.ipython/profile_default/startup
 COPY mplimporthook.py $HOME/.ipython/profile_default/startup/


### PR DESCRIPTION
Matplotlib builds a font cache the first time it's imported. By importing it during the docker build, we can avoid this:

![screen shot 2016-09-26 at 9 06 14 am](https://cloud.githubusercontent.com/assets/2279598/18835362/b9ed324c-83c8-11e6-8259-c672d6450ff0.png)
