### PR TITLE
prepend R channel

### DIFF
--- a/datascience-notebook/Dockerfile
+++ b/datascience-notebook/Dockerfile
@@ -36,7 +36,7 @@ RUN . /etc/os-release && \
 USER $NB_USER
 
 # R packages including IRKernel which gets installed globally.
-RUN conda config --system --add channels r && \
+RUN conda config --system --append channels r && \
     conda install --quiet --yes \
     'rpy2=2.8*' \
     'r-base=3.3.2' \


### PR DESCRIPTION
instead of appending, which causes broken R due to mismatched icu version.

gives R channel lower priority than conda-forge.

This is probably due to some package having an improper pin somewhere.