### PR TITLE
Activate ipywidgets for JupyterLab. #505

### DIFF
--- a/scipy-notebook/Dockerfile
+++ b/scipy-notebook/Dockerfile
@@ -46,6 +46,8 @@ RUN conda install --quiet --yes \
     conda clean -tipsy && \
     # Activate ipywidgets extension in the environment that runs the notebook server
     jupyter nbextension enable --py widgetsnbextension --sys-prefix && \
+    # Also activate ipywidgets extension for JupyterLab
+    jupyter labextension install @jupyter-widgets/jupyterlab-manager && \
     fix-permissions $CONDA_DIR
 
 # Install facets which does not have a pip or conda package at the moment


### PR DESCRIPTION
As discussed in https://github.com/jupyter/docker-stacks/issues/505
Also mentioned here: https://github.com/jupyter-widgets/ipywidgets/issues/1683#issuecomment-328952119

Docker image builded with
`docker build -t $USER/scipy-notebook -f Dockerfile .`

Image run with
```
alias ds='docker run -ti --rm -p 8888:8888 -v "$PWD":/home/jovyan/work --name scipy-notebook $USER/scipy-notebook'
ds
```

In JupyterLab mode, ipywidgets confirmed working
```
import ipywidgets
ipywidgets.IntSlider()
```
![screen shot 2017-11-23 at 14 36 57](https://user-images.githubusercontent.com/1208292/33176134-464ada0e-d05e-11e7-9d59-a0df239feb04.png)

List of extension tested with
```
jupyter nbextension list
jupyter labextension list

```
![screen shot 2017-11-23 at 14 38 09](https://user-images.githubusercontent.com/1208292/33176158-5fb4fa60-d05e-11e7-8b4f-0d1c381059d1.png)
