### PR TITLE
add jupyterlab 0.17 to minimal-notebook

### DIFF
--- a/base-notebook/Dockerfile
+++ b/base-notebook/Dockerfile
@@ -71,6 +71,7 @@ RUN cd /tmp && \
 RUN conda install --quiet --yes \
     'notebook=4.4.*' \
     'jupyterhub=0.7.*' \
+    'jupyterlab=0.17.*' \
     && conda clean -tipsy
 
 USER root


### PR DESCRIPTION
we could also move it down to `scipy-notebook`, if we don't want to increase the size of the base images.

@jasongrout @blink1073 @ellisonbg any (conda-packaged) extensions you think we should have available by default at the `scipy-notebook` or `datascience-notebook` level?