### PR TITLE
Update Tensorflow example

### DIFF
--- a/tensorflow-notebook/README.md
+++ b/tensorflow-notebook/README.md
@@ -27,7 +27,7 @@ import tensorflow as tf
 hello = tf.Variable('Hello World!')
 
 sess = tf.Session()
-init = tf.initialize_all_variables()
+init = tf.global_variables_initializer()
 
 sess.run(init)
 sess.run(hello)


### PR DESCRIPTION
`initialize_all_variables` is deprecated, although it still works, and `global_variables_initializer` is the replacement.