### PR TITLE
add r-htmltools pkg

### DIFF
--- a/r-notebook/Dockerfile
+++ b/r-notebook/Dockerfile
@@ -34,6 +34,8 @@ RUN conda install --quiet --yes \
     'r-rcurl=1.95*' \
     'r-crayon=1.3*' \
     'r-randomforest=4.6*' \
+    'r-htmltools=0.3*' \
+    'r-htmlwidgets=0.9*' \
     'r-hexbin=1.27*' && \
     conda clean -tipsy && \
     fix-permissions $CONDA_DIR


### PR DESCRIPTION
This is another conda package which is required for some tidyverse functions (specifically, `stringr::str_view`) but not included in the `r-tidyverse` metapackage. (cf #532)