### PR TITLE
install Julia packages in /opt/julia

### DIFF
--- a/datascience-notebook/Dockerfile
+++ b/datascience-notebook/Dockerfile
@@ -15,13 +15,21 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 # Julia dependencies
+# install Julia packages in /opt/julia instead of $HOME
+ENV JULIA_PKGDIR=/opt/julia
+
 RUN echo "deb http://ppa.launchpad.net/staticfloat/juliareleases/ubuntu trusty main" > /etc/apt/sources.list.d/julia.list && \
     apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 3D3D3ACC && \
     apt-get update && \
     apt-get install -y --no-install-recommends \
     julia \
     libnettle4 && apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
+    rm -rf /var/lib/apt/lists/* && \
+    # Show Julia where conda libraries are \
+    echo "push!(Libdl.DL_LOAD_PATH, \"$CONDA_DIR/lib\")" >> /usr/etc/julia/juliarc.jl && \
+    # Create JULIA_PKGDIR \
+    mkdir $JULIA_PKGDIR && \
+    chown -R $NB_USER:users $JULIA_PKGDIR
 
 USER $NB_USER
 
@@ -45,18 +53,23 @@ RUN conda config --system --add channels r && \
     'r-crayon=1.3*' \
     'r-randomforest=4.6*' && conda clean -tipsy
 
-# Install IJulia packages as jovyan and then move the kernelspec out
+# Add Julia packages
+# Install IJulia as jovyan and then move the kernelspec out
 # to the system share location. Avoids problems with runtime UID change not
 # taking effect properly on the .local folder in the jovyan home dir.
-RUN julia -e 'Pkg.add("IJulia")' && \
+RUN julia -e 'Pkg.init()' && \
+    julia -e 'Pkg.update()' && \
+    julia -e 'Pkg.add("HDF5")' && \
+    julia -e 'Pkg.add("Gadfly")' && \
+    julia -e 'Pkg.add("RDatasets")' && \
+    julia -e 'Pkg.add("IJulia")' && \
+    # Precompile Julia packages \
+    julia -e 'using HDF5' && \
+    julia -e 'using Gadfly' && \
+    julia -e 'using RDatasets' && \
+    julia -e 'using IJulia' && \
+    # move kernelspec out of home \
     mv $HOME/.local/share/jupyter/kernels/julia* $CONDA_DIR/share/jupyter/kernels/ && \
     chmod -R go+rx $CONDA_DIR/share/jupyter && \
     rm -rf $HOME/.local
 
-# Show Julia where conda libraries are
-# Add essential packages
-RUN echo "push!(Libdl.DL_LOAD_PATH, \"$CONDA_DIR/lib\")" > /home/$NB_USER/.juliarc.jl && \
-    julia -e 'Pkg.add("Gadfly")' && julia -e 'Pkg.add("RDatasets")' && julia -F -e 'Pkg.add("HDF5")'
-
-# Precompile Julia pakcages
-RUN julia -e 'using IJulia' && julia -e 'using Gadfly' && julia -e 'using RDatasets'&& julia -e 'using HDF5'


### PR DESCRIPTION
This gets close to #331, but we're not quite there. I believe the only files left in $HOME are `.curlrc` and `.ipython/profile_default/startup/mplimporthook`

@parente do you recall what the curlrc config solves and/or if it can be put in `/etc/` somewhere?