### PR TITLE
Avoid placing anything under home directory in OpenShift deployments.

### DIFF
--- a/examples/openshift/README.md
+++ b/examples/openshift/README.md
@@ -133,10 +133,8 @@ You can upload notebooks and other files using the web interface of the notebook
 oc set volume dc/mynotebook --add \
       --type=pvc --claim-size=1Gi --claim-mode=ReadWriteOnce \
       --claim-name mynotebook-data --name data \
-      --mount-path /home/jovyan/work
+      --mount-path /home/jovyan
 ```
-
-When you upload any notebooks or data files, place them under the ``work`` directory.
 
 When you have deleted the notebook instance, if using a persistent volume, you will need to delete it in a separate step.
 
@@ -158,7 +156,7 @@ The ``data`` field of the config map contains Python code used as the ``jupyter_
 If you are using a persistent volume, you can also create a configuration file at:
 
 ```
-/home/jovyan/work/.jupyter/jupyter_notebook_config.py
+/home/jovyan/.jupyter/jupyter_notebook_config.py
 ```
 
 This will be merged at the end of the configuration from the config map.
@@ -207,7 +205,7 @@ This will trigger a new deployment so ensure you have downloaded any work if not
 If using a persistent volume, you could instead setup a password in the file:
 
 ```
-/home/jovyan/work/.jupyter/jupyter_notebook_config.py
+/home/jovyan/.jupyter/jupyter_notebook_config.py
 ```
 
 as per guidelines in:

--- a/examples/openshift/templates.json
+++ b/examples/openshift/templates.json
@@ -38,7 +38,7 @@
                 }
 	    },
 	    "data": {
-		"jupyter_notebook_config.py": "import os\n\npassword = os.environ.get('JUPYTER_NOTEBOOK_PASSWORD')\n\nif password:\n    import notebook.auth\n    c.NotebookApp.password = notebook.auth.passwd(password)\n    del password\n    del os.environ['JUPYTER_NOTEBOOK_PASSWORD']\n\nimage_config_file = '/home/jovyan/work/.jupyter/jupyter_notebook_config.py'\n\nif os.path.exists(image_config_file):\n    with open(image_config_file) as fp:\n        exec(compile(fp.read(), image_config_file, 'exec'), globals())\n"
+		"jupyter_notebook_config.py": "import os\n\npassword = os.environ.get('JUPYTER_NOTEBOOK_PASSWORD')\n\nif password:\n    import notebook.auth\n    c.NotebookApp.password = notebook.auth.passwd(password)\n    del password\n    del os.environ['JUPYTER_NOTEBOOK_PASSWORD']\n\nimage_config_file = '/home/jovyan/.jupyter/jupyter_notebook_config.py'\n\nif os.path.exists(image_config_file):\n    with open(image_config_file) as fp:\n        exec(compile(fp.read(), image_config_file, 'exec'), globals())\n"
 	    }
 	},
         {
@@ -81,7 +81,7 @@
                                 "image": "${NOTEBOOK_IMAGE}",
 				"command": [
 				    "start-notebook.sh",
-				    "--config=/home/jovyan/configs/jupyter_notebook_config.py",
+				    "--config=/etc/jupyter/openshift/jupyter_notebook_config.py",
 				    "--no-browser",
 				    "--ip=0.0.0.0"
 				],
@@ -100,7 +100,7 @@
                                 ],
 				"volumeMounts": [
 				    {
-					"mountPath": "/home/jovyan/configs",
+					"mountPath": "/etc/jupyter/openshift",
 					"name": "configs"
 				    }
 				]


### PR DESCRIPTION
This changes the OpenShift example so as not to place anything under the ``jovyan`` home directory. It was misunderstood that convention was that people would use ``work`` subdirectory for user files and that ``work`` directory would be where volume mounts should be added. Since mounting volumes on home directory is seen as okay, then need to make sure don't mount configuration from OpenShift under that to avoid mount conflicts.