### PR TITLE
Add passwd/group file entries when running images as assigned user ID not in passwd file.

### DIFF
--- a/base-notebook/Dockerfile
+++ b/base-notebook/Dockerfile
@@ -47,9 +47,12 @@ ENV PATH=$CONDA_DIR/bin:$PATH \
 ADD fix-permissions /usr/local/bin/fix-permissions
 # Create jovyan user with UID=1000 and in the 'users' group
 # and make sure these dirs are writable by the `users` group.
+# Make /etc/passwd and /etc/group writable so can add entries
+# for uid/gid when container run as arbitrarily assigned uid.
 RUN useradd -m -s /bin/bash -N -u $NB_UID $NB_USER && \
     mkdir -p $CONDA_DIR && \
     chown $NB_USER:$NB_GID $CONDA_DIR && \
+    chmod g+w /etc/passwd /etc/group && \
     fix-permissions $HOME && \
     fix-permissions $CONDA_DIR
 
@@ -90,13 +93,15 @@ EXPOSE 8888
 WORKDIR $HOME
 
 # Configure container startup
-ENTRYPOINT ["tini", "--"]
+ENTRYPOINT ["container-entrypoint"]
 CMD ["start-notebook.sh"]
 
 # Add local files as late as possible to avoid cache busting
 COPY start.sh /usr/local/bin/
 COPY start-notebook.sh /usr/local/bin/
 COPY start-singleuser.sh /usr/local/bin/
+COPY container-entrypoint /usr/local/bin/
+COPY fix-passwd-entry /usr/local/bin/
 COPY jupyter_notebook_config.py /etc/jupyter/
 RUN fix-permissions /etc/jupyter/
 

--- a/base-notebook/container-entrypoint
+++ b/base-notebook/container-entrypoint
@@ -1,0 +1,15 @@
+#!/bin/bash
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+
+# Add entries to /etc/passwd and /etc/group if being run as user ID
+# other than which the image has specified by the USER statement.
+
+fix-passwd-entry
+
+# Run 'tini' as a mini supervisor. This will manage the actual
+# application process, passing on signals received by the container, and
+# also reaping zombie processes. Must use 'exec' so that it inherits
+# process ID 1 of the container.
+
+exec tini -- "$@"

--- a/base-notebook/fix-passwd-entry
+++ b/base-notebook/fix-passwd-entry
@@ -1,0 +1,22 @@
+#!/bin/bash
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+
+# By default the image would run as user ID 1000. If the user is run as
+# an arbitrarily assigned user ID by the container platform it will be
+# much higher and the lack of entries in /etc/passwd and /etc/group can
+# cause failure of any Python code which doesn't tolerate having no
+# entries for uid/gid. Assume that if running with larger uid that we
+# need to add entries into the respective files for that user. Have the
+# check be greater than 100000 to allow room in case custom images
+# derived from this image were adding additional explict users/groups of
+# their own.
+
+if [ `id -u` -ge 100000 ]; then
+    cat /etc/passwd | sed -e "s/^jovyan:/nayvoj:/" > /tmp/passwd
+    echo "jovyan:x:`id -u`:`id -g`:,,,:/home/jovyan:/bin/bash" >> /tmp/passwd
+    cat /tmp/passwd > /etc/passwd
+    rm /tmp/passwd
+
+    echo "jovyan:x:`id -u`:" >> /etc/group
+fi

--- a/base-notebook/fix-passwd-entry
+++ b/base-notebook/fix-passwd-entry
@@ -12,11 +12,17 @@
 # derived from this image were adding additional explict users/groups of
 # their own.
 
-if [ `id -u` -ge 100000 ]; then
+NB_UID=`id -u`
+NB_GID=`id -g`
+
+if [ $NB_UID -ge 100000 ]; then
     cat /etc/passwd | sed -e "s/^jovyan:/nayvoj:/" > /tmp/passwd
-    echo "jovyan:x:`id -u`:`id -g`:,,,:/home/jovyan:/bin/bash" >> /tmp/passwd
+    echo "jovyan:x:$NB_UID:$NB_GID:,,,:/home/jovyan:/bin/bash" >> /tmp/passwd
     cat /tmp/passwd > /etc/passwd
     rm /tmp/passwd
 
-    echo "jovyan:x:`id -u`:" >> /etc/group
+    id -G | grep -q -w $NB_UID; STATUS=$?
+    if [ $STATUS -eq 0 ]; then
+        echo "jovyan:x:$NB_UID:" >> /etc/group
+    fi
 fi


### PR DESCRIPTION
Details of the reason for this change in https://github.com/jupyter/docker-stacks/issues/552