### PR TITLE
Install Toree to conda env instead of user home

### DIFF
--- a/all-spark-notebook/Dockerfile
+++ b/all-spark-notebook/Dockerfile
@@ -30,4 +30,4 @@ RUN conda config --add channels r && \
 
 # Apache Toree kernel
 RUN pip --no-cache-dir install https://dist.apache.org/repos/dist/dev/incubator/toree/0.2.0/snapshots/dev1/toree-pip/toree-0.2.0.dev1.tar.gz
-RUN jupyter toree install --user
+RUN jupyter toree install --sys-prefix


### PR DESCRIPTION
Alternative fix for #315 to allow docker-demo-image to combine the current
datascience-notebook image which clears ~/.local directory with
all-spark-notebook.