### PR TITLE
update base image to debian:stretch

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Starting with [git commit SHA 9bd33dcc8688](https://github.com/jupyter/docker-st
 
 **When there's a security fix in the Debian base image, do the following in place of the last command:**
 
-Update the `debian:jessie` SHA in the most-base images (e.g., base-notebook). Submit it as a regular PR and go through the build process. Expect the build to take a while to complete: every image layer will rebuild.
+Update the `debian:stretch` SHA in the most-base images (e.g., base-notebook). Submit it as a regular PR and go through the build process. Expect the build to take a while to complete: every image layer will rebuild.
 
 **When there's a new stack definition, do the following before merging the PR with the new stack:**
 

--- a/base-notebook/Dockerfile
+++ b/base-notebook/Dockerfile
@@ -1,9 +1,9 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 
-# Debian Jessie debootstrap from 2017-02-27
-# https://github.com/docker-library/official-images/commit/aa5973d0c918c70c035ec0746b8acaec3a4d7777
-FROM debian@sha256:52af198afd8c264f1035206ca66a5c48e602afb32dc912ebf9e9478134601ec4
+# Debian Stretch debootstrap from 2017-07-23
+# https://github.com/docker-library/official-images/commit/0ea9b38b835ffb656c497783321632ec7f87b60c
+FROM debian@sha256:6ccbcbf362dbc4add74711cb774751b59cdfd7aed16c3c29aaecbea871952fe0
 
 MAINTAINER Jupyter Project <jupyter@googlegroups.com>
 
@@ -13,7 +13,7 @@ USER root
 # features (e.g., download as all possible file formats)
 ENV DEBIAN_FRONTEND noninteractive
 RUN REPO=http://cdn-fastly.deb.debian.org \
- && echo "deb $REPO/debian jessie main\ndeb $REPO/debian-security jessie/updates main" > /etc/apt/sources.list \
+ && echo "deb $REPO/debian stretch main\ndeb $REPO/debian-security stretch/updates main" > /etc/apt/sources.list \
  && apt-get update && apt-get -yq dist-upgrade \
  && apt-get install -yq --no-install-recommends \
     wget \

--- a/datascience-notebook/Dockerfile
+++ b/datascience-notebook/Dockerfile
@@ -17,19 +17,8 @@ RUN apt-get update && \
 # Julia dependencies
 # install Julia packages in /opt/julia instead of $HOME
 ENV JULIA_PKGDIR=/opt/julia
-
-RUN echo "deb http://ppa.launchpad.net/staticfloat/juliareleases/ubuntu trusty main" > /etc/apt/sources.list.d/julia.list && \
-    apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 3D3D3ACC && \
-    apt-get update && \
-    apt-get install -y --no-install-recommends \
-    julia \
-    libnettle4 && apt-get clean && \
-    rm -rf /var/lib/apt/lists/* && \
-    # Show Julia where conda libraries are \
-    echo "push!(Libdl.DL_LOAD_PATH, \"$CONDA_DIR/lib\")" >> /usr/etc/julia/juliarc.jl && \
-    # Create JULIA_PKGDIR \
-    mkdir $JULIA_PKGDIR && \
-    chown -R $NB_USER:users $JULIA_PKGDIR
+RUN mkdir $JULIA_PKGDIR && \
+    chown $NB_USER:users $JULIA_PKGDIR
 
 USER $NB_USER
 
@@ -52,6 +41,20 @@ RUN conda config --system --add channels r && \
     'r-rcurl=1.95*' \
     'r-crayon=1.3*' \
     'r-randomforest=4.6*' && conda clean -tipsy
+
+# install julia binary
+RUN V2=0.6; V3=0.6.0; \
+    SHA256=3a27ea78b06f46701dc4274820d9853789db205bce56afdc7147f7bd6fa83e41; \
+    wget --quiet https://julialang-s3.julialang.org/bin/linux/x64/$V2/julia-$V3-linux-x86_64.tar.gz && \
+    echo "$SHA256 *julia-$V3-linux-x86_64.tar.gz" | sha256sum -c - && \
+    tar -xzf julia-0.6.0-linux-x86_64.tar.gz && \
+    rm julia-$V3-linux-x86_64.tar.gz && \
+    mv julia-*/* $JULIA_PKGDIR/ && \
+    chown -R $NB_USER:users $JULIA_PKGDIR && \
+    # Show Julia where conda libraries are \
+    echo "push!(Libdl.DL_LOAD_PATH, \"$CONDA_DIR/lib\")" >> $JULIA_PKGDIR/etc/julia/juliarc.jl
+
+ENV PATH $JULIA_PKGDIR/bin:$PATH
 
 # Add Julia packages
 # Install IJulia as jovyan and then move the kernelspec out

--- a/examples/docker-compose/bin/letsencrypt.sh
+++ b/examples/docker-compose/bin/letsencrypt.sh
@@ -43,6 +43,6 @@ docker run --rm -it \
 # directory so that the FQDN doesn't have to be known later.
 docker run --rm -it \
   -v $SECRETS_VOLUME:/etc/letsencrypt \
-  debian:jessie \
+  debian:stretch \
 		bash -c "ln -s /etc/letsencrypt/live/$FQDN/* /etc/letsencrypt/ && \
 			find /etc/letsencrypt -type d -exec chmod 755 {} +"

--- a/pyspark-notebook/Dockerfile
+++ b/pyspark-notebook/Dockerfile
@@ -10,11 +10,13 @@ USER root
 ENV APACHE_SPARK_VERSION 2.2.0
 ENV HADOOP_VERSION 2.7
 
-# Temporarily add jessie backports to get openjdk 8, but then remove that source
-RUN echo 'deb http://cdn-fastly.deb.debian.org/debian jessie-backports main' > /etc/apt/sources.list.d/jessie-backports.list && \
-    apt-get -y update && \
-    apt-get install --no-install-recommends -t jessie-backports -y openjdk-8-jre-headless ca-certificates-java && \
-    rm /etc/apt/sources.list.d/jessie-backports.list && \
+RUN apt-get -y update && \
+    apt-get install --no-install-recommends -y \
+      openjdk-8-jre-headless \
+      ca-certificates-java \
+      gnupg \
+      dirmngr \
+      && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 RUN cd /tmp && \
@@ -27,7 +29,7 @@ RUN cd /usr/local && ln -s spark-${APACHE_SPARK_VERSION}-bin-hadoop${HADOOP_VERS
 # Mesos dependencies
 RUN apt-key adv --keyserver keyserver.ubuntu.com --recv E56151BF && \
     DISTRO=debian && \
-    CODENAME=jessie && \
+    CODENAME=stretch && \
     echo "deb http://repos.mesosphere.io/${DISTRO} ${CODENAME} main" > /etc/apt/sources.list.d/mesosphere.list && \
     apt-get -y update && \
     apt-get --no-install-recommends -y --force-yes install mesos=1.2\* && \

--- a/pyspark-notebook/Dockerfile
+++ b/pyspark-notebook/Dockerfile
@@ -27,12 +27,18 @@ RUN cd /tmp && \
 RUN cd /usr/local && ln -s spark-${APACHE_SPARK_VERSION}-bin-hadoop${HADOOP_VERSION} spark
 
 # Mesos dependencies
-RUN apt-key adv --keyserver keyserver.ubuntu.com --recv E56151BF && \
+# FIXME: remove jessie-backports and update CODENAME=stretch
+# when there's a mesos .deb for stretch
+RUN echo 'deb http://cdn-fastly.deb.debian.org/debian jessie-backports main' > /etc/apt/sources.list.d/jessie-backports.list && \
+    apt-key adv --keyserver keyserver.ubuntu.com --recv E56151BF && \
     DISTRO=debian && \
-    CODENAME=stretch && \
+    CODENAME=jessie && \
     echo "deb http://repos.mesosphere.io/${DISTRO} ${CODENAME} main" > /etc/apt/sources.list.d/mesosphere.list && \
     apt-get -y update && \
-    apt-get --no-install-recommends -y --force-yes install mesos=1.2\* && \
+    apt-get --no-install-recommends -y --force-yes install \
+      systemd && \
+      mesos=1.2\* && \
+    rm /etc/apt/sources.list.d/jessie-backports.list && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
- Mostly minor s/jessie/stretch/ in a few places
- Switched Julia from ppa to official binaries (ppa doesn't work for stretch due to libssl upgrade, but official binaries are probably better anyway for non-ubuntu)
- removed no-longer-needed backports for jdk-8

<del>The only thing missing is mesos. There doesn't appear to be a .deb for stretch, yet, and I couldn't find any portable mesos binaries.</del>

mesos is installed for jessie, pulling libssl-1.0.0 from jessie-backports.

mesos on stretch: https://github.com/mesosphere/mesos-deb-packaging/issues/109