### PR TITLE
Add a tiny alpine based notebook

### DIFF
--- a/tiniest-notebook/Dockerfile
+++ b/tiniest-notebook/Dockerfile
@@ -1,0 +1,11 @@
+FROM alpine:3.5
+
+# We install py-zmq from alpine, since installing it from pip requires we have
+# gcc and build tools installed. manylinux1 wheels don't work on / for alpine yet
+RUN apk add --no-cache python3 py-zmq
+
+RUN pip3 install --no-cache-dir notebook ipykernel jupyterhub
+
+CMD ["/usr/bin/jupyter", "notebook", "--ip=0.0.0.0", "--port=8888"]
+
+EXPOSE 8888

--- a/tiniest-notebook/README.md
+++ b/tiniest-notebook/README.md
@@ -1,0 +1,26 @@
+# Tiniest notebook stack #
+
+This is the tiniest possible docker image that can run a Jupyter Notebook. It
+is primarily meant for demo purposes where speed of pulling is important.
+
+Not recommended for non-demo uses!
+
+## What it gives you
+
+It is based on [Alpine Linux](https://alpinelinux.org/). It uses pip to install
+both the notebook and jupyterhub packages - the latter allows us to use this
+image for single-user servers in Kubernetes / Docker spawners.
+
+You can use pip3 to install packages (with `pip3` or `apk`) as root. There
+are no non-root users provisioned.
+
+## Basic usage
+
+You can run a notebook with:
+
+```
+sudo docker run  -it  --rm  -p 8888:8888 jupyter/tiniest-notebook
+```
+
+The default command is `/usr/bin/jupyter` (not `/usr/local/bin/jupyth`). For
+use with jupyterhub, `/usr/bin/jupyterhub-singleuser` is also available.


### PR DESCRIPTION
When doing live demos of JupyterHub  container based deployments,
showmanship is important. And one big aspect of it is 'time taken
from nothing at all to running single-user container'. Image pull
times are a big contributor to this first time demo experience -
and all the current docker-stacks images are too big to give a
'pop'.

This image is optimized for size and demo-worthiness only. Not
to be used for anything else, ideally. Part of the demo can be
configuring the spawner to use a different dockerstack image -
this provides a nice way to explain why it is slow without it
taking away from the initial demo's speed.