### PR TITLE
Add option to use PORT environment variable

### DIFF
--- a/base-notebook/jupyter_notebook_config.py
+++ b/base-notebook/jupyter_notebook_config.py
@@ -9,7 +9,7 @@ import stat
 
 c = get_config()
 c.NotebookApp.ip = '*'
-c.NotebookApp.port = 8888
+c.NotebookApp.port = int(os.getenv('PORT', 8888))
 c.NotebookApp.open_browser = False
 
 # Generate a self-signed certificate


### PR DESCRIPTION
This commit will add an ability to configure listening port number at runtime just providing `PORT` environment variable.

It can be workaround by passing `start-notebook.sh --NotebookApp.port=8080` as a runtime command, but passing `PORT` environment variable is much popular way to configure listening port by 12-factor apps.