### PR TITLE
Fix wrong permissions when changing NB_UID or NB_GID.

### DIFF
--- a/base-notebook/start.sh
+++ b/base-notebook/start.sh
@@ -39,6 +39,14 @@ if [ $(id -u) == 0 ] ; then
         groupmod -g $NB_GID -o $(id -g -n $NB_USER)
     fi
 
+    # Grant permissions on home and in /opt/conda to $NB_USER
+    if [ "$NB_UID" != $(id -u $NB_USER) -o "$NB_GID" ] ; then
+	echo "Granting permissions to $NB_USER on /home/$NB_USER and /opt/conda"
+        CURRENT_GID=${NB_GID:-$(id -g $NB_USER)}
+	chown -R $NB_UID:$CURRENT_GID /home/$NB_USER
+	chown -R $NB_UID:$CURRENT_GID /opt/conda
+    fi
+
     # Enable sudo if requested
     if [[ "$GRANT_SUDO" == "1" || "$GRANT_SUDO" == 'yes' ]]; then
         echo "Granting $NB_USER sudo access"


### PR DESCRIPTION
When changing UID or GID of the jovyan user, I noticed that a usermod and/or groupmod commands are issued, but then the own home directory and `/opt/conda` still belong to the previous UID of jovyan, so permissions should be granted again in the case of a new UID or GID is requested via container environment variables.

This change takes some time. It could be made in the background, but then it may make some tests fail that execute just after starting the notebook server.