### PR TITLE
JupyterHub 0.7

### DIFF
--- a/base-notebook/Dockerfile
+++ b/base-notebook/Dockerfile
@@ -74,10 +74,8 @@ RUN echo "jpeg 8*" >> /opt/conda/conda-meta/pinned
 # Install Jupyter notebook as jovyan
 RUN conda install --quiet --yes \
     'notebook=4.2*' \
+    jupyterhub=0.7 \
     && conda clean -tipsy
-
-# Install JupyterHub to get the jupyterhub-singleuser startup script
-RUN pip --no-cache-dir install 'jupyterhub==0.5'
 
 USER root
 


### PR DESCRIPTION
and get it from conda (conda-forge)

single-user protocol should still be compatible, so this shouldn't change supported Hub versions