### PR TITLE
Update Julia version to 0.5

### DIFF
--- a/datascience-notebook/Dockerfile
+++ b/datascience-notebook/Dockerfile
@@ -60,3 +60,6 @@ RUN julia -e 'Pkg.add("IJulia")' && \
 # Add essential packages
 RUN echo "push!(Libdl.DL_LOAD_PATH, \"$CONDA_DIR/lib\")" > /home/$NB_USER/.juliarc.jl && \
     julia -e 'Pkg.add("Gadfly")' && julia -e 'Pkg.add("RDatasets")' && julia -F -e 'Pkg.add("HDF5")'
+
+# Precompile Julia pakcages
+RUN julia -e 'using IJulia' && julia -e 'using Gadfly' && julia -e 'using RDatasets'&& julia -e 'using HDF5'

--- a/datascience-notebook/Dockerfile
+++ b/datascience-notebook/Dockerfile
@@ -58,5 +58,5 @@ RUN julia -e 'Pkg.add("IJulia")' && \
 
 # Show Julia where conda libraries are
 # Add essential packages
-RUN echo "push!(Sys.DL_LOAD_PATH, \"$CONDA_DIR/lib\")" > /home/$NB_USER/.juliarc.jl && \
+RUN echo "push!(Libdl.DL_LOAD_PATH, \"$CONDA_DIR/lib\")" > /home/$NB_USER/.juliarc.jl && \
     julia -e 'Pkg.add("Gadfly")' && julia -e 'Pkg.add("RDatasets")' && julia -F -e 'Pkg.add("HDF5")'

--- a/datascience-notebook/Dockerfile
+++ b/datascience-notebook/Dockerfile
@@ -15,7 +15,9 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 # Julia dependencies
-RUN apt-get update && \
+RUN echo "deb http://ppa.launchpad.net/staticfloat/juliareleases/ubuntu trusty main" > /etc/apt/sources.list.d/julia.list && \
+    apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 3D3D3ACC && \
+    apt-get update && \
     apt-get install -y --no-install-recommends \
     julia \
     libnettle4 && apt-get clean && \

--- a/datascience-notebook/README.md
+++ b/datascience-notebook/README.md
@@ -9,7 +9,7 @@
 * pandas, matplotlib, scipy, seaborn, scikit-learn, scikit-image, sympy, cython, patsy, statsmodel, cloudpickle, dill, numba, bokeh pre-installed
 * Conda R v3.3.x and channel
 * plyr, devtools, dplyr, ggplot2, tidyr, shiny, rmarkdown, forecast, stringr, rsqlite, reshape2, nycflights13, caret, rcurl, and randomforest pre-installed
-* Julia v0.3.x with Gadfly, RDatasets and HDF5 pre-installed
+* Julia v0.5.x with Gadfly, RDatasets and HDF5 pre-installed
 * Unprivileged user `jovyan` (uid=1000, configurable, see options) in group `users` (gid=100) with ownership over `/home/jovyan` and `/opt/conda`
 * [tini](https://github.com/krallin/tini) as the container entrypoint and [start-notebook.sh](../base-notebook/start-notebook.sh) as the default command
 * A [start-singleuser.sh](../base-notebook/start-singleuser.sh) script useful for running a single-user instance of the Notebook server, as required by JupyterHub


### PR DESCRIPTION
Julia 0.3 is pretty old and most Julia packages no longer support it. These commits move us to 0.5, which was released in September.

Unfortunately, none of the Debian repositories seem to support 0.5, so I have a hack to use Ubuntu's stable Julia PPA instead. I've done some moderate sanity checks (playing around with Gadfly, reading and writing HDF5 files), but it's pretty kludgey.

One option would be to stick with Julia 0.4.7, which is in the Sid repositories for Debian. I think that the changes in Julia 0.5 are major enough that we should go with 0.5... OTOH I don't actually use Julia that much so `¯\_(ツ)_/¯`.