### PR TITLE
Ensure directories/files under home directory are writable.

### DIFF
--- a/all-spark-notebook/Dockerfile
+++ b/all-spark-notebook/Dockerfile
@@ -29,17 +29,22 @@ RUN conda install --quiet --yes \
     'r-sparklyr=0.5*' \
     'r-rcurl=1.95*' && \
     conda clean -tipsy && \
-    fix-permissions $CONDA_DIR
+    fix-permissions $CONDA_DIR && \
+    fix-permissions /home/$NB_USER
 
 # Apache Toree kernel
 RUN pip install --no-cache-dir \
     https://dist.apache.org/repos/dist/dev/incubator/toree/0.2.0/snapshots/dev1/toree-pip/toree-0.2.0.dev1.tar.gz \
     && \
     jupyter toree install --sys-prefix && \
-    fix-permissions $CONDA_DIR
+    rm -rf /home/$NB_USER/.local && \
+    fix-permissions $CONDA_DIR && \
+    fix-permissions /home/$NB_USER
 
 # Spylon-kernel
 RUN conda install --quiet --yes 'spylon-kernel=0.4*' && \
     conda clean -tipsy && \
     python -m spylon_kernel install --sys-prefix && \
-    fix-permissions $CONDA_DIR
+    rm -rf /home/$NB_USER/.local && \
+    fix-permissions $CONDA_DIR && \
+    fix-permissions /home/$NB_USER

--- a/base-notebook/Dockerfile
+++ b/base-notebook/Dockerfile
@@ -71,7 +71,9 @@ RUN cd /tmp && \
     $CONDA_DIR/bin/conda config --system --set show_channel_urls true && \
     $CONDA_DIR/bin/conda update --all --quiet --yes && \
     conda clean -tipsy && \
-    fix-permissions $CONDA_DIR
+    rm -rf /home/$NB_USER/.cache/yarn && \
+    fix-permissions $CONDA_DIR && \
+    fix-permissions /home/$NB_USER
 
 # Install Jupyter Notebook and Hub
 RUN conda install --quiet --yes \
@@ -82,7 +84,9 @@ RUN conda install --quiet --yes \
     jupyter labextension install @jupyterlab/hub-extension@^0.8.0 && \
     npm cache clean && \
     rm -rf $CONDA_DIR/share/jupyter/lab/staging && \
-    fix-permissions $CONDA_DIR
+    rm -rf /home/$NB_USER/.cache/yarn && \
+    fix-permissions $CONDA_DIR && \
+    fix-permissions /home/$NB_USER
 
 USER root
 

--- a/datascience-notebook/Dockerfile
+++ b/datascience-notebook/Dockerfile
@@ -58,7 +58,8 @@ RUN conda config --system --append channels r && \
     'r-crayon=1.3*' \
     'r-randomforest=4.6*' && \
     conda clean -tipsy && \
-    fix-permissions $CONDA_DIR
+    fix-permissions $CONDA_DIR && \
+    fix-permissions /home/$NB_USER
 
 # Add Julia packages
 # Install IJulia as jovyan and then move the kernelspec out

--- a/scipy-notebook/Dockerfile
+++ b/scipy-notebook/Dockerfile
@@ -50,7 +50,10 @@ RUN conda install --quiet --yes \
     jupyter labextension install @jupyter-widgets/jupyterlab-manager@^0.33.1 && \
     npm cache clean && \
     rm -rf $CONDA_DIR/share/jupyter/lab/staging && \
-    fix-permissions $CONDA_DIR
+    rm -rf /home/$NB_USER/.cache/yarn && \
+    rm -rf /home/$NB_USER/.node-gyp && \
+    fix-permissions $CONDA_DIR && \
+    fix-permissions /home/$NB_USER
 
 # Install facets which does not have a pip or conda package at the moment
 RUN cd /tmp && \
@@ -58,7 +61,8 @@ RUN cd /tmp && \
     cd facets && \
     jupyter nbextension install facets-dist/ --sys-prefix && \
     rm -rf facets && \
-    fix-permissions $CONDA_DIR
+    fix-permissions $CONDA_DIR && \
+    fix-permissions /home/$NB_USER
 
 # Import matplotlib the first time to build the font cache.
 ENV XDG_CACHE_HOME /home/$NB_USER/.cache/

--- a/tensorflow-notebook/Dockerfile
+++ b/tensorflow-notebook/Dockerfile
@@ -9,4 +9,5 @@ RUN conda install --quiet --yes \
     'tensorflow=1.3*' \
     'keras=2.0*' && \
     conda clean -tipsy && \
-    fix-permissions $CONDA_DIR
+    fix-permissions $CONDA_DIR && \
+    fix-permissions /home/$NB_USER


### PR DESCRIPTION
For details of why the PR exists see https://github.com/jupyter/docker-stacks/issues/547

The result (for all-spark-notebook in this case) is as shown down below.

The ``matplotlib`` cache (scipy-notebook) is retained as I think that is needed to avoid recalculating font cache details. I haven't aggressively removed the whole of ``.cache``, ``.conda``, ``.config`` and ``.yarn`` in case some change comes along in base images later which does need to retain something. Better to retain and deal with removing extra files later, rather than always remove everything as then later is harder to work out why files were being removed which weren't expected to be.

```
$ ls -lasR
.:
total 40
4 drwsrwsr-x 10 jovyan users 4096 Feb 16 10:59 .
4 drwxr-xr-x 10 root   root  4096 Feb 16 10:59 ..
4 -rw-rw-r--  1 jovyan users  220 Aug 31  2015 .bash_logout
4 -rw-rw-r--  1 jovyan users 3771 Aug 31  2015 .bashrc
4 drwsrwsr-x  4 jovyan users 4096 Feb 16 10:56 .cache
4 drwsrwsr-x  3 jovyan users 4096 Feb 16 08:29 .conda
4 drwsrwsr-x  3 jovyan users 4096 Feb 16 09:25 .config
4 -rw-rw-r--  1 jovyan users  655 May 16  2017 .profile
4 drwsrwsr-x  2 jovyan users 4096 Feb 16 08:27 work
4 drwsrwsr-x  3 jovyan users 4096 Feb 16 08:38 .yarn

./.cache:
total 16
4 drwsrwsr-x  4 jovyan users 4096 Feb 16 10:56 .
4 drwsrwsr-x 10 jovyan users 4096 Feb 16 10:59 ..
4 drwsrwsr-x  3 jovyan users 4096 Feb 16 09:25 matplotlib
4 drwsrwsr-x  2 jovyan users 4096 Feb 16 10:56 pip

./.cache/matplotlib:
total 80
 4 drwsrwsr-x 3 jovyan users  4096 Feb 16 09:25 .
 4 drwsrwsr-x 4 jovyan users  4096 Feb 16 10:56 ..
68 -rw-rw-r-- 1 jovyan users 65849 Feb 16 09:25 fontList.py3k.cache
 4 drwsrwsr-x 2 jovyan users  4096 Feb 16 09:25 tex.cache

./.cache/matplotlib/tex.cache:
total 8
4 drwsrwsr-x 2 jovyan users 4096 Feb 16 09:25 .
4 drwsrwsr-x 3 jovyan users 4096 Feb 16 09:25 ..

./.cache/pip:
total 12
4 drwsrwsr-x 2 jovyan users 4096 Feb 16 10:56 .
4 drwsrwsr-x 4 jovyan users 4096 Feb 16 10:56 ..
4 -rw-rw-r-- 1 jovyan users   75 Feb 16 10:56 selfcheck.json

./.conda:
total 12
4 drwsrwsr-x  3 jovyan users 4096 Feb 16 08:29 .
4 drwsrwsr-x 10 jovyan users 4096 Feb 16 10:59 ..
4 drwsrwsr-x  2 jovyan users 4096 Feb 16 08:29 pkgs

./.conda/pkgs:
total 8
4 drwsrwsr-x 2 jovyan users 4096 Feb 16 08:29 .
4 drwsrwsr-x 3 jovyan users 4096 Feb 16 08:29 ..
0 -rw-rw-r-- 1 jovyan users    0 Feb 16 08:29 urls
0 -rw-rw-r-- 1 jovyan users    0 Feb 16 08:29 urls.txt

./.config:
total 12
4 drwsrwsr-x  3 jovyan users 4096 Feb 16 09:25 .
4 drwsrwsr-x 10 jovyan users 4096 Feb 16 10:59 ..
4 drwsrwsr-x  2 jovyan users 4096 Feb 16 09:25 matplotlib

./.config/matplotlib:
total 8
4 drwsrwsr-x 2 jovyan users 4096 Feb 16 09:25 .
4 drwsrwsr-x 3 jovyan users 4096 Feb 16 09:25 ..

./work:
total 8
4 drwsrwsr-x  2 jovyan users 4096 Feb 16 08:27 .
4 drwsrwsr-x 10 jovyan users 4096 Feb 16 10:59 ..

./.yarn:
total 12
4 drwsrwsr-x  3 jovyan users 4096 Feb 16 08:38 .
4 drwsrwsr-x 10 jovyan users 4096 Feb 16 10:59 ..
4 drwsrwsr-x  2 jovyan users 4096 Feb 16 08:38 bin

./.yarn/bin:
total 8
4 drwsrwsr-x 2 jovyan users 4096 Feb 16 08:38 .
4 drwsrwsr-x 3 jovyan users 4096 Feb 16 08:38 ..
```