### PR TITLE
use groups for managing write-access to files

### DIFF
--- a/all-spark-notebook/Dockerfile
+++ b/all-spark-notebook/Dockerfile
@@ -25,13 +25,19 @@ RUN conda install --quiet --yes \
     'r-irkernel=0.7*' \
     'r-ggplot2=2.2*' \
     'r-sparklyr=0.5*' \
-    'r-rcurl=1.95*' && conda clean -tipsy
+    'r-rcurl=1.95*' && \
+    conda clean -tipsy && \
+    fix-permissions $CONDA_DIR
 
 # Apache Toree kernel
-RUN pip --no-cache-dir install https://dist.apache.org/repos/dist/dev/incubator/toree/0.2.0/snapshots/dev1/toree-pip/toree-0.2.0.dev1.tar.gz
-RUN jupyter toree install --sys-prefix
+RUN pip install --no-cache-dir \
+    https://dist.apache.org/repos/dist/dev/incubator/toree/0.2.0/snapshots/dev1/toree-pip/toree-0.2.0.dev1.tar.gz \
+    && \
+    jupyter toree install --sys-prefix && \
+    fix-permissions $CONDA_DIR
 
 # Spylon-kernel
 RUN conda install --quiet --yes 'spylon-kernel=0.4*' && \
-    conda clean -tipsy
-RUN python -m spylon_kernel install --sys-prefix
+    conda clean -tipsy && \
+    python -m spylon_kernel install --sys-prefix && \
+    fix-permissions $CONDA_DIR

--- a/all-spark-notebook/README.md
+++ b/all-spark-notebook/README.md
@@ -285,20 +285,6 @@ conda install some-package
 
 ## Alternative Commands
 
-### start-singleuser.sh
-
-[JupyterHub](https://jupyterhub.readthedocs.io) requires a single-user instance of the Jupyter Notebook server per user.   To use this stack with JupyterHub and [DockerSpawner](https://github.com/jupyter/dockerspawner), you must specify the container image name and override the default container run command in your `jupyterhub_config.py`:
-
-```python
-# Spawn user containers from this image
-c.DockerSpawner.container_image = 'jupyter/all-spark-notebook'
-
-# Have the Spawner override the Docker run command
-c.DockerSpawner.extra_create_kwargs.update({
-    'command': '/usr/local/bin/start-singleuser.sh'
-})
-```
-
 ### start.sh
 
 The `start.sh` script supports the same features as the default `start-notebook.sh` script (e.g., `GRANT_SUDO`), but allows you to specify an arbitrary command to execute. For example, to run the text-based `ipython` console in a container, do the following:

--- a/base-notebook/Dockerfile
+++ b/base-notebook/Dockerfile
@@ -33,25 +33,34 @@ RUN wget --quiet https://github.com/krallin/tini/releases/download/v0.10.0/tini 
     chmod +x /usr/local/bin/tini
 
 # Configure environment
-ENV CONDA_DIR /opt/conda
-ENV PATH $CONDA_DIR/bin:$PATH
-ENV SHELL /bin/bash
-ENV NB_USER jovyan
-ENV NB_UID 1000
-ENV HOME /home/$NB_USER
-ENV LC_ALL en_US.UTF-8
-ENV LANG en_US.UTF-8
-ENV LANGUAGE en_US.UTF-8
+ENV CONDA_DIR=/opt/conda \
+    SHELL=/bin/bash \
+    NB_USER=jovyan \
+    NB_UID=1000 \
+    NB_OWNER_GROUP=user-writable \
+    NB_OWNER_GID=10000 \
+    LC_ALL=en_US.UTF-8 \
+    LANG=en_US.UTF-8 \
+    LANGUAGE=en_US.UTF-8
+ENV PATH=$CONDA_DIR/bin:$PATH \
+    HOME=/home/$NB_USER
 
+ADD fix-permissions /usr/local/bin/fix-permissions
 # Create jovyan user with UID=1000 and in the 'users' group
+# and the user-writable group, which owns all of the
+# files we want users to write (/home/jovyan, packages)
 RUN useradd -m -s /bin/bash -N -u $NB_UID $NB_USER && \
     mkdir -p $CONDA_DIR && \
-    chown $NB_USER $CONDA_DIR
+    chown $NB_USER $CONDA_DIR && \
+    groupadd -g $NB_OWNER_GID $NB_OWNER_GROUP && \
+    usermod -G $NB_OWNER_GROUP $NB_USER && \
+    fix-permissions /home/$NB_USER
 
 USER $NB_USER
 
 # Setup work directory for backward-compatibility
-RUN mkdir /home/$NB_USER/work
+RUN mkdir /home/$NB_USER/work && \
+    fix-permissions /home/$NB_USER
 
 # Install conda as jovyan and check the md5 sum provided on the download site
 ENV MINICONDA_VERSION 4.3.21
@@ -65,14 +74,16 @@ RUN cd /tmp && \
     $CONDA_DIR/bin/conda config --system --set auto_update_conda false && \
     $CONDA_DIR/bin/conda config --system --set show_channel_urls true && \
     $CONDA_DIR/bin/conda update --all && \
-    conda clean -tipsy
+    conda clean -tipsy && \
+    fix-permissions $CONDA_DIR
 
 # Install Jupyter Notebook and Hub
 RUN conda install --quiet --yes \
     'notebook=5.0.*' \
     'jupyterhub=0.7.*' \
     'jupyterlab=0.27.*' \
-    && conda clean -tipsy
+    && conda clean -tipsy && \
+    fix-permissions $CONDA_DIR
 
 USER root
 
@@ -88,7 +99,7 @@ COPY start.sh /usr/local/bin/
 COPY start-notebook.sh /usr/local/bin/
 COPY start-singleuser.sh /usr/local/bin/
 COPY jupyter_notebook_config.py /etc/jupyter/
-RUN chown -R $NB_USER:users /etc/jupyter/
+RUN fix-permissions /etc/jupyter/
 
 # Switch back to jovyan to avoid accidental container runs as root
 USER $NB_USER

--- a/base-notebook/Dockerfile
+++ b/base-notebook/Dockerfile
@@ -46,8 +46,7 @@ ENV PATH=$CONDA_DIR/bin:$PATH \
 
 ADD fix-permissions /usr/local/bin/fix-permissions
 # Create jovyan user with UID=1000 and in the 'users' group
-# and the user-writable group, which owns all of the
-# files we want users to write (/home/jovyan, packages)
+# and make sure these dirs are writable by the `users` group.
 RUN useradd -m -s /bin/bash -N -u $NB_UID $NB_USER && \
     mkdir -p $CONDA_DIR && \
     chown $NB_USER:$NB_GID $CONDA_DIR && \

--- a/base-notebook/Dockerfile
+++ b/base-notebook/Dockerfile
@@ -37,8 +37,7 @@ ENV CONDA_DIR=/opt/conda \
     SHELL=/bin/bash \
     NB_USER=jovyan \
     NB_UID=1000 \
-    NB_OWNER_GROUP=user-writable \
-    NB_OWNER_GID=10000 \
+    NB_GID=100 \
     LC_ALL=en_US.UTF-8 \
     LANG=en_US.UTF-8 \
     LANGUAGE=en_US.UTF-8
@@ -51,10 +50,9 @@ ADD fix-permissions /usr/local/bin/fix-permissions
 # files we want users to write (/home/jovyan, packages)
 RUN useradd -m -s /bin/bash -N -u $NB_UID $NB_USER && \
     mkdir -p $CONDA_DIR && \
-    chown $NB_USER $CONDA_DIR && \
-    groupadd -g $NB_OWNER_GID $NB_OWNER_GROUP && \
-    usermod -G $NB_OWNER_GROUP $NB_USER && \
-    fix-permissions /home/$NB_USER
+    chown $NB_USER:$NB_GID $CONDA_DIR && \
+    fix-permissions $HOME && \
+    fix-permissions $CONDA_DIR
 
 USER $NB_USER
 
@@ -65,7 +63,6 @@ RUN mkdir /home/$NB_USER/work && \
 # Install conda as jovyan and check the md5 sum provided on the download site
 ENV MINICONDA_VERSION 4.3.21
 RUN cd /tmp && \
-    mkdir -p $CONDA_DIR && \
     wget --quiet https://repo.continuum.io/miniconda/Miniconda3-${MINICONDA_VERSION}-Linux-x86_64.sh && \
     echo "c1c15d3baba15bf50293ae963abef853 *Miniconda3-${MINICONDA_VERSION}-Linux-x86_64.sh" | md5sum -c - && \
     /bin/bash Miniconda3-${MINICONDA_VERSION}-Linux-x86_64.sh -f -b -p $CONDA_DIR && \
@@ -73,7 +70,7 @@ RUN cd /tmp && \
     $CONDA_DIR/bin/conda config --system --prepend channels conda-forge && \
     $CONDA_DIR/bin/conda config --system --set auto_update_conda false && \
     $CONDA_DIR/bin/conda config --system --set show_channel_urls true && \
-    $CONDA_DIR/bin/conda update --all && \
+    $CONDA_DIR/bin/conda update --all --quiet --yes && \
     conda clean -tipsy && \
     fix-permissions $CONDA_DIR
 

--- a/base-notebook/README.md
+++ b/base-notebook/README.md
@@ -58,7 +58,7 @@ You may customize the execution of the Docker container and the command it is ru
 * `-e NB_GID=100` - Specify the gid of the `jovyan` user. Useful to mount host volumes with specific file ownership. For this option to take effect, you must run the container with `--user root`. (The `start-notebook.sh` script will `su jovyan` after adjusting the group id.)
 * `-e GRANT_SUDO=yes` - Gives the `jovyan` user passwordless `sudo` capability. Useful for installing OS packages. For this option to take effect, you must run the container with `--user root`. (The `start-notebook.sh` script will `su jovyan` after adding `jovyan` to sudoers.) **You should only enable `sudo` if you trust the user or if the container is running on an isolated host.**
 * `-v /some/host/folder/for/work:/home/jovyan/work` - Mounts a host machine directory as folder in the container. Useful when you want to preserve notebooks and other work even after the container is destroyed. **You must grant the within-container notebook user or group (`NB_UID` or `NB_GID`) write access to the host directory (e.g., `sudo chown 1000 /some/host/folder/for/work`).**
-* `--group-add user-writable` - use this argument if you are also specifying
+* `--group-add users` - use this argument if you are also specifying
   a specific user id to launch the container (`-u 5000`), rather than launching the container as root and relying on NB_UID and NB_GID to set the user and group.
 
 

--- a/base-notebook/README.md
+++ b/base-notebook/README.md
@@ -58,6 +58,9 @@ You may customize the execution of the Docker container and the command it is ru
 * `-e NB_GID=100` - Specify the gid of the `jovyan` user. Useful to mount host volumes with specific file ownership. For this option to take effect, you must run the container with `--user root`. (The `start-notebook.sh` script will `su jovyan` after adjusting the group id.)
 * `-e GRANT_SUDO=yes` - Gives the `jovyan` user passwordless `sudo` capability. Useful for installing OS packages. For this option to take effect, you must run the container with `--user root`. (The `start-notebook.sh` script will `su jovyan` after adding `jovyan` to sudoers.) **You should only enable `sudo` if you trust the user or if the container is running on an isolated host.**
 * `-v /some/host/folder/for/work:/home/jovyan/work` - Mounts a host machine directory as folder in the container. Useful when you want to preserve notebooks and other work even after the container is destroyed. **You must grant the within-container notebook user or group (`NB_UID` or `NB_GID`) write access to the host directory (e.g., `sudo chown 1000 /some/host/folder/for/work`).**
+* `--group-add user-writable` - use this argument if you are also specifying
+  a specific user id to launch the container (`-u 5000`), rather than launching the container as root and relying on NB_UID and NB_GID to set the user and group.
+
 
 ## SSL Certificates
 
@@ -111,11 +114,6 @@ conda install some-package
 ```python
 # Spawn user containers from this image
 c.DockerSpawner.container_image = 'jupyter/base-notebook'
-
-# Have the Spawner override the Docker run command
-c.DockerSpawner.extra_create_kwargs.update({
-	'command': '/usr/local/bin/start-singleuser.sh'
-})
 ```
 
 ### start.sh
@@ -137,3 +135,4 @@ This script is particularly useful when you derive a new Dockerfile from this im
 ### Others
 
 You can bypass the provided scripts and specify your an arbitrary start command. If you do, keep in mind that certain features documented above will not function (e.g., `GRANT_SUDO`).
+

--- a/base-notebook/README.md
+++ b/base-notebook/README.md
@@ -107,15 +107,6 @@ conda install some-package
 
 ## Alternative Commands
 
-### start-singleuser.sh
-
-[JupyterHub](https://jupyterhub.readthedocs.io) requires a single-user instance of the Jupyter Notebook server per user.   To use this stack with JupyterHub and [DockerSpawner](https://github.com/jupyter/dockerspawner), you must specify the container image name and override the default container run command in your `jupyterhub_config.py`:
-
-```python
-# Spawn user containers from this image
-c.DockerSpawner.container_image = 'jupyter/base-notebook'
-```
-
 ### start.sh
 
 The `start.sh` script supports the same features as the default `start-notebook.sh` script (e.g., `GRANT_SUDO`), but allows you to specify an arbitrary command to execute. For example, to run the text-based `ipython` console in a container, do the following:

--- a/base-notebook/fix-permissions
+++ b/base-notebook/fix-permissions
@@ -5,7 +5,7 @@
 # It will make everything in the directory owned by the group $NB_GID
 # and writable by that group.
 # Deployments that want to set a specific user id can preserve permissions
-# by adding the `--group-add user-writable` line to `docker run`.
+# by adding the `--group-add users` line to `docker run`.
 
 # uses find to avoid touching files that already have the right permissions,
 # which would cause massive image explosion

--- a/base-notebook/fix-permissions
+++ b/base-notebook/fix-permissions
@@ -2,7 +2,7 @@
 # set permissions on a directory
 # after any installation, if a directory needs to be (human) user-writable,
 # run this script on it.
-# It will make everything in the directory owned by the group $NB_OWNER_GROUP
+# It will make everything in the directory owned by the group $NB_GID
 # and writable by that group.
 # Deployments that want to set a specific user id can preserve permissions
 # by adding the `--group-add user-writable` line to `docker run`.
@@ -11,17 +11,25 @@
 # which would cause massive image explosion
 
 # right permissions are:
-# group=$NB_OWNER_GROUP
+# group=$NB_GID
 # AND permissions include group rwX (directory-execute)
+# AND directories have setuid,setgid bits set
 
 set -e
 
 for d in $@; do
   find "$d" \
     ! \( \
-      -group $NB_OWNER_GROUP \
+      -group $NB_GID \
       -a -perm -g+rwX  \
     \) \
-    -exec chgrp $NB_OWNER_GROUP {} \; \
+    -exec chgrp $NB_GID {} \; \
     -exec chmod g+rwX {} \;
+  # setuid,setgid *on directories only*
+  find "$d" \
+    \( \
+        -type d \
+        -a ! -perm -6000  \
+    \) \
+    -exec chmod +6000 {} \;
 done

--- a/base-notebook/fix-permissions
+++ b/base-notebook/fix-permissions
@@ -1,0 +1,27 @@
+#!/bin/bash
+# set permissions on a directory
+# after any installation, if a directory needs to be (human) user-writable,
+# run this script on it.
+# It will make everything in the directory owned by the group $NB_OWNER_GROUP
+# and writable by that group.
+# Deployments that want to set a specific user id can preserve permissions
+# by adding the `--group-add user-writable` line to `docker run`.
+
+# uses find to avoid touching files that already have the right permissions,
+# which would cause massive image explosion
+
+# right permissions are:
+# group=$NB_OWNER_GROUP
+# AND permissions include group rwX (directory-execute)
+
+set -e
+
+for d in $@; do
+  find "$d" \
+    ! \( \
+      -group $NB_OWNER_GROUP \
+      -a -perm -g+rwX  \
+    \) \
+    -exec chgrp $NB_OWNER_GROUP {} \; \
+    -exec chmod g+rwX {} \;
+done

--- a/base-notebook/start.sh
+++ b/base-notebook/start.sh
@@ -13,14 +13,6 @@ if [ $(id -u) == 0 ] ; then
     if [ "$NB_UID" != $(id -u $NB_USER) ] ; then
         echo "Set user UID to: $NB_UID"
         usermod -u $NB_UID $NB_USER
-        # Careful: $HOME might resolve to /root depending on how the
-        # container is started. Use the $NB_USER home path explicitly.
-        for d in "$CONDA_DIR" "$JULIA_PKGDIR" "/home/$NB_USER"; do
-            if [[ ! -z "$d" && -d "$d" ]]; then
-                echo "Set ownership to uid $NB_UID: $d"
-                chown -R $NB_UID "$d"
-            fi
-        done
     fi
 
     # Change GID of NB_USER to NB_GID if NB_GID is passed as a parameter

--- a/datascience-notebook/Dockerfile
+++ b/datascience-notebook/Dockerfile
@@ -30,7 +30,8 @@ RUN . /etc/os-release && \
     echo "push!(Libdl.DL_LOAD_PATH, \"$CONDA_DIR/lib\")" >> /usr/etc/julia/juliarc.jl && \
     # Create JULIA_PKGDIR \
     mkdir $JULIA_PKGDIR && \
-    chown -R $NB_USER:users $JULIA_PKGDIR
+    chown $NB_USER $JULIA_PKGDIR && \
+    fix-permissions $JULIA_PKGDIR
 
 USER $NB_USER
 
@@ -52,7 +53,9 @@ RUN conda config --system --add channels r && \
     'r-caret=6.0*' \
     'r-rcurl=1.95*' \
     'r-crayon=1.3*' \
-    'r-randomforest=4.6*' && conda clean -tipsy
+    'r-randomforest=4.6*' && \
+    conda clean -tipsy && \
+    fix-permissions $CONDA_DIR
 
 # Add Julia packages
 # Install IJulia as jovyan and then move the kernelspec out
@@ -72,5 +75,6 @@ RUN julia -e 'Pkg.init()' && \
     # move kernelspec out of home \
     mv $HOME/.local/share/jupyter/kernels/julia* $CONDA_DIR/share/jupyter/kernels/ && \
     chmod -R go+rx $CONDA_DIR/share/jupyter && \
-    rm -rf $HOME/.local
+    rm -rf $HOME/.local && \
+    fix-permissions $JULIA_PKGDIR $CONDA_DIR/share/jupyter
 

--- a/datascience-notebook/README.md
+++ b/datascience-notebook/README.md
@@ -106,19 +106,6 @@ conda install some-package
 
 ## Alternative Commands
 
-### start-singleuser.sh
-
-[JupyterHub](https://jupyterhub.readthedocs.io) requires a single-user instance of the Jupyter Notebook server per user.   To use this stack with JupyterHub and [DockerSpawner](https://github.com/jupyter/dockerspawner), you must specify the container image name and override the default container run command in your `jupyterhub_config.py`:
-
-```python
-# Spawn user containers from this image
-c.DockerSpawner.container_image = 'jupyter/datascience-notebook'
-
-# Have the Spawner override the Docker run command
-c.DockerSpawner.extra_create_kwargs.update({
-	'command': '/usr/local/bin/start-singleuser.sh'
-})
-```
 
 ### start.sh
 

--- a/minimal-notebook/README.md
+++ b/minimal-notebook/README.md
@@ -105,19 +105,6 @@ conda install some-package
 
 ## Alternative Commands
 
-### start-singleuser.sh
-
-[JupyterHub](https://jupyterhub.readthedocs.io) requires a single-user instance of the Jupyter Notebook server per user.   To use this stack with JupyterHub and [DockerSpawner](https://github.com/jupyter/dockerspawner), you must specify the container image name and override the default container run command in your `jupyterhub_config.py`:
-
-```python
-# Spawn user containers from this image
-c.DockerSpawner.container_image = 'jupyter/minimal-notebook'
-
-# Have the Spawner override the Docker run command
-c.DockerSpawner.extra_create_kwargs.update({
-	'command': '/usr/local/bin/start-singleuser.sh'
-})
-```
 
 ### start.sh
 

--- a/pyspark-notebook/README.md
+++ b/pyspark-notebook/README.md
@@ -177,19 +177,6 @@ conda install some-package
 
 ## Alternative Commands
 
-### start-singleuser.sh
-
-[JupyterHub](https://jupyterhub.readthedocs.io) requires a single-user instance of the Jupyter Notebook server per user.   To use this stack with JupyterHub and [DockerSpawner](https://github.com/jupyter/dockerspawner), you must specify the container image name and override the default container run command in your `jupyterhub_config.py`:
-
-```python
-# Spawn user containers from this image
-c.DockerSpawner.container_image = 'jupyter/pyspark-notebook'
-
-# Have the Spawner override the Docker run command
-c.DockerSpawner.extra_create_kwargs.update({
-    'command': '/usr/local/bin/start-singleuser.sh'
-})
-```
 
 ### start.sh
 

--- a/r-notebook/Dockerfile
+++ b/r-notebook/Dockerfile
@@ -32,4 +32,6 @@ RUN conda install --quiet --yes \
     'r-caret=6.0*' \
     'r-rcurl=1.95*' \
     'r-crayon=1.3*' \
-    'r-randomforest=4.6*' && conda clean -tipsy
+    'r-randomforest=4.6*' && \
+    conda clean -tipsy && \
+    fix-permissions $CONDA_DIR

--- a/r-notebook/README.md
+++ b/r-notebook/README.md
@@ -90,19 +90,6 @@ For additional information about using SSL, see the following:
 
 ## Alternative Commands
 
-### start-singleuser.sh
-
-[JupyterHub](https://jupyterhub.readthedocs.io) requires a single-user instance of the Jupyter Notebook server per user.   To use this stack with JupyterHub and [DockerSpawner](https://github.com/jupyter/dockerspawner), you must specify the container image name and override the default container run command in your `jupyterhub_config.py`:
-
-```python
-# Spawn user containers from this image
-c.DockerSpawner.container_image = 'jupyter/r-notebook'
-
-# Have the Spawner override the Docker run command
-c.DockerSpawner.extra_create_kwargs.update({
-	'command': '/usr/local/bin/start-singleuser.sh'
-})
-```
 
 ### start.sh
 

--- a/scipy-notebook/Dockerfile
+++ b/scipy-notebook/Dockerfile
@@ -42,13 +42,14 @@ RUN conda install --quiet --yes \
     'beautifulsoup4=4.5.*' \
     'xlrd'  && \
     conda remove --quiet --yes --force qt pyqt && \
-    conda clean -tipsy
-
-# Activate ipywidgets extension in the environment that runs the notebook server
-RUN jupyter nbextension enable --py widgetsnbextension --sys-prefix
+    conda clean -tipsy && \
+    # Activate ipywidgets extension in the environment that runs the notebook server
+    jupyter nbextension enable --py widgetsnbextension --sys-prefix && \
+    fix-permissions $CONDA_DIR
 
 # Import matplotlib the first time to build the font cache.
 ENV XDG_CACHE_HOME /home/$NB_USER/.cache/
-RUN MPLBACKEND=Agg python -c "import matplotlib.pyplot"
+RUN MPLBACKEND=Agg python -c "import matplotlib.pyplot" && \
+    fix-permissions /home/$NB_USER
 
 USER $NB_USER

--- a/scipy-notebook/README.md
+++ b/scipy-notebook/README.md
@@ -103,19 +103,6 @@ conda install some-package
 
 ## Alternative Commands
 
-### start-singleuser.sh
-
-[JupyterHub](https://jupyterhub.readthedocs.io) requires a single-user instance of the Jupyter Notebook server per user.   To use this stack with JupyterHub and [DockerSpawner](https://github.com/jupyter/dockerspawner), you must specify the container image name and override the default container run command in your `jupyterhub_config.py`:
-
-```python
-# Spawn user containers from this image
-c.DockerSpawner.container_image = 'jupyter/scipy-notebook'
-
-# Have the Spawner override the Docker run command
-c.DockerSpawner.extra_create_kwargs.update({
-	'command': '/usr/local/bin/start-singleuser.sh'
-})
-```
 
 ### start.sh
 

--- a/tensorflow-notebook/Dockerfile
+++ b/tensorflow-notebook/Dockerfile
@@ -4,5 +4,7 @@ FROM jupyter/scipy-notebook
 
 MAINTAINER Jupyter Project <jupyter@googlegroups.com>
 
-# Install Python 3 Tensorflow
-RUN conda install --quiet --yes 'tensorflow=1.0*'
+# Install Tensorflow
+RUN conda install --quiet --yes 'tensorflow=1.0*' && \
+    conda clean -tipsy && \
+    fix-permissions $CONDA_DIR

--- a/tensorflow-notebook/README.md
+++ b/tensorflow-notebook/README.md
@@ -112,20 +112,6 @@ conda install some-package
 
 ## Alternative Commands
 
-### start-singleuser.sh
-
-[JupyterHub](https://jupyterhub.readthedocs.io) requires a single-user instance of the Jupyter Notebook server per user.   To use this stack with JupyterHub and [DockerSpawner](https://github.com/jupyter/dockerspawner), you must specify the container image name and override the default container run command in your `jupyterhub_config.py`:
-
-```python
-# Spawn user containers from this image
-c.DockerSpawner.container_image = 'jupyter/tensorflow-notebook'
-
-# Have the Spawner override the Docker run command
-c.DockerSpawner.extra_create_kwargs.update({
-	'command': '/usr/local/bin/start-singleuser.sh'
-})
-```
-
 ### start.sh
 
 The `start.sh` script supports the same features as the default `start-notebook.sh` script (e.g., `GRANT_SUDO`), but allows you to specify an arbitrary command to execute. For example, to run the text-based `ipython` console in a container, do the following:


### PR DESCRIPTION
- any files the user should be able to write should have group `user-permissions` with `g+rwX`
- remove `chown` from start.sh because it is no longer needed
- add `fix-permissions` script for setting the user-writable permissions on a path
- users group is GID 100
- containers can set group with `--group-add users` if they want to run with a different uid/gid
  (without -u root -e NB_UID -e NB_GID, which make this unnecessary), for instance:
  

       docker run -u 501:501 --group-add users -it jupyter/base-notebook

Questions:

- is there a reason we need a dedicated high-gid group for this? Or can we leave it as the default `users` group 100?

closes #434
closes #395

I believe this resolves issues brought up in #188 without needing to consider the possible implications of running with gid=0