### PR TITLE
Add PHP Stack

### DIFF
--- a/php-notebook/.dockerignore
+++ b/php-notebook/.dockerignore
@@ -1,0 +1,2 @@
+# Documentation
+README.md

--- a/php-notebook/Dockerfile
+++ b/php-notebook/Dockerfile
@@ -6,12 +6,17 @@ MAINTAINER Jupyter Project <jupyter@googlegroups.com>
 
 USER root
 
-# PHP 7.0
+RUN echo "deb http://download.opensuse.org/repositories/network:/messaging:/zeromq:/release-stable/Debian_9.0/ ./" >> /etc/apt/sources.list && \
+    wget https://download.opensuse.org/repositories/network:/messaging:/zeromq:/release-stable/Debian_9.0/Release.key -O- | sudo apt-key add
+
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-    php7.0 php7.0-cli php7.0-common php7.0-mbstring php7.0-gd php7.0-intl php7.0-xml php7.0-mysql php7.0-mcrypt php7.0-zip \
-    php-pear php7.0-dev \
-    pkg-config
+        php7.0 php7.0-cli php7.0-common php7.0-mbstring php7.0-gd php7.0-intl php7.0-xml php7.0-mysql php7.0-mcrypt php7.0-zip php-pear php7.0-dev pkg-config \
+        libzmq3-dev \
+    && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
 
 # Composer
 RUN php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" &&\
@@ -19,13 +24,6 @@ RUN php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" &&
     php composer-setup.php &&\
     php -r "unlink('composer-setup.php');" &&\
     mv composer.phar /usr/local/bin/composer
-
-# ZMQ
-RUN echo "deb http://download.opensuse.org/repositories/network:/messaging:/zeromq:/release-stable/Debian_9.0/ ./" >> /etc/apt/sources.list && \
-    wget https://download.opensuse.org/repositories/network:/messaging:/zeromq:/release-stable/Debian_9.0/Release.key -O- | sudo apt-key add && \
-    apt-get update && \
-    apt-get install -y --no-install-recommends \
-    libzmq3-dev
 
 # ZMQ PHP binding
 RUN sudo pecl install zmq-beta -v
@@ -37,7 +35,3 @@ RUN cd /tmp && \
     wget https://litipk.github.io/Jupyter-PHP-Installer/dist/jupyter-php-installer.phar && \
     chmod +x jupyter-php-installer.phar && \
     ./jupyter-php-installer.phar install -vv
-
-# clean
-RUN apt-get clean && \
-    rm -rf /var/lib/apt/lists/*

--- a/php-notebook/Dockerfile
+++ b/php-notebook/Dockerfile
@@ -1,0 +1,43 @@
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+FROM jupyter/minimal-notebook
+
+MAINTAINER Jupyter Project <jupyter@googlegroups.com>
+
+USER root
+
+# PHP 7.0
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    php7.0 php7.0-cli php7.0-common php7.0-mbstring php7.0-gd php7.0-intl php7.0-xml php7.0-mysql php7.0-mcrypt php7.0-zip \
+    php-pear php7.0-dev \
+    pkg-config
+
+# Composer
+RUN php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" &&\
+    php -r "if (hash_file('SHA384', 'composer-setup.php') === '669656bab3166a7aff8a7506b8cb2d1c292f042046c5a994c43155c0be6190fa0355160742ab2e1c88d40d5be660b410') { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;" &&\
+    php composer-setup.php &&\
+    php -r "unlink('composer-setup.php');" &&\
+    mv composer.phar /usr/local/bin/composer
+
+# ZMQ
+RUN echo "deb http://download.opensuse.org/repositories/network:/messaging:/zeromq:/release-stable/Debian_9.0/ ./" >> /etc/apt/sources.list && \
+    wget https://download.opensuse.org/repositories/network:/messaging:/zeromq:/release-stable/Debian_9.0/Release.key -O- | sudo apt-key add && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends \
+    libzmq3-dev
+
+# ZMQ PHP binding
+RUN sudo pecl install zmq-beta -v
+RUN echo "extension=zmq.so" >> /etc/php/7.0/mods-available/zmq.ini  && \
+    phpenmod zmq
+
+# Jupyter PHP kernel
+RUN cd /tmp && \
+    wget https://litipk.github.io/Jupyter-PHP-Installer/dist/jupyter-php-installer.phar && \
+    chmod +x jupyter-php-installer.phar && \
+    ./jupyter-php-installer.phar install -vv
+
+# clean
+RUN apt-get clean && \
+    rm -rf /var/lib/apt/lists/*

--- a/php-notebook/README.md
+++ b/php-notebook/README.md
@@ -1,0 +1,135 @@
+<!--- (![docker pulls](https://img.shields.io/docker/pulls/jupyter/base-notebook.svg) ![docker stars](https://img.shields.io/docker/stars/jupyter/base-notebook.svg) [![](https://images.microbadger.com/badges/image/jupyter/base-notebook.svg)](https://microbadger.com/images/jupyter/base-notebook "jupyter/base-notebook image metadata") -->
+
+# Jupyter Notebook PHP Stack
+
+PHP stack based on official [Base Jupyter Notebook Stack](https://github.com/jupyter/docker-stacks/tree/master/base-notebook)
+
+## What it Gives You
+
+* Minimally-functional Jupyter Notebook 5.0.x (e.g., no pandoc for document conversion)
+* PHP 7.0
+* (Jupyter-PHP)[https://github.com/Litipk/Jupyter-PHP] kernel
+* Miniconda Python 3.x
+* No preinstalled scientific computing packages
+* Unprivileged user `jovyan` (uid=1000, configurable, see options) in group `users` (gid=100) with ownership over `/home/jovyan` and `/opt/conda`
+* [tini](https://github.com/krallin/tini) as the container entrypoint and [start-notebook.sh](./start-notebook.sh) as the default command
+* A [start-singleuser.sh](./start-singleuser.sh) script useful for running a single-user instance of the Notebook server, as required by JupyterHub
+* A [start.sh](./start.sh) script useful for running alternative commands in the container (e.g. `ipython`, `jupyter kernelgateway`, `jupyter lab`)
+* Options for a self-signed HTTPS certificate and passwordless `sudo`
+
+## Basic Use
+
+The following command starts a container with the Notebook server listening for HTTP connections on port 8888 with a randomly generated authentication token configured.
+
+```
+docker run -it --rm -p 8888:8888 jupyter/base-notebook
+```
+
+Take note of the authentication token included in the notebook startup log messages. Include it in the URL you visit to access the Notebook server or enter it in the Notebook login form.
+
+## Notebook Options
+
+The Docker container executes a [`start-notebook.sh` script](./start-notebook.sh) script by default. The `start-notebook.sh` script handles the `NB_UID`, `NB_GID` and `GRANT_SUDO` features documented in the next section, and then executes the `jupyter notebook`.
+
+You can pass [Jupyter command line options](https://jupyter.readthedocs.io/en/latest/projects/jupyter-command.html) through the `start-notebook.sh` script when launching the container. For example, to secure the Notebook server with a custom password hashed using `IPython.lib.passwd()` instead of the default token, run the following:
+
+```
+docker run -d -p 8888:8888 jupyter/base-notebook start-notebook.sh --NotebookApp.password='sha1:74ba40f8a388:c913541b7ee99d15d5ed31d4226bf7838f83a50e'
+```
+
+For example, to set the base URL of the notebook server, run the following:
+
+```
+docker run -d -p 8888:8888 jupyter/base-notebook start-notebook.sh --NotebookApp.base_url=/some/path
+```
+
+For example, to disable all authentication mechanisms (not a recommended practice):
+
+```
+docker run -d -p 8888:8888 jupyter/base-notebook start-notebook.sh --NotebookApp.token=''
+```
+
+You can sidestep the `start-notebook.sh` script and run your own commands in the container. See the *Alternative Commands* section later in this document for more information.
+
+## Docker Options
+
+You may customize the execution of the Docker container and the command it is running with the following optional arguments.
+
+* `-e GEN_CERT=yes` - Generates a self-signed SSL certificate and configures Jupyter Notebook to use it to accept encrypted HTTPS connections.
+* `-e NB_UID=1000` - Specify the uid of the `jovyan` user. Useful to mount host volumes with specific file ownership. For this option to take effect, you must run the container with `--user root`. (The `start-notebook.sh` script will `su jovyan` after adjusting the user id.)
+* `-e NB_GID=100` - Specify the gid of the `jovyan` user. Useful to mount host volumes with specific file ownership. For this option to take effect, you must run the container with `--user root`. (The `start-notebook.sh` script will `su jovyan` after adjusting the group id.)
+* `-e GRANT_SUDO=yes` - Gives the `jovyan` user passwordless `sudo` capability. Useful for installing OS packages. For this option to take effect, you must run the container with `--user root`. (The `start-notebook.sh` script will `su jovyan` after adding `jovyan` to sudoers.) **You should only enable `sudo` if you trust the user or if the container is running on an isolated host.**
+* `-v /some/host/folder/for/work:/home/jovyan/work` - Host mounts the default working directory on the host to preserve work even when the container is destroyed and recreated (e.g., during an upgrade).
+
+## SSL Certificates
+
+You may mount SSL key and certificate files into a container and configure Jupyter Notebook to use them to accept HTTPS connections. For example, to mount a host folder containing a `notebook.key` and `notebook.crt`:
+
+```
+docker run -d -p 8888:8888 \
+    -v /some/host/folder:/etc/ssl/notebook \
+    jupyter/base-notebook start-notebook.sh \
+    --NotebookApp.keyfile=/etc/ssl/notebook/notebook.key
+    --NotebookApp.certfile=/etc/ssl/notebook/notebook.crt
+```
+
+Alternatively, you may mount a single PEM file containing both the key and certificate. For example:
+
+```
+docker run -d -p 8888:8888 \
+    -v /some/host/folder/notebook.pem:/etc/ssl/notebook.pem \
+    jupyter/base-notebook start-notebook.sh \
+    --NotebookApp.certfile=/etc/ssl/notebook.pem
+```
+
+In either case, Jupyter Notebook expects the key and certificate to be a base64 encoded text file. The certificate file or PEM may contain one or more certificates (e.g., server, intermediate, and root).
+
+For additional information about using SSL, see the following:
+
+* The [docker-stacks/examples](https://github.com/jupyter/docker-stacks/tree/master/examples) for information about how to use [Let's Encrypt](https://letsencrypt.org/) certificates when you run these stacks on a publicly visible domain.
+* The [jupyter_notebook_config.py](jupyter_notebook_config.py) file for how this Docker image generates a self-signed certificate.
+* The [Jupyter Notebook documentation](https://jupyter-notebook.readthedocs.io/en/latest/public_server.html#using-ssl-for-encrypted-communication) for best practices about running a public notebook server in general, most of which are encoded in this image.
+
+
+## Conda Environments
+
+The default Python 3.x [Conda environment](http://conda.pydata.org/docs/using/envs.html) resides in `/opt/conda`. 
+
+The commands `jupyter`, `ipython`, `python`, `pip`, and `conda` (among others) are available in both environments. For convenience, you can install packages into either environment regardless of what environment is currently active using commands like the following:
+
+```
+# install a package into the default (python 3.x) environment
+pip install some-package
+conda install some-package
+```
+
+
+## Alternative Commands
+
+### start-singleuser.sh
+
+[JupyterHub](https://jupyterhub.readthedocs.io) requires a single-user instance of the Jupyter Notebook server per user.   To use this stack with JupyterHub and [DockerSpawner](https://github.com/jupyter/dockerspawner), you must specify the container image name and override the default container run command in your `jupyterhub_config.py`:
+
+```python
+# Spawn user containers from this image
+c.DockerSpawner.container_image = 'jupyter/base-notebook'
+
+# Have the Spawner override the Docker run command
+c.DockerSpawner.extra_create_kwargs.update({
+	'command': '/usr/local/bin/start-singleuser.sh'
+})
+```
+
+### start.sh
+
+The `start.sh` script supports the same features as the default `start-notebook.sh` script (e.g., `GRANT_SUDO`), but allows you to specify an arbitrary command to execute. For example, to run the text-based `ipython` console in a container, do the following:
+
+```
+docker run -it --rm jupyter/base-notebook start.sh ipython
+```
+
+This script is particularly useful when you derive a new Dockerfile from this image and install additional Jupyter applications with subcommands like `jupyter console`, `jupyter kernelgateway`, and `jupyter lab`.
+
+### Others
+
+You can bypass the provided scripts and specify your an arbitrary start command. If you do, keep in mind that certain features documented above will not function (e.g., `GRANT_SUDO`).

--- a/php-notebook/README.md
+++ b/php-notebook/README.md
@@ -8,7 +8,7 @@ PHP stack based on official [Base Jupyter Notebook Stack](https://github.com/jup
 
 * Minimally-functional Jupyter Notebook 5.0.x (e.g., no pandoc for document conversion)
 * PHP 7.0
-* (Jupyter-PHP)[https://github.com/Litipk/Jupyter-PHP] kernel
+* [Jupyter-PHP](https://github.com/Litipk/Jupyter-PHP) kernel
 * Miniconda Python 3.x
 * No preinstalled scientific computing packages
 * Unprivileged user `jovyan` (uid=1000, configurable, see options) in group `users` (gid=100) with ownership over `/home/jovyan` and `/opt/conda`

--- a/php-notebook/hooks/post_push
+++ b/php-notebook/hooks/post_push
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# Tag the latest build with the short git sha. Push the tag in addition
+# to the "latest" tag already pushed.
+GIT_SHA_TAG=${SOURCE_COMMIT:0:12}
+docker tag $IMAGE_NAME $DOCKER_REPO:$GIT_SHA_TAG
+docker push $DOCKER_REPO:$GIT_SHA_TAG
+
+# Invoke all downstream build triggers.
+for url in $(echo $NEXT_BUILD_TRIGGERS | sed "s/,/ /g")
+do
+    curl -X POST $url
+done


### PR DESCRIPTION
PHP stack based on official [Base Jupyter Notebook Stack](https://github.com/jupyter/docker-stacks/tree/master/base-notebook)

It comes with PHP 7.0 and [Jupyter-PHP](https://github.com/Litipk/Jupyter-PHP) kernel