### PR TITLE
Force ownership change on /home/jovyan/work

### DIFF
--- a/base-notebook/start.sh
+++ b/base-notebook/start.sh
@@ -16,6 +16,9 @@ if [ $UID == 0 ] ; then
                 chown -R $NB_UID "$d"
             fi
         done
+    elif [[ -d /home/$NB_USER/work && $(stat -c %U /home/$NB_USER/work) != "$NB_USER" ]]; then
+      echo "Change ownership of /home/$NB_USER/work from $(stat -c %U /home/$NB_USER/work) to $NB_USER"
+      chown -R $NB_UID /home/$NB_USER
     fi
 
     # Change GID of NB_USER to NB_GID if NB_GID is passed as a parameter


### PR DESCRIPTION
In case Jupyter is started by Marathon with a persistant volume, `/home/jovyan/work` is owned by [root](url). We still want to use uid 1000, partly because we don't want to change ownership on [/opt/conda](url) and so on).

So, just test ownership of the work directory, if it is wrong for this folder, just chown it.

Note: we cannot controle which user the Marathon Volume will be created with, it is mandatorily owned by `root` user.

Signed-off-by: Gaetan Semet <gaetan@xeberon.net>