### PR TITLE
Update julia to v0.6.0 from upstream binaries

### DIFF
--- a/datascience-notebook/Dockerfile
+++ b/datascience-notebook/Dockerfile
@@ -19,13 +19,10 @@ RUN apt-get update && \
 ENV JULIA_PKGDIR=/opt/julia
 
 RUN . /etc/os-release && \
-    echo "deb http://ppa.launchpad.net/staticfloat/juliareleases/ubuntu $VERSION_CODENAME main" > /etc/apt/sources.list.d/julia.list && \
-    apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 3D3D3ACC && \
-    apt-get update && \
-    apt-get install -y --no-install-recommends \
-    julia && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/* && \
+    # download julia-v0.6.0 \
+    curl https://julialang-s3.julialang.org/bin/linux/x64/0.6/julia-0.6.0-linux-x86_64.tar.gz | tar xz && \
+    # put julia and julia-debug onto the system path \
+    mv julia-*/bin* /usr/local/bin/ && \
     # Show Julia where conda libraries are \
     echo "push!(Libdl.DL_LOAD_PATH, \"$CONDA_DIR/lib\")" >> /usr/etc/julia/juliarc.jl && \
     # Create JULIA_PKGDIR \


### PR DESCRIPTION
Thanks for providing these awesome dockerfiles, my libraries require julia-v0.6+. So I updated the dockerfile.

download and install julia from julialang.org install to /usr/local/bin/