### PR TITLE
Update jupyterlab to 0.28

### DIFF
--- a/base-notebook/Dockerfile
+++ b/base-notebook/Dockerfile
@@ -77,7 +77,7 @@ RUN cd /tmp && \
 RUN conda install --quiet --yes \
     'notebook=5.1.*' \
     'jupyterhub=0.8.*' \
-    'jupyterlab=0.27.*' \
+    'jupyterlab=0.28.*' \
     && conda clean -tipsy && \
     fix-permissions $CONDA_DIR
 


### PR DESCRIPTION
Update jupyterlab from 0.27.* to 0.28.*.
This allows the current version of ipywidgets (7.0.2) to be installed.