### PR TITLE
update home folder and username on startup

### DIFF
--- a/base-notebook/start.sh
+++ b/base-notebook/start.sh
@@ -6,6 +6,9 @@ set -e
 
 # Handle special flags if we're root
 if [ $(id -u) == 0 ] ; then
+    # Handle username change. Since this is cheap, do this unconditionally
+    usermod -d /home/$NB_USER -l $NB_USER jovyan
+
     # Change UID of NB_USER to NB_UID if it does not match
     if [ "$NB_UID" != $(id -u $NB_USER) ] ; then
         echo "Set user UID to: $NB_UID"


### PR DESCRIPTION
closes #414 

Some remarks:
* This now assumes that the base image does not rename the notebook user, and keeps it `jovyan`. Is that OK?
* Like the previously existing code, I assume that the home is located in `/home/$NB_USER`. This isn't given, but out of scope of the MR
* I do not copy anything from `/home/jovyan` to the new location, assuming that the users know what they want to put in the new location.
* I am not a linux administration expert and I may be forgetting something obvious.