### PR TITLE
Revert "Fix sudoers.d inclusion on debian img (fix #394)"

### DIFF
--- a/base-notebook/start.sh
+++ b/base-notebook/start.sh
@@ -28,8 +28,6 @@ if [ $UID == 0 ] ; then
 
     # Enable sudo if requested
     if [ ! -z "$GRANT_SUDO" ]; then
-        # Ensure includedir sudoers.d is not commented
-        sed -i -E 's|^#(includedir /etc/sudoers.d.*)|\1|g' /etc/sudoers
         echo "$NB_USER ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/notebook
     fi
 


### PR DESCRIPTION
This reverts commit 4b3b6697e78bd286910ccabd7cfe423592e1a841.

\#includedir is the correct syntax, not a comment
https://www.sudo.ws/man/1.8.13/sudoers.man.html#Including_other_files_from_within_sudoers

Fixes #400