### PR TITLE
Support provisioned storage with incorrect permissions

### DIFF
--- a/base-notebook/start.sh
+++ b/base-notebook/start.sh
@@ -20,7 +20,10 @@ if [ $(id -u) == 0 ] ; then
     
     # Handle case where provisioned storage does not have the correct permissions by default
     # Ex: default NFS/EFS (no auto-uid/gid)
-    chown $NB_UID:$NB_GID /home/$NB_USER
+    if [[ "$CHOWN_HOME" == "1" || "$CHOWN_HOME" == 'yes' ]]; then
+        echo "Changing ownership of /home/$NB_USER to $NB_UID:$NB_GID"
+        chown $NB_UID:$NB_GID /home/$NB_USER
+    fi
 
     # handle home and working directory if the username changed
     if [[ "$NB_USER" != "jovyan" ]]; then

--- a/base-notebook/start.sh
+++ b/base-notebook/start.sh
@@ -17,6 +17,10 @@ if [ $(id -u) == 0 ] ; then
     # Handle username change. Since this is cheap, do this unconditionally
     echo "Set username to: $NB_USER"
     usermod -d /home/$NB_USER -l $NB_USER jovyan
+    
+    # Handle case where provisioned storage does not have the correct permissions by default
+    # Ex: default NFS/EFS (no auto-uid/gid)
+    chown $NB_UID:$NB_GID /home/$NB_USER
 
     # handle home and working directory if the username changed
     if [[ "$NB_USER" != "jovyan" ]]; then


### PR DESCRIPTION
I ran into an issue when trying to get this to work with a NFS server which I did not have direct control over (EFS).  As part of the PersistentVolumeClaim, there is no easy way to set the UID and GID of the created directory.on the networked FS.

My only concern with this chown is that some user out there might be running jupyterhub in an odd configuration where $NB_USER is not supposed to have these exact permissions on the storage.  I think this is quite unlikely, but it is worth mentioning. 

I chronicled my experiences with working around this issue and setting up z2jh on EFS in https://github.com/jupyterhub/zero-to-jupyterhub-k8s/issues/421 with @yuvipanda.