### PR TITLE
Enable master branch build-tag-push on Docker Cloud

### DIFF
--- a/all-spark-notebook/hooks/post_push
+++ b/all-spark-notebook/hooks/post_push
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# Tag the latest build with the short git sha. Push the tag in addition
+# to the "latest" tag already pushed.
+GIT_SHA_TAG=${SOURCE_COMMIT:0:12}
+docker tag $IMAGE_NAME $DOCKER_REPO:$GIT_SHA_TAG
+docker push $DOCKER_REPO:$GIT_SHA_TAG
+
+# Invoke all downstream build triggers.
+for url in $(echo $NEXT_BUILD_TRIGGERS | sed "s/,/ /g")
+do
+    curl -X POST $url
+done

--- a/base-notebook/hooks/post_push
+++ b/base-notebook/hooks/post_push
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# Tag the latest build with the short git sha. Push the tag in addition
+# to the "latest" tag already pushed.
+GIT_SHA_TAG=${SOURCE_COMMIT:0:12}
+docker tag $IMAGE_NAME $DOCKER_REPO:$GIT_SHA_TAG
+docker push $DOCKER_REPO:$GIT_SHA_TAG
+
+# Invoke all downstream build triggers.
+for url in $(echo $NEXT_BUILD_TRIGGERS | sed "s/,/ /g")
+do
+    curl -X POST $url
+done

--- a/datascience-notebook/hooks/post_push
+++ b/datascience-notebook/hooks/post_push
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# Tag the latest build with the short git sha. Push the tag in addition
+# to the "latest" tag already pushed.
+GIT_SHA_TAG=${SOURCE_COMMIT:0:12}
+docker tag $IMAGE_NAME $DOCKER_REPO:$GIT_SHA_TAG
+docker push $DOCKER_REPO:$GIT_SHA_TAG
+
+# Invoke all downstream build triggers.
+for url in $(echo $NEXT_BUILD_TRIGGERS | sed "s/,/ /g")
+do
+    curl -X POST $url
+done

--- a/minimal-notebook/hooks/post_push
+++ b/minimal-notebook/hooks/post_push
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# Tag the latest build with the short git sha. Push the tag in addition
+# to the "latest" tag already pushed.
+GIT_SHA_TAG=${SOURCE_COMMIT:0:12}
+docker tag $IMAGE_NAME $DOCKER_REPO:$GIT_SHA_TAG
+docker push $DOCKER_REPO:$GIT_SHA_TAG
+
+# Invoke all downstream build triggers.
+for url in $(echo $NEXT_BUILD_TRIGGERS | sed "s/,/ /g")
+do
+    curl -X POST $url
+done

--- a/pyspark-notebook/hooks/post_push
+++ b/pyspark-notebook/hooks/post_push
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# Tag the latest build with the short git sha. Push the tag in addition
+# to the "latest" tag already pushed.
+GIT_SHA_TAG=${SOURCE_COMMIT:0:12}
+docker tag $IMAGE_NAME $DOCKER_REPO:$GIT_SHA_TAG
+docker push $DOCKER_REPO:$GIT_SHA_TAG
+
+# Invoke all downstream build triggers.
+for url in $(echo $NEXT_BUILD_TRIGGERS | sed "s/,/ /g")
+do
+    curl -X POST $url
+done

--- a/r-notebook/hooks/post_push
+++ b/r-notebook/hooks/post_push
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# Tag the latest build with the short git sha. Push the tag in addition
+# to the "latest" tag already pushed.
+GIT_SHA_TAG=${SOURCE_COMMIT:0:12}
+docker tag $IMAGE_NAME $DOCKER_REPO:$GIT_SHA_TAG
+docker push $DOCKER_REPO:$GIT_SHA_TAG
+
+# Invoke all downstream build triggers.
+for url in $(echo $NEXT_BUILD_TRIGGERS | sed "s/,/ /g")
+do
+    curl -X POST $url
+done

--- a/scipy-notebook/hooks/post_push
+++ b/scipy-notebook/hooks/post_push
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# Tag the latest build with the short git sha. Push the tag in addition
+# to the "latest" tag already pushed.
+GIT_SHA_TAG=${SOURCE_COMMIT:0:12}
+docker tag $IMAGE_NAME $DOCKER_REPO:$GIT_SHA_TAG
+docker push $DOCKER_REPO:$GIT_SHA_TAG
+
+# Invoke all downstream build triggers.
+for url in $(echo $NEXT_BUILD_TRIGGERS | sed "s/,/ /g")
+do
+    curl -X POST $url
+done

--- a/tensorflow-notebook/hooks/post_push
+++ b/tensorflow-notebook/hooks/post_push
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# Tag the latest build with the short git sha. Push the tag in addition
+# to the "latest" tag already pushed.
+GIT_SHA_TAG=${SOURCE_COMMIT:0:12}
+docker tag $IMAGE_NAME $DOCKER_REPO:$GIT_SHA_TAG
+docker push $DOCKER_REPO:$GIT_SHA_TAG
+
+# Invoke all downstream build triggers.
+for url in $(echo $NEXT_BUILD_TRIGGERS | sed "s/,/ /g")
+do
+    curl -X POST $url
+done


### PR DESCRIPTION
* Added `hooks/post_push` to tag builds with the 12-char git SHA and invoke downstream builds
* Updated the README with info about managing the build order of repositories on Docker Cloud

Note that the hooks must be replicated in every folder since every stack is independent and assumes a build root of its own folder.

Closes #215.