### PR TITLE
Fixing PYTHONPATH in base-notebook/start.sh

### DIFF
--- a/base-notebook/start.sh
+++ b/base-notebook/start.sh
@@ -65,7 +65,7 @@ if [ $(id -u) == 0 ] ; then
     # Exec the command as NB_USER with the PATH and the rest of
     # the environment preserved
     echo "Executing the command: $cmd"
-    exec sudo -E -H -u $NB_USER PATH=$PATH $cmd
+    exec sudo -E -H -u $NB_USER PATH=$PATH PYTHONPATH=$PYTHONPATH $cmd
 else
     if [[ ! -z "$NB_UID" && "$NB_UID" != "$(id -u)" ]]; then
         echo 'Container must be run as root to set $NB_UID'


### PR DESCRIPTION
In order to fix the PYTHONPATH problem in pyspark-notebook, I have added PYTHONPATH to sudo command in start.sh