### PR TITLE
Add fonts-liberation requirement, fix #372

### DIFF
--- a/base-notebook/Dockerfile
+++ b/base-notebook/Dockerfile
@@ -21,6 +21,7 @@ RUN REPO=http://cdn-fastly.deb.debian.org \
     ca-certificates \
     sudo \
     locales \
+    fonts-liberation \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
I added the `fonts-liberation` requirement to `base-notebook`. Since it's so early in the image layers, it requires a fairly massive rebuild, which may not be desirable. On the other hand, it should solve the font issue everywhere, and it doesn't add terribly much to the image size. 

See: [Commonly Used Fonts on Debian](https://wiki.debian.org/Fonts#Commonly_Used_Fonts)

Also, FWIW, I considered using,

```sh
fc-list -f "%{file}\n" | grep .ttf | \
while read f ; \
    do cp $f /opt/conda/lib/python3.5/site-packages/matplotlib/mpl-data/fonts/ttf; \
done
```

This copies all available `ttf`s to the `matplotlib` font directory. But, font-liberation seems like a cleaner solution.
