### PR TITLE
R's tidyverse added to r-notebook and datascience-notebook

### DIFF
--- a/datascience-notebook/Dockerfile
+++ b/datascience-notebook/Dockerfile
@@ -33,13 +33,10 @@ RUN conda config --add channels r && \
     'r-irkernel=0.7*' \
     'r-plyr=1.8*' \
     'r-devtools=1.12*' \
-    'r-dplyr=0.5*' \
-    'r-ggplot2=2.2*' \
-    'r-tidyr=0.6*' \
+    'r-tidyverse=1.0*' \
     'r-shiny=0.14*' \
     'r-rmarkdown=1.2*' \
     'r-forecast=7.3*' \
-    'r-stringr=1.1*' \
     'r-rsqlite=1.1*' \
     'r-reshape2=1.4*' \
     'r-nycflights13=0.2*' \

--- a/datascience-notebook/README.md
+++ b/datascience-notebook/README.md
@@ -8,7 +8,8 @@
 * Conda Python 3.x and Python 2.7.x environments
 * pandas, matplotlib, scipy, seaborn, scikit-learn, scikit-image, sympy, cython, patsy, statsmodel, cloudpickle, dill, numba, bokeh pre-installed
 * Conda R v3.3.x and channel
-* plyr, devtools, dplyr, ggplot2, tidyr, shiny, rmarkdown, forecast, stringr, rsqlite, reshape2, nycflights13, caret, rcurl, and randomforest pre-installed
+* plyr, devtools, shiny, rmarkdown, forecast, rsqlite, reshape2, nycflights13, caret, rcurl, and randomforest pre-installed
+* The [tidyverse](https://github.com/tidyverse/tidyverse) R packages are also installed, including ggplot2, dplyr, tidyr, readr, purrr, tibble, stringr, lubridate, and broom
 * Julia v0.5.x with Gadfly, RDatasets and HDF5 pre-installed
 * Unprivileged user `jovyan` (uid=1000, configurable, see options) in group `users` (gid=100) with ownership over `/home/jovyan` and `/opt/conda`
 * [tini](https://github.com/krallin/tini) as the container entrypoint and [start-notebook.sh](../base-notebook/start-notebook.sh) as the default command

--- a/r-notebook/Dockerfile
+++ b/r-notebook/Dockerfile
@@ -23,13 +23,10 @@ RUN conda config --add channels r && \
     'r-irkernel=0.7*' \
     'r-plyr=1.8*' \
     'r-devtools=1.12*' \
-    'r-dplyr=0.5*' \
-    'r-ggplot2=2.2*' \
-    'r-tidyr=0.6*' \
+    'r-tidyverse=1.0*' \
     'r-shiny=0.14*' \
     'r-rmarkdown=1.2*' \
     'r-forecast=7.3*' \
-    'r-stringr=1.1*' \
     'r-rsqlite=1.1*' \
     'r-reshape2=1.4*' \
     'r-nycflights13=0.2*' \

--- a/r-notebook/README.md
+++ b/r-notebook/README.md
@@ -6,7 +6,8 @@
 
 * Jupyter Notebook 4.3.x
 * Conda R v3.3.x and channel
-* plyr, devtools, dplyr, ggplot2, tidyr, shiny, rmarkdown, forecast, stringr, rsqlite, reshape2, nycflights13, caret, rcurl, and randomforest pre-installed
+* plyr, devtools, shiny, rmarkdown, forecast, rsqlite, reshape2, nycflights13, caret, rcurl, and randomforest pre-installed
+* The [tidyverse](https://github.com/tidyverse/tidyverse) R packages are also installed, including ggplot2, dplyr, tidyr, readr, purrr, tibble, stringr, lubridate, and broom
 * Unprivileged user `jovyan` (uid=1000, configurable, see options) in group `users` (gid=100) with ownership over `/home/jovyan` and `/opt/conda`
 * [tini](https://github.com/krallin/tini) as the container entrypoint and [start-notebook.sh](../base-notebook/start-notebook.sh) as the default command
 * A [start-singleuser.sh](../base-notebook/start-singleuser.sh) script useful for running a single-user instance of the Notebook server, as required by JupyterHub


### PR DESCRIPTION
I've added [Hadley Wickham's `tidyverse`](https://github.com/tidyverse/tidyverse) to both the R and data science notebooks. The `tidyverse` package includes dependencies to major R packages that are frequently used in modern data analyses, including (copied shamelessly from the tidyverse README):

* `ggplot2`, for data visualisation.
* `dplyr`, for data manipulation.
* `tidyr`, for data tidying.
* `readr`, for data import.
* `purrr`, for functional programming.
* `stringr`, for strings.
* `lubridate`, for date/times.
* `modelr`, for modelling within a pipeline
* `broom`, for turning models into tidy data

The `conda` reference to `tidyverse` replaces the references to `ggplot2`, `dplyr`, `tidyr`, and `stringr`. Their version numbers remain the same as the ones previously specified in both Dockerfiles.