### PR TITLE
Dockefile for Cling

### DIFF
--- a/cling-notebook/Dockerfile
+++ b/cling-notebook/Dockerfile
@@ -1,0 +1,23 @@
+FROM jupyter/base-notebook
+
+USER root
+
+ENV PATH /opt/cling_2017-11-13_ubuntu16/bin:$PATH
+
+RUN apt-get -y update && \
+    apt-get install -y --upgrade python3-pip     
+
+RUN cd /tmp && \
+    wget --quiet https://root.cern.ch/download/cling/cling_2017-11-13_ubuntu16.tar.bz2 && \
+    tar -C /opt -xjf cling_2017-11-13_ubuntu16.tar.bz2 && \
+    cd /opt/cling_2017-11-13_ubuntu16/share/cling/Jupyter/kernel && \
+    pip3 install -e . && \
+    jupyter-kernelspec install cling-cpp17 && \
+    jupyter-kernelspec install cling-cpp1z && \
+    jupyter-kernelspec install cling-cpp14 && \
+    jupyter-kernelspec install cling-cpp11
+
+RUN fix-permissions /opt/cling_2017-11-13_ubuntu16
+RUN fix-permissions $HOME
+
+USER $NB_USER

--- a/cling-notebook/Dockerfile
+++ b/cling-notebook/Dockerfile
@@ -2,22 +2,23 @@ FROM jupyter/base-notebook
 
 USER root
 
-ENV PATH /opt/cling_2017-11-13_ubuntu16/bin:$PATH
+ENV PATH=/opt/cling_2017-11-13_ubuntu16/bin:$PATH \
+    CLING_VERSION=cling_2017-11-13_ubuntu16
 
 RUN apt-get -y update && \
     apt-get install -y --upgrade python3-pip     
 
 RUN cd /tmp && \
-    wget --quiet https://root.cern.ch/download/cling/cling_2017-11-13_ubuntu16.tar.bz2 && \
-    tar -C /opt -xjf cling_2017-11-13_ubuntu16.tar.bz2 && \
-    cd /opt/cling_2017-11-13_ubuntu16/share/cling/Jupyter/kernel && \
+    wget --quiet https://root.cern.ch/download/cling/${CLING_VERSION}.tar.bz2 && \
+    tar -C /opt -xjf ${CLING_VERSION}.tar.bz2 && \
+    cd /opt/${CLING_VERSION}/share/cling/Jupyter/kernel && \
     pip3 install -e . && \
     jupyter-kernelspec install cling-cpp17 && \
     jupyter-kernelspec install cling-cpp1z && \
     jupyter-kernelspec install cling-cpp14 && \
     jupyter-kernelspec install cling-cpp11
 
-RUN fix-permissions /opt/cling_2017-11-13_ubuntu16
+RUN fix-permissions /opt/${CLING_VERSION}
 RUN fix-permissions $HOME
 
 USER $NB_USER


### PR DESCRIPTION
Cling is an interactive C++ interpreter, built on top of Clang and LLVM compiler infrastructure. The binary distribution includes Jupyter kernels for c++11, c++14 and c++17. This Dockerfile downloads binary distribution and installs it to /opt, and installs the Jupyter kernels.