### PR TITLE
make jupyterhub env->cli args optional

### DIFF
--- a/base-notebook/start-singleuser.sh
+++ b/base-notebook/start-singleuser.sh
@@ -4,19 +4,35 @@
 
 set -e
 
-notebook_arg=""
-if [ -n "${NOTEBOOK_DIR:+x}" ]
-then
-    notebook_arg="--notebook-dir=${NOTEBOOK_DIR}"
+# set default ip to 0.0.0.0
+if [[ "$NOTEBOOK_ARGS $@" != *"--ip="* ]]; then
+  NOTEBOOK_ARGS="--ip=0.0.0.0 $NOTEBOOK_ARGS"
 fi
 
-. /usr/local/bin/start.sh jupyterhub-singleuser \
-  --port=${JPY_PORT:-8888} \
-  --ip=0.0.0.0 \
-  --user=$JPY_USER \
-  --cookie-name=$JPY_COOKIE_NAME \
-  --base-url=$JPY_BASE_URL \
-  --hub-prefix=$JPY_HUB_PREFIX \
-  --hub-api-url=$JPY_HUB_API_URL \
-  ${notebook_arg} \
-  $@
+# handle some deprecated environment variables
+# from DockerSpawner < 0.8.
+# These won't be passed from DockerSpawner 0.9,
+# so avoid specifying --arg=empty-string
+if [ ! -z "$NOTEBOOK_DIR" ]; then
+  NOTEBOOK_ARGS="--notebook-dir=$NOTEBOOK_DIR $NOTEBOOK_ARGS"
+fi
+if [ ! -z "$JPY_PORT" ]; then
+  NOTEBOOK_ARGS="--port=$JPY_PORT $NOTEBOOK_ARGS"
+fi
+if [ ! -z "$JPY_USER" ]; then
+  NOTEBOOK_ARGS="--user=$JPY_USER $NOTEBOOK_ARGS"
+fi
+if [ ! -z "$JPY_COOKIE_NAME" ]; then
+  NOTEBOOK_ARGS="--cookie-name=$JPY_COOKIE_NAME $NOTEBOOK_ARGS"
+fi
+if [ ! -z "$JPY_BASE_URL" ]; then
+  NOTEBOOK_ARGS="--base-url=$JPY_BASE_URL $NOTEBOOK_ARGS"
+fi
+if [ ! -z "$JPY_HUB_PREFIX" ]; then
+  NOTEBOOK_ARGS="--hub-prefix=$JPY_HUB_PREFIX $NOTEBOOK_ARGS"
+fi
+if [ ! -z "$JPY_HUB_API_URL" ]; then
+  NOTEBOOK_ARGS="--hub-api-url=$JPY_HUB_API_URL $NOTEBOOK_ARGS"
+fi
+
+. /usr/local/bin/start.sh jupyterhub-singleuser $NOTEBOOK_ARGS $@

--- a/base-notebook/start-singleuser.sh
+++ b/base-notebook/start-singleuser.sh
@@ -14,7 +14,7 @@ fi
 # These won't be passed from DockerSpawner 0.9,
 # so avoid specifying --arg=empty-string
 if [ ! -z "$NOTEBOOK_DIR" ]; then
-  NOTEBOOK_ARGS="--notebook-dir=$NOTEBOOK_DIR $NOTEBOOK_ARGS"
+  NOTEBOOK_ARGS="--notebook-dir='$NOTEBOOK_DIR' $NOTEBOOK_ARGS"
 fi
 if [ ! -z "$JPY_PORT" ]; then
   NOTEBOOK_ARGS="--port=$JPY_PORT $NOTEBOOK_ARGS"


### PR DESCRIPTION
DockerSpawner will stop passing these args, so make them optional before we start passing `--arg=<empty>`