### PR TITLE
jupyterhub-lab support will be enabled if $JUPYTER_ENABLE_LAB is set.

### DIFF
--- a/base-notebook/README.md
+++ b/base-notebook/README.md
@@ -29,6 +29,12 @@ Take note of the authentication token included in the notebook startup log messa
 
 The Docker container executes a [`start-notebook.sh` script](./start-notebook.sh) script by default. The `start-notebook.sh` script handles the `NB_UID`, `NB_GID` and `GRANT_SUDO` features documented in the next section, and then executes the `jupyter notebook`.
 
+You can launch [JupyterLab](https://github.com/jupyterlab/jupyterlab) by setting `JUPYTER_ENABLE_LAB`:
+
+```
+docker run -it --rm -e JUPYTER_ENABLE_LAB=1 --rm -p 8888:8888 jupyter/base-notebook
+```
+
 You can pass [Jupyter command line options](https://jupyter.readthedocs.io/en/latest/projects/jupyter-command.html) through the `start-notebook.sh` script when launching the container. For example, to secure the Notebook server with a custom password hashed using `IPython.lib.passwd()` instead of the default token, run the following:
 
 ```

--- a/base-notebook/start-notebook.sh
+++ b/base-notebook/start-notebook.sh
@@ -8,5 +8,9 @@ if [[ ! -z "${JUPYTERHUB_API_TOKEN}" ]]; then
   # launched by JupyterHub, use single-user entrypoint
   exec /usr/local/bin/start-singleuser.sh $*
 else
-  . /usr/local/bin/start.sh jupyter notebook $*
+  if [[ ! -z "${JUPYTER_ENABLE_LAB}" ]]; then
+    . /usr/local/bin/start.sh jupyter lab $*
+  else
+    . /usr/local/bin/start.sh jupyter notebook $*
+  fi
 fi

--- a/base-notebook/start-singleuser.sh
+++ b/base-notebook/start-singleuser.sh
@@ -34,5 +34,10 @@ fi
 if [ ! -z "$JPY_HUB_API_URL" ]; then
   NOTEBOOK_ARGS="--hub-api-url=$JPY_HUB_API_URL $NOTEBOOK_ARGS"
 fi
+if [ ! -z "$JUPYTERHUB_ENABLE_LAB" ]; then
+  NOTEBOOK_BIN="jupyter labhub"
+else
+  NOTEBOOK_BIN=jupyterhub-singleuser
+fi
 
-. /usr/local/bin/start.sh jupyterhub-singleuser $NOTEBOOK_ARGS $@
+. /usr/local/bin/start.sh $NOTEBOOK_BIN $NOTEBOOK_ARGS $@

--- a/base-notebook/start-singleuser.sh
+++ b/base-notebook/start-singleuser.sh
@@ -34,7 +34,7 @@ fi
 if [ ! -z "$JPY_HUB_API_URL" ]; then
   NOTEBOOK_ARGS="--hub-api-url=$JPY_HUB_API_URL $NOTEBOOK_ARGS"
 fi
-if [ ! -z "$JUPYTERHUB_ENABLE_LAB" ]; then
+if [ ! -z "$JUPYTER_ENABLE_LAB" ]; then
   NOTEBOOK_BIN="jupyter labhub"
 else
   NOTEBOOK_BIN=jupyterhub-singleuser


### PR DESCRIPTION
Closes #531.