### PR TITLE
singleuser-start adjustments

### DIFF
--- a/base-notebook/start-notebook.sh
+++ b/base-notebook/start-notebook.sh
@@ -4,4 +4,9 @@
 
 set -e
 
-. /usr/local/bin/start.sh jupyter notebook $*
+if [[ ! -z "${JUPYTERHUB_API_TOKEN}" ]]; then
+  # launched by JupyterHub, use single-user entrypoint
+  exec /usr/local/bin/start-singleuser.sh $*
+else
+  . /usr/local/bin/start.sh jupyter notebook $*
+fi

--- a/base-notebook/start-singleuser.sh
+++ b/base-notebook/start-singleuser.sh
@@ -10,7 +10,7 @@ then
     notebook_arg="--notebook-dir=${NOTEBOOK_DIR}"
 fi
 
-exec jupyterhub-singleuser \
+. /usr/local/bin/start.sh jupyterhub-singleuser \
   --port=${JPY_PORT:-8888} \
   --ip=0.0.0.0 \
   --user=$JPY_USER \


### PR DESCRIPTION
- launch singleuser if JupyterHub environment variables are detected (avoids users' need to set CMD)
- invoke start.sh in start-singleuser.sh, for consistency with notebook entrypoint (e.g. GRANT_SUDO)