### PR TITLE
Add instructions for enabling Jupyter Lab interface with OpenShift deployment.

### DIFF
--- a/examples/openshift/README.md
+++ b/examples/openshift/README.md
@@ -124,6 +124,17 @@ To delete the notebook instance, run ``oc delete`` using a label selector for th
 oc delete all,configmap --selector app=mynotebook
 ```
 
+Enabling Jupyter Lab Interface
+------------------------------
+
+To enable the Jupyter Lab interface for a deployed notebook set the ``JUPYTER_ENABLE_LAB`` environment variable.
+
+```
+oc set env dc/mynotebook JUPYTER_ENABLE_LAB=true
+```
+
+Setting the environment variable will trigger a new deployment and the Jupyter Lab interface will be enabled.
+
 Adding Persistent Storage
 -------------------------
 


### PR DESCRIPTION
This is a change to README for OpenShift example which shows how the Jupyter Lab interface can be enabled after the notebook has been deployed. There is no template parameter to set it at this point, but could consider adding it later so can optionally enable it at time of first deployment.