### PR TITLE
TensorFlow 0.11.0

### DIFF
--- a/tensorflow-notebook/Dockerfile
+++ b/tensorflow-notebook/Dockerfile
@@ -7,7 +7,7 @@ MAINTAINER Jupyter Project <jupyter@googlegroups.com>
 USER $NB_USER
 
 # Install Python 3 Tensorflow
-RUN conda install --quiet --yes 'tensorflow=0.9.0'
+RUN conda install --quiet --yes 'tensorflow=0.11.0'
 
 # Install Python 2 Tensorflow
-RUN conda install --quiet --yes -n python2 'tensorflow=0.9.0'
+RUN conda install --quiet --yes -n python2 'tensorflow=0.11.0'


### PR DESCRIPTION
The tensorflow-notebook image currently ships TensorFlow version 0.9.0. However, the official TensorFlow website no longer carries documentations for this version. Documentations are available for versions 0.10.0, 0.11.0, and 0.12.0.

Given 0.12.0 is still in RC0 and not available in conda-forge yet, I opted for 0.11.0. I am new to TensorFlow, and I don't know how soon the release version of 0.12.0 would come out. It may be better not  updating the docker image just now. However, it would be great to have a version with  still accessible official documentations.