### PR TITLE
Enable jupyterlab as a jupyter serverextension

### DIFF
--- a/base-notebook/Dockerfile
+++ b/base-notebook/Dockerfile
@@ -74,6 +74,8 @@ RUN conda install --quiet --yes \
     'jupyterlab=0.17.*' \
     && conda clean -tipsy
 
+RUN jupyter serverextension enable --py jupyterlab --sys-prefix
+
 USER root
 
 EXPOSE 8888


### PR DESCRIPTION
It's required when working with jupyterhub script start-singleuser.sh and jupyterhub-singleuser