### PR TITLE
proposal: base image on ubuntu:16.04 (LTS)

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,9 +57,9 @@ Starting with [git commit SHA 9bd33dcc8688](https://github.com/jupyter/docker-st
 5. Avoid merging another PR to master until all outstanding builds complete.
     * There's no way at present to propagate the git SHA to build through the Docker Cloud build trigger API. Every build trigger works off of master HEAD.
 
-**When there's a security fix in the Debian base image, do the following in place of the last command:**
+**When there's a security fix in the Ubuntu base image, do the following in place of the last command:**
 
-Update the `debian:jessie` SHA in the most-base images (e.g., base-notebook). Submit it as a regular PR and go through the build process. Expect the build to take a while to complete: every image layer will rebuild.
+Update the `ubuntu:16.04` SHA in the most-base images (e.g., base-notebook). Submit it as a regular PR and go through the build process. Expect the build to take a while to complete: every image layer will rebuild.
 
 **When there's a new stack definition, do the following before merging the PR with the new stack:**
 

--- a/base-notebook/Dockerfile
+++ b/base-notebook/Dockerfile
@@ -1,9 +1,9 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 
-# Debian Jessie debootstrap from 2017-02-27
-# https://github.com/docker-library/official-images/commit/aa5973d0c918c70c035ec0746b8acaec3a4d7777
-FROM debian@sha256:52af198afd8c264f1035206ca66a5c48e602afb32dc912ebf9e9478134601ec4
+# Ubuntu 16.04 (xenial) from 2017-07-23
+# https://github.com/docker-library/official-images/commit/0ea9b38b835ffb656c497783321632ec7f87b60c
+FROM ubuntu@sha256:84c334414e2bfdcae99509a6add166bbb4fa4041dc3fa6af08046a66fed3005f
 
 MAINTAINER Jupyter Project <jupyter@googlegroups.com>
 
@@ -12,9 +12,7 @@ USER root
 # Install all OS dependencies for notebook server that starts but lacks all
 # features (e.g., download as all possible file formats)
 ENV DEBIAN_FRONTEND noninteractive
-RUN REPO=http://cdn-fastly.deb.debian.org \
- && echo "deb $REPO/debian jessie main\ndeb $REPO/debian-security jessie/updates main" > /etc/apt/sources.list \
- && apt-get update && apt-get -yq dist-upgrade \
+RUN apt-get update && apt-get -yq dist-upgrade \
  && apt-get install -yq --no-install-recommends \
     wget \
     bzip2 \

--- a/datascience-notebook/Dockerfile
+++ b/datascience-notebook/Dockerfile
@@ -18,12 +18,13 @@ RUN apt-get update && \
 # install Julia packages in /opt/julia instead of $HOME
 ENV JULIA_PKGDIR=/opt/julia
 
-RUN echo "deb http://ppa.launchpad.net/staticfloat/juliareleases/ubuntu trusty main" > /etc/apt/sources.list.d/julia.list && \
+RUN . /etc/os-release && \
+    echo "deb http://ppa.launchpad.net/staticfloat/juliareleases/ubuntu $VERSION_CODENAME main" > /etc/apt/sources.list.d/julia.list && \
     apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 3D3D3ACC && \
     apt-get update && \
     apt-get install -y --no-install-recommends \
-    julia \
-    libnettle4 && apt-get clean && \
+    julia && \
+    apt-get clean && \
     rm -rf /var/lib/apt/lists/* && \
     # Show Julia where conda libraries are \
     echo "push!(Libdl.DL_LOAD_PATH, \"$CONDA_DIR/lib\")" >> /usr/etc/julia/juliarc.jl && \

--- a/examples/docker-compose/bin/letsencrypt.sh
+++ b/examples/docker-compose/bin/letsencrypt.sh
@@ -43,6 +43,6 @@ docker run --rm -it \
 # directory so that the FQDN doesn't have to be known later.
 docker run --rm -it \
   -v $SECRETS_VOLUME:/etc/letsencrypt \
-  debian:jessie \
+  ubuntu:16.04 \
 		bash -c "ln -s /etc/letsencrypt/live/$FQDN/* /etc/letsencrypt/ && \
 			find /etc/letsencrypt -type d -exec chmod 755 {} +"

--- a/pyspark-notebook/Dockerfile
+++ b/pyspark-notebook/Dockerfile
@@ -10,11 +10,8 @@ USER root
 ENV APACHE_SPARK_VERSION 2.2.0
 ENV HADOOP_VERSION 2.7
 
-# Temporarily add jessie backports to get openjdk 8, but then remove that source
-RUN echo 'deb http://cdn-fastly.deb.debian.org/debian jessie-backports main' > /etc/apt/sources.list.d/jessie-backports.list && \
-    apt-get -y update && \
-    apt-get install --no-install-recommends -t jessie-backports -y openjdk-8-jre-headless ca-certificates-java && \
-    rm /etc/apt/sources.list.d/jessie-backports.list && \
+RUN apt-get -y update && \
+    apt-get install --no-install-recommends -y openjdk-8-jre-headless ca-certificates-java && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 RUN cd /tmp && \
@@ -25,9 +22,10 @@ RUN cd /tmp && \
 RUN cd /usr/local && ln -s spark-${APACHE_SPARK_VERSION}-bin-hadoop${HADOOP_VERSION} spark
 
 # Mesos dependencies
-RUN apt-key adv --keyserver keyserver.ubuntu.com --recv E56151BF && \
-    DISTRO=debian && \
-    CODENAME=jessie && \
+RUN . /etc/os-release && \
+    apt-key adv --keyserver keyserver.ubuntu.com --recv E56151BF && \
+    DISTRO=$ID && \
+    CODENAME=$VERSION_CODENAME && \
     echo "deb http://repos.mesosphere.io/${DISTRO} ${CODENAME} main" > /etc/apt/sources.list.d/mesosphere.list && \
     apt-get -y update && \
     apt-get --no-install-recommends -y --force-yes install mesos=1.2\* && \


### PR DESCRIPTION
alternative to #427

Especially since we use at least one PPA, we might have an easier time tracking Ubuntu.

I haven't been able to find a really good way to choose between debian and ubuntu. Docker best practices reference debian as a good default starting point, but package support seems better on ubuntu.