### PR TITLE
Adds texlive-xetex package

### DIFF
--- a/minimal-notebook/Dockerfile
+++ b/minimal-notebook/Dockerfile
@@ -23,6 +23,7 @@ RUN apt-get update && apt-get install -yq --no-install-recommends \
     texlive-fonts-extra \
     texlive-fonts-recommended \
     texlive-generic-recommended \
+    texlive-xetex \
     libxrender1 \
     inkscape \
     && apt-get clean && \


### PR DESCRIPTION
texlive-xetex provides xelatex, fixing `nbconvert failed: xelatex not found on PATH` issue

Fixes #353 