### PR TITLE
Bump all the package versions

### DIFF
--- a/base-notebook/Dockerfile
+++ b/base-notebook/Dockerfile
@@ -59,10 +59,10 @@ RUN mkdir /home/$NB_USER/work && \
 # Install conda as jovyan
 RUN cd /tmp && \
     mkdir -p $CONDA_DIR && \
-    wget --quiet https://repo.continuum.io/miniconda/Miniconda3-4.3.11-Linux-x86_64.sh && \
-    echo "b9fe70ce7b6fa8df05abfb56995959b897d0365299f5046063bc236843474fb8 *Miniconda3-4.3.11-Linux-x86_64.sh" | sha256sum -c - && \
-    /bin/bash Miniconda3-4.3.11-Linux-x86_64.sh -f -b -p $CONDA_DIR && \
-    rm Miniconda3-4.3.11-Linux-x86_64.sh && \
+    wget --quiet https://repo.continuum.io/miniconda/Miniconda3-4.2.12-Linux-x86_64.sh && \
+    echo "c59b3dd3cad550ac7596e0d599b91e75d88826db132e4146030ef471bb434e9a *Miniconda3-4.2.12-Linux-x86_64.sh" | sha256sum -c - && \
+    /bin/bash Miniconda3-4.2.12-Linux-x86_64.sh -f -b -p $CONDA_DIR && \
+    rm Miniconda3-4.2.12-Linux-x86_64.sh && \
     $CONDA_DIR/bin/conda config --system --add channels conda-forge && \
     $CONDA_DIR/bin/conda config --system --set auto_update_conda false && \
     conda clean -tipsy

--- a/base-notebook/Dockerfile
+++ b/base-notebook/Dockerfile
@@ -69,8 +69,8 @@ RUN cd /tmp && \
 
 # Install Jupyter Notebook and Hub
 RUN conda install --quiet --yes \
-    'notebook=4.3*' \
-    jupyterhub=0.7.* \
+    'notebook=4.4.*' \
+    'jupyterhub=0.7.*' \
     && conda clean -tipsy
 
 USER root

--- a/base-notebook/Dockerfile
+++ b/base-notebook/Dockerfile
@@ -59,10 +59,10 @@ RUN mkdir /home/$NB_USER/work && \
 # Install conda as jovyan
 RUN cd /tmp && \
     mkdir -p $CONDA_DIR && \
-    wget --quiet https://repo.continuum.io/miniconda/Miniconda3-4.2.12-Linux-x86_64.sh && \
-    echo "c59b3dd3cad550ac7596e0d599b91e75d88826db132e4146030ef471bb434e9a *Miniconda3-4.2.12-Linux-x86_64.sh" | sha256sum -c - && \
-    /bin/bash Miniconda3-4.2.12-Linux-x86_64.sh -f -b -p $CONDA_DIR && \
-    rm Miniconda3-4.2.12-Linux-x86_64.sh && \
+    wget --quiet https://repo.continuum.io/miniconda/Miniconda3-4.3.11-Linux-x86_64.sh && \
+    echo "b9fe70ce7b6fa8df05abfb56995959b897d0365299f5046063bc236843474fb8 *Miniconda3-4.3.11-Linux-x86_64.sh" | sha256sum -c - && \
+    /bin/bash Miniconda3-4.3.11-Linux-x86_64.sh -f -b -p $CONDA_DIR && \
+    rm Miniconda3-4.3.11-Linux-x86_64.sh && \
     $CONDA_DIR/bin/conda config --system --add channels conda-forge && \
     $CONDA_DIR/bin/conda config --system --set auto_update_conda false && \
     conda clean -tipsy

--- a/base-notebook/Dockerfile
+++ b/base-notebook/Dockerfile
@@ -70,7 +70,7 @@ RUN cd /tmp && \
 # Install Jupyter Notebook and Hub
 RUN conda install --quiet --yes \
     'notebook=4.3*' \
-    jupyterhub=0.7 \
+    jupyterhub=0.7.* \
     && conda clean -tipsy
 
 USER root

--- a/scipy-notebook/Dockerfile
+++ b/scipy-notebook/Dockerfile
@@ -30,7 +30,7 @@ RUN conda install --quiet --yes \
     'sympy=1.0*' \
     'cython=0.25*' \
     'patsy=0.4*' \
-    'statsmodels=0.6*' \
+    'statsmodels=0.8*' \
     'cloudpickle=0.2*' \
     'dill=0.2*' \
     'numba=0.31*' \

--- a/scipy-notebook/Dockerfile
+++ b/scipy-notebook/Dockerfile
@@ -52,26 +52,26 @@ RUN jupyter nbextension enable --py widgetsnbextension --sys-prefix
 # use notebook-friendly backends in these images
 RUN conda create --quiet --yes -p $CONDA_DIR/envs/python2 python=2.7 \
     'nomkl' \
-    'ipython=4.2*' \
-    'ipywidgets=5.2*' \
+    'ipython=5.3*' \
+    'ipywidgets=6.0*' \
     'pandas=0.19*' \
     'numexpr=2.6*' \
     'matplotlib=1.5*' \
-    'scipy=0.17*' \
+    'scipy=0.19*' \
     'seaborn=0.7*' \
-    'scikit-learn=0.17*' \
-    'scikit-image=0.11*' \
+    'scikit-learn=0.18*' \
+    'scikit-image=0.12*' \
     'sympy=1.0*' \
-    'cython=0.23*' \
+    'cython=0.25*' \
     'patsy=0.4*' \
-    'statsmodels=0.6*' \
-    'cloudpickle=0.1*' \
+    'statsmodels=0.8*' \
+    'cloudpickle=0.2*' \
     'dill=0.2*' \
-    'numba=0.23*' \
+    'numba=0.31*' \
     'bokeh=0.12*' \
     'hdf5=1.8.17' \
     'h5py=2.6*' \
-    'sqlalchemy=1.0*' \
+    'sqlalchemy=1.1*' \
     'pyzmq' \
     'vincent=0.4.*' \
     'beautifulsoup4=4.5.*' \

--- a/scipy-notebook/Dockerfile
+++ b/scipy-notebook/Dockerfile
@@ -19,23 +19,23 @@ USER $NB_USER
 # use notebook-friendly backends in these images
 RUN conda install --quiet --yes \
     'nomkl' \
-    'ipywidgets=5.2*' \
+    'ipywidgets=6.0*' \
     'pandas=0.19*' \
     'numexpr=2.6*' \
     'matplotlib=1.5*' \
-    'scipy=0.17*' \
+    'scipy=0.19*' \
     'seaborn=0.7*' \
     'scikit-learn=0.18*' \
-    'scikit-image=0.11*' \
+    'scikit-image=0.12*' \
     'sympy=1.0*' \
-    'cython=0.23*' \
+    'cython=0.25*' \
     'patsy=0.4*' \
     'statsmodels=0.6*' \
-    'cloudpickle=0.1*' \
+    'cloudpickle=0.2*' \
     'dill=0.2*' \
-    'numba=0.23*' \
-    'bokeh=0.11*' \
-    'sqlalchemy=1.0*' \
+    'numba=0.31*' \
+    'bokeh=0.12*' \
+    'sqlalchemy=1.1*' \
     'hdf5=1.8.17' \
     'h5py=2.6*' \
     'vincent=0.4.*' \
@@ -68,7 +68,7 @@ RUN conda create --quiet --yes -p $CONDA_DIR/envs/python2 python=2.7 \
     'cloudpickle=0.1*' \
     'dill=0.2*' \
     'numba=0.23*' \
-    'bokeh=0.11*' \
+    'bokeh=0.12*' \
     'hdf5=1.8.17' \
     'h5py=2.6*' \
     'sqlalchemy=1.0*' \

--- a/scipy-notebook/Dockerfile
+++ b/scipy-notebook/Dockerfile
@@ -22,7 +22,7 @@ RUN conda install --quiet --yes \
     'ipywidgets=6.0*' \
     'pandas=0.19*' \
     'numexpr=2.6*' \
-    'matplotlib=1.5*' \
+    'matplotlib=2.0*' \
     'scipy=0.19*' \
     'seaborn=0.7*' \
     'scikit-learn=0.18*' \
@@ -56,7 +56,7 @@ RUN conda create --quiet --yes -p $CONDA_DIR/envs/python2 python=2.7 \
     'ipywidgets=6.0*' \
     'pandas=0.19*' \
     'numexpr=2.6*' \
-    'matplotlib=1.5*' \
+    'matplotlib=2.0*' \
     'scipy=0.19*' \
     'seaborn=0.7*' \
     'scikit-learn=0.18*' \

--- a/tensorflow-notebook/Dockerfile
+++ b/tensorflow-notebook/Dockerfile
@@ -7,7 +7,7 @@ MAINTAINER Jupyter Project <jupyter@googlegroups.com>
 USER $NB_USER
 
 # Install Python 3 Tensorflow
-RUN conda install --quiet --yes 'tensorflow=0.11.0'
+RUN conda install --quiet --yes 'tensorflow=1.0*'
 
 # Install Python 2 Tensorflow
-RUN conda install --quiet --yes -n python2 'tensorflow=0.11.0'
+RUN conda install --quiet --yes -n python2 'tensorflow=1.0*'


### PR DESCRIPTION
This PR changes the versions of packages such that we can easily switch to Python 3.6 later.

Once Spark 2.1.1 is released and `spylon-kernel` updated to `py36` we can change `conda` to 4.3* and profit 😄 