### PR TITLE
Update tidyverse to 1.2 in datascience-notebook

### DIFF
--- a/datascience-notebook/Dockerfile
+++ b/datascience-notebook/Dockerfile
@@ -46,7 +46,7 @@ RUN conda config --system --append channels r && \
     'r-irkernel=0.7*' \
     'r-plyr=1.8*' \
     'r-devtools=1.12*' \
-    'r-tidyverse=1.0*' \
+    'r-tidyverse=1.2*' \
     'r-shiny=0.14*' \
     'r-rmarkdown=1.2*' \
     'r-forecast=7.3*' \


### PR DESCRIPTION
This moves the tidyverse version forwards to 1.2.

We'd like to use this version for a jupyterhub deployment for http://openhumans.org/. Using this docker image and contributing to its upkeep is much easier than making a derivative.

cc @gedankenstuecke for questions about R version compatibility etc