### PR TITLE
Fix #340: Failing openjdk install

### DIFF
--- a/pyspark-notebook/Dockerfile
+++ b/pyspark-notebook/Dockerfile
@@ -13,7 +13,7 @@ ENV HADOOP_VERSION 2.7
 # Temporarily add jessie backports to get openjdk 8, but then remove that source
 RUN echo 'deb http://cdn-fastly.deb.debian.org/debian jessie-backports main' > /etc/apt/sources.list.d/jessie-backports.list && \
     apt-get -y update && \
-    apt-get install -y --no-install-recommends openjdk-8-jre-headless && \
+    apt-get install --no-install-recommends -t jessie-backports -y openjdk-8-jre-headless ca-certificates-java && \
     rm /etc/apt/sources.list.d/jessie-backports.list && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Add ca-certificates-java and prefer jessie-backports. Ref: http://unix.stackexchange.com/questions/342403/openjdk-8-jre-headless-depends-ca-certificates-java-but-it-is-not-going-to-be