### PR TITLE
optional GPU builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,8 +42,12 @@ arch_patch/%: ## apply hardware architecture specific patches to the Dockerfile
 	fi
 
 build/%: DARGS?=
+ifeq ($(GPU),1)
+build/%: TAG_POSTFIX?=-gpu
+build/%: BARGS?=--build-arg BASE=nvidia/cuda:8.0-cudnn7-devel-ubuntu16.04 --build-arg TAG_POSTFIX=$(TAG_POSTFIX)
+endif
 build/%: ## build the latest image for a stack
-	docker build $(DARGS) --rm --force-rm -t $(OWNER)/$(notdir $@):latest ./$(notdir $@)
+	docker build $(BARGS) $(DARGS) --rm --force-rm -t $(OWNER)/$(notdir $@):latest$(TAG_POSTFIX) ./$(notdir $@)
 
 build-all: $(foreach I,$(ALL_IMAGES),arch_patch/$(I) build/$(I) ) ## build all stacks
 build-test-all: $(foreach I,$(ALL_IMAGES),arch_patch/$(I) build/$(I) test/$(I) ) ## build and test all stacks

--- a/all-spark-notebook/Dockerfile
+++ b/all-spark-notebook/Dockerfile
@@ -1,6 +1,7 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
-FROM jupyter/pyspark-notebook
+ARG TAG_POSTFIX=
+FROM jupyter/pyspark-notebook:latest${TAG_POSTFIX}
 
 LABEL maintainer="Jupyter Project <jupyter@googlegroups.com>"
 

--- a/base-notebook/Dockerfile
+++ b/base-notebook/Dockerfile
@@ -3,7 +3,8 @@
 
 # Ubuntu 16.04 (xenial) from 2017-07-23
 # https://github.com/docker-library/official-images/commit/0ea9b38b835ffb656c497783321632ec7f87b60c
-FROM ubuntu@sha256:84c334414e2bfdcae99509a6add166bbb4fa4041dc3fa6af08046a66fed3005f
+ARG BASE=ubuntu@sha256:84c334414e2bfdcae99509a6add166bbb4fa4041dc3fa6af08046a66fed3005f
+FROM ${BASE}
 
 LABEL maintainer="Jupyter Project <jupyter@googlegroups.com>"
 

--- a/datascience-notebook/Dockerfile
+++ b/datascience-notebook/Dockerfile
@@ -1,6 +1,7 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
-FROM jupyter/scipy-notebook
+ARG TAG_POSTFIX=
+FROM jupyter/scipy-notebook${TAG_POSTFIX}
 
 LABEL maintainer="Jupyter Project <jupyter@googlegroups.com>"
 

--- a/minimal-notebook/Dockerfile
+++ b/minimal-notebook/Dockerfile
@@ -1,7 +1,8 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 
-FROM jupyter/base-notebook
+ARG TAG_POSTFIX=
+FROM jupyter/base-notebook:latest${TAG_POSTFIX}
 
 LABEL maintainer="Jupyter Project <jupyter@googlegroups.com>"
 

--- a/pyspark-notebook/Dockerfile
+++ b/pyspark-notebook/Dockerfile
@@ -1,6 +1,7 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
-FROM jupyter/scipy-notebook
+ARG TAG_POSTFIX=
+FROM jupyter/scipy-notebook:latest${TAG_POSTFIX}
 
 LABEL maintainer="Jupyter Project <jupyter@googlegroups.com>"
 

--- a/r-notebook/Dockerfile
+++ b/r-notebook/Dockerfile
@@ -1,6 +1,7 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
-FROM jupyter/minimal-notebook
+ARG TAG_POSTFIX=
+FROM jupyter/minimal-notebook:latest${TAG_POSTFIX}
 
 LABEL maintainer="Jupyter Project <jupyter@googlegroups.com>"
 

--- a/scipy-notebook/Dockerfile
+++ b/scipy-notebook/Dockerfile
@@ -1,6 +1,7 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
-FROM jupyter/minimal-notebook
+ARG TAG_POSTFIX=
+FROM jupyter/minimal-notebook:latest${TAG_POSTFIX}
 
 LABEL maintainer="Jupyter Project <jupyter@googlegroups.com>"
 

--- a/tensorflow-notebook/Dockerfile
+++ b/tensorflow-notebook/Dockerfile
@@ -1,12 +1,13 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
-FROM jupyter/scipy-notebook
+ARG TAG_POSTFIX=
+FROM jupyter/scipy-notebook:latest${TAG_POSTFIX}
 
 LABEL maintainer="Jupyter Project <jupyter@googlegroups.com>"
 
 # Install Tensorflow
 RUN conda install --quiet --yes \
-    'tensorflow=1.3*' \
+    tensorflow${TAG_POSTFIX}=1.3* \
     'keras=2.0*' && \
     conda clean -tipsy && \
     fix-permissions $CONDA_DIR


### PR DESCRIPTION
This PR enables GPU builds by adding `GPU=1` to make, which switches to nvidia/cuda:8.0-cudnn7-devel-ubuntu16.04 for the base image, and builds notebook images as the `latest-gpu` tags to be consumed by downstream images. #540

The tensorflow-notebook also installs tensorflow-gpu accordingly.

Closes #516.