### PR TITLE
 Fix for granting SUDO to jovyan user and run bash commands.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,13 +14,14 @@ If you're familiar with Docker, have it configured, and know exactly what you'd 
 # -ti: pseudo-TTY+STDIN open.
 # -rm: remove the container on exit.
 # -p: publish port to the host
-
 docker run -ti --rm -p 8888:8888 jupyter/<your desired stack>:<git-sha-tag>
+
+# And mount current directory into 'work' directory in image
+docker run -ti --rm -p 8888:8888 -v "$PWD":/home/jovyan/work jupyter/<your desired stack>:<git-sha-tag>
 
 # Bagkground mode:
 # -d: detach, run container in background.
 # -P: Publish all exposed ports to random ports
-
 docker run -d -P jupyter/<your desired stack>:<git-sha-tag>
 ```
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,16 @@ If this is your first time using Docker or any of the Jupyter projects, do the f
 3. Follow the README for that stack.
 
 ## Visual Overview
+[Click here for commented build history, with reference to SHA values.](https://github.com/jupyter/docker-stacks/wiki/Docker-build-history)
+
+* base-notebook: [README](https://github.com/jupyter/docker-stacks/tree/master/base-notebook), [SHA list](https://hub.docker.com/r/jupyter/base-notebook/tags/)
+* minimal-notebook: [README](https://github.com/jupyter/docker-stacks/tree/master/minimal-notebook), [SHA list](https://hub.docker.com/r/jupyter/minimal-notebook/tags/)
+* scipy-notebook: [README](https://github.com/jupyter/docker-stacks/tree/master/scipy-notebook), [SHA list](https://hub.docker.com/r/jupyter/scipy-notebook/tags/)
+* r-notebook: [README](https://github.com/jupyter/docker-stacks/tree/master/r-notebook), [SHA list](https://hub.docker.com/r/jupyter/r-notebook/tags/)
+* tensorflow-notebook: [README](https://github.com/jupyter/docker-stacks/tree/master/tensorflow-notebook), [SHA list](https://hub.docker.com/r/jupyter/tensorflow-notebook/tags/)
+* datascience-notebook: [README](https://github.com/jupyter/docker-stacks/tree/master/datascience-notebook), [SHA list](https://hub.docker.com/r/jupyter/datascience-notebook/tags/)
+* pyspark-notebook: [README](https://github.com/jupyter/docker-stacks/tree/master/pyspark-notebook), [SHA list](https://hub.docker.com/r/jupyter/pyspark-notebook/tags/)
+* all-spark-notebook: [README](https://github.com/jupyter/docker-stacks/tree/master/all-spark-notebook), [SHA list](https://hub.docker.com/r/jupyter/all-spark-notebook/tags/)
 
 Here's a diagram of the `FROM` relationships between all of the images defined in this project:
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,17 @@ Opinionated stacks of ready-to-run Jupyter applications in Docker.
 If you're familiar with Docker, have it configured, and know exactly what you'd like to run, this one-liner should work in most cases:
 
 ```
+# Foreground mode:
+# -ti: pseudo-TTY+STDIN open.
+# -rm: remove the container on exit.
+# -p: publish port to the host
+
+docker run -ti --rm -p 8888:8888 jupyter/<your desired stack>:<git-sha-tag>
+
+# Bagkground mode:
+# -d: detach, run container in background.
+# -P: Publish all exposed ports to random ports
+
 docker run -d -P jupyter/<your desired stack>:<git-sha-tag>
 ```
 

--- a/README.md
+++ b/README.md
@@ -7,19 +7,23 @@ Opinionated stacks of ready-to-run Jupyter applications in Docker.
 
 ## Quick Start
 
-If you're familiar with Docker, have it configured, and know exactly what you'd like to run, this one-liner should work in most cases:
+If you're familiar with Docker, have it configured, and know exactly what you'd like to run, one of these commands should get you up and running:
 
 ```
-# Foreground mode:
+# Run an ephemeral Jupyter Notebook server in a Docker container in the terminal foreground.
+# Note that any work saved in the container will be lost when it is destroyed with this config.
 # -ti: pseudo-TTY+STDIN open.
 # -rm: remove the container on exit.
 # -p: publish port to the host
 docker run -ti --rm -p 8888:8888 jupyter/<your desired stack>:<git-sha-tag>
 
-# And mount current directory into 'work' directory in image
+# Run a Jupyter Notebook server in a Docker container in the terminal foreground.
+# Any files written to ~/work in the container will be saved to the current working
+# directory on the host.
 docker run -ti --rm -p 8888:8888 -v "$PWD":/home/jovyan/work jupyter/<your desired stack>:<git-sha-tag>
 
-# Bagkground mode:
+# Run an ephemeral Jupyter Notebook server in a Docker container in the background.
+# Note that any work saved in the container will be lost when it is destroyed with this config.
 # -d: detach, run container in background.
 # -P: Publish all exposed ports to random ports
 docker run -d -P jupyter/<your desired stack>:<git-sha-tag>
@@ -34,7 +38,14 @@ If this is your first time using Docker or any of the Jupyter projects, do the f
 3. Follow the README for that stack.
 
 ## Visual Overview
-[Click here for commented build history, with reference to SHA values.](https://github.com/jupyter/docker-stacks/wiki/Docker-build-history)
+
+Here's a diagram of the `FROM` relationships between all of the images defined in this project:
+
+[![Image inheritance diagram](internal/inherit-diagram.svg)](http://interactive.blockdiag.com/?compression=deflate&src=eJyFzTEPgjAQhuHdX9Gws5sQjGzujsaYKxzmQrlr2msMGv-71K0srO_3XGud9NNA8DSfgzESCFlBSdi0xkvQAKTNugw4QnL6GIU10hvX-Zh7Z24OLLq2SjaxpvP10lX35vCf6pOxELFmUbQiUz4oQhYzMc3gCrRt2cWe_FKosmSjyFHC6OS1AwdQWCtyj7sfh523_BI9hKlQ25YdOFdv5fcH0kiEMA)
+
+[Click here for a commented build history of each image, with references to tag/SHA values.](https://github.com/jupyter/docker-stacks/wiki/Docker-build-history)
+
+The following are quick-links to READMEs about each image and their Docker image tags on Docker Cloud:
 
 * base-notebook: [README](https://github.com/jupyter/docker-stacks/tree/master/base-notebook), [SHA list](https://hub.docker.com/r/jupyter/base-notebook/tags/)
 * minimal-notebook: [README](https://github.com/jupyter/docker-stacks/tree/master/minimal-notebook), [SHA list](https://hub.docker.com/r/jupyter/minimal-notebook/tags/)
@@ -44,10 +55,6 @@ If this is your first time using Docker or any of the Jupyter projects, do the f
 * datascience-notebook: [README](https://github.com/jupyter/docker-stacks/tree/master/datascience-notebook), [SHA list](https://hub.docker.com/r/jupyter/datascience-notebook/tags/)
 * pyspark-notebook: [README](https://github.com/jupyter/docker-stacks/tree/master/pyspark-notebook), [SHA list](https://hub.docker.com/r/jupyter/pyspark-notebook/tags/)
 * all-spark-notebook: [README](https://github.com/jupyter/docker-stacks/tree/master/all-spark-notebook), [SHA list](https://hub.docker.com/r/jupyter/all-spark-notebook/tags/)
-
-Here's a diagram of the `FROM` relationships between all of the images defined in this project:
-
-[![Image inheritance diagram](internal/inherit-diagram.svg)](http://interactive.blockdiag.com/?compression=deflate&src=eJyFzTEPgjAQhuHdX9Gws5sQjGzujsaYKxzmQrlr2msMGv-71K0srO_3XGud9NNA8DSfgzESCFlBSdi0xkvQAKTNugw4QnL6GIU10hvX-Zh7Z24OLLq2SjaxpvP10lX35vCf6pOxELFmUbQiUz4oQhYzMc3gCrRt2cWe_FKosmSjyFHC6OS1AwdQWCtyj7sfh523_BI9hKlQ25YdOFdv5fcH0kiEMA)
 
 ## Stacks, Tags, Versioning, and Progress
 

--- a/base-notebook/start.sh
+++ b/base-notebook/start.sh
@@ -4,6 +4,13 @@
 
 set -e
 
+# Exec the specified command or fall back on bash
+if [ $# -eq 0 ]; then
+    cmd=bash
+else
+    cmd=$*
+fi
+
 # Handle special flags if we're root
 if [ $(id -u) == 0 ] ; then
 
@@ -45,34 +52,22 @@ if [ $(id -u) == 0 ] ; then
         echo "$NB_USER ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/notebook
     fi
 
-    # Exec the command as NB_USER or root
-    echo "Execute the command: $*"
-    if [[ "$GRANT_SUDO" == "1" || "$GRANT_SUDO" == 'yes' ]]; then
-        if [ $# -eq 0 ]; then
-            echo "No arguments supplied"
-            sudo -H -u $NB_USER bash -c 'env; PATH=$PATH; bash'
-        else
-            exec su $NB_USER -c "env PATH=$PATH $*"
-        fi
-    else
-        if [ $# -eq 0 ]; then
-            echo "No arguments supplied"
-            bash -c 'env; PATH=$PATH; bash'
-        else
-            env PATH=$PATH $*
-        fi
-    fi
+    # Exec the command as NB_USER with the PATH and the rest of
+    # the environment preserved
+    echo "Executing the command: $cmd"
+    exec sudo -E -H -u $NB_USER PATH=$PATH $cmd
 else
-  if [[ ! -z "$NB_UID" && "$NB_UID" != "$(id -u)" ]]; then
-      echo 'Container must be run as root to set $NB_UID'
-  fi
-  if [[ ! -z "$NB_GID" && "$NB_GID" != "$(id -g)" ]]; then
-      echo 'Container must be run as root to set $NB_GID'
-  fi
-  if [[ "$GRANT_SUDO" == "1" || "$GRANT_SUDO" == 'yes' ]]; then
-      echo 'Container must be run as root to grant sudo permissions'
-  fi
-    # Exec the command
-    echo "Execute the command: $*"
-    exec $*
+    if [[ ! -z "$NB_UID" && "$NB_UID" != "$(id -u)" ]]; then
+        echo 'Container must be run as root to set $NB_UID'
+    fi
+    if [[ ! -z "$NB_GID" && "$NB_GID" != "$(id -g)" ]]; then
+        echo 'Container must be run as root to set $NB_GID'
+    fi
+    if [[ "$GRANT_SUDO" == "1" || "$GRANT_SUDO" == 'yes' ]]; then
+        echo 'Container must be run as root to grant sudo permissions'
+    fi
+
+    # Execute the command
+    echo "Executing the command: $cmd"
+    exec $cmd
 fi

--- a/base-notebook/start.sh
+++ b/base-notebook/start.sh
@@ -47,7 +47,12 @@ if [ $(id -u) == 0 ] ; then
 
     # Exec the command as NB_USER
     echo "Execute the command: $*"
-    exec su $NB_USER -c "env PATH=$PATH $*"
+    if [ $# -eq 0 ]; then
+        echo "No arguments supplied"
+        sudo -H -u $NB_USER bash -c 'env; PATH=$PATH; bash'
+    else
+        exec su $NB_USER -c "env PATH=$PATH $*"
+    fi
 else
   if [[ ! -z "$NB_UID" && "$NB_UID" != "$(id -u)" ]]; then
       echo 'Container must be run as root to set $NB_UID'

--- a/base-notebook/start.sh
+++ b/base-notebook/start.sh
@@ -45,13 +45,22 @@ if [ $(id -u) == 0 ] ; then
         echo "$NB_USER ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/notebook
     fi
 
-    # Exec the command as NB_USER
+    # Exec the command as NB_USER or root
     echo "Execute the command: $*"
-    if [ $# -eq 0 ]; then
-        echo "No arguments supplied"
-        sudo -H -u $NB_USER bash -c 'env; PATH=$PATH; bash'
+    if [[ "$GRANT_SUDO" == "1" || "$GRANT_SUDO" == 'yes' ]]; then
+        if [ $# -eq 0 ]; then
+            echo "No arguments supplied"
+            sudo -H -u $NB_USER bash -c 'env; PATH=$PATH; bash'
+        else
+            exec su $NB_USER -c "env PATH=$PATH $*"
+        fi
     else
-        exec su $NB_USER -c "env PATH=$PATH $*"
+        if [ $# -eq 0 ]; then
+            echo "No arguments supplied"
+            bash -c 'env; PATH=$PATH; bash'
+        else
+            env PATH=$PATH $*
+        fi
     fi
 else
   if [[ ! -z "$NB_UID" && "$NB_UID" != "$(id -u)" ]]; then

--- a/base-notebook/test/test_container_options.py
+++ b/base-notebook/test/test_container_options.py
@@ -24,7 +24,7 @@ def test_unsigned_ssl(container, http_client):
     container.run(
         environment=['GEN_CERT=yes']
     )
-    # NOTE: The requests.Session backing the http_client fixture  does not retry
+    # NOTE: The requests.Session backing the http_client fixture does not retry
     # properly while the server is booting up. An SSL handshake error seems to
     # abort the retry logic. Forcing a long sleep for the moment until I have
     # time to dig more.
@@ -40,7 +40,7 @@ def test_uid_change(container):
         tty=True,
         user='root',
         environment=['NB_UID=1010'],
-        command=['start.sh', 'id && touch /opt/conda/test-file']
+        command=['start.sh', 'bash', '-c', 'id && touch /opt/conda/test-file']
     )
     # usermod is slow so give it some time
     c.wait(timeout=120)

--- a/scipy-notebook/Dockerfile
+++ b/scipy-notebook/Dockerfile
@@ -47,7 +47,7 @@ RUN conda install --quiet --yes \
     # Activate ipywidgets extension in the environment that runs the notebook server
     jupyter nbextension enable --py widgetsnbextension --sys-prefix && \
     # Also activate ipywidgets extension for JupyterLab
-    jupyter labextension install @jupyter-widgets/jupyterlab-manager^0.31.0 && \
+    jupyter labextension install @jupyter-widgets/jupyterlab-manager@^0.31.0 && \
     npm cache clean && \
     rm -rf $CONDA_DIR/share/jupyter/lab/staging && \
     fix-permissions $CONDA_DIR

--- a/scipy-notebook/Dockerfile
+++ b/scipy-notebook/Dockerfile
@@ -47,7 +47,7 @@ RUN conda install --quiet --yes \
     # Activate ipywidgets extension in the environment that runs the notebook server
     jupyter nbextension enable --py widgetsnbextension --sys-prefix && \
     # Also activate ipywidgets extension for JupyterLab
-    jupyter labextension install @jupyter-widgets/jupyterlab-manager && \
+    jupyter labextension install @jupyter-widgets/jupyterlab-manager^0.31.0 && \
     npm cache clean && \
     rm -rf $CONDA_DIR/share/jupyter/lab/staging && \
     fix-permissions $CONDA_DIR


### PR DESCRIPTION
Adding extra information to the main README file, for easier access to sub images.

Fix for granting SUDO to jovyan user and run bash commands.

Running:
docker run -ti --rm -p 8888:8888 -e GRANT_SUDO=yes --user root jupyter/base-notebook:033056e6d164 start.sh

Will immediately exit the container.

With the fix, the image stays in bash after granting SUDO to jovyan user.