### PR TITLE
Add entries to passwd/group if running as user not in passwd file.

### DIFF
--- a/base-notebook/Dockerfile
+++ b/base-notebook/Dockerfile
@@ -50,6 +50,7 @@ ADD fix-permissions /usr/local/bin/fix-permissions
 RUN useradd -m -s /bin/bash -N -u $NB_UID $NB_USER && \
     mkdir -p $CONDA_DIR && \
     chown $NB_USER:$NB_GID $CONDA_DIR && \
+    chmod g+w /etc/passwd /etc/group && \
     fix-permissions $HOME && \
     fix-permissions $CONDA_DIR
 

--- a/base-notebook/start.sh
+++ b/base-notebook/start.sh
@@ -67,12 +67,47 @@ if [ $(id -u) == 0 ] ; then
     echo "Executing the command: $cmd"
     exec sudo -E -H -u $NB_USER PATH=$PATH PYTHONPATH=$PYTHONPATH $cmd
 else
-    if [[ ! -z "$NB_UID" && "$NB_UID" != "$(id -u)" ]]; then
-        echo 'Container must be run as root to set $NB_UID'
+    if [[ "$NB_UID" == "$(id -u jovyan)" && "$NB_GID" == "$(id -g jovyan)" ]]; then
+        # User is not attempting to override user/group via environment
+        # variables, but they could still have overridden the uid/gid that
+        # container runs as. Check that the user has an entry in the passwd
+        # file and if not add an entry. Also add a group file entry if the
+        # uid has its own distinct group but there is no entry.
+	whoami &> /dev/null || STATUS=$? && true
+	if [[ "$STATUS" != "0" ]]; then
+            if [[ -w /etc/passwd ]]; then
+                echo "Adding passwd file entry for $(id -u)"
+                cat /etc/passwd | sed -e "s/^jovyan:/nayvoj:/" > /tmp/passwd
+                echo "jovyan:x:$(id -u):$(id -g):,,,:/home/jovyan:/bin/bash" >> /tmp/passwd
+                cat /tmp/passwd > /etc/passwd
+                rm /tmp/passwd
+                id -G -n 2>/dev/null | grep -q -w $(id -u) || STATUS=$? && true
+                if [[ "$STATUS" != "0" && "$(id -g)" == "0" ]]; then
+                    echo "Adding group file entry for $(id -u)"
+                    echo "jovyan:x:$(id -u):" >> /etc/group
+                fi
+            else
+                echo 'Container must be run with group root to update passwd file'
+            fi
+        fi
+
+        # Warn if the user isn't going to be able to write files to $HOME.
+        if [[ ! -w /home/jovyan ]]; then
+            echo 'Container must be run with group users to update files'
+        fi
+    else
+        # Warn if looks like user want to override uid/gid but hasn't
+        # run the container as root.
+        if [[ ! -z "$NB_UID" && "$NB_UID" != "$(id -u)" ]]; then
+            echo 'Container must be run as root to set $NB_UID'
+        fi
+        if [[ ! -z "$NB_GID" && "$NB_GID" != "$(id -g)" ]]; then
+            echo 'Container must be run as root to set $NB_GID'
+        fi
     fi
-    if [[ ! -z "$NB_GID" && "$NB_GID" != "$(id -g)" ]]; then
-        echo 'Container must be run as root to set $NB_GID'
-    fi
+
+    # Warn if looks like user want to run in sudo mode but hasn't run
+    # the container as root.
     if [[ "$GRANT_SUDO" == "1" || "$GRANT_SUDO" == 'yes' ]]; then
         echo 'Container must be run as root to grant sudo permissions'
     fi


### PR DESCRIPTION
Alternate PR to address https://github.com/jupyter/docker-stacks/issues/552.

See also discussion against prior PR at https://github.com/jupyter/docker-stacks/pull/553.

This PR does everything in ``start.sh`` with only other change being in ``Dockerfile`` to make passwd and group files writable by root group.