### PR TITLE
Add jupyterlab_bokeh extension

### DIFF
--- a/scipy-notebook/Dockerfile
+++ b/scipy-notebook/Dockerfile
@@ -48,6 +48,7 @@ RUN conda install --quiet --yes \
     jupyter nbextension enable --py widgetsnbextension --sys-prefix && \
     # Also activate ipywidgets extension for JupyterLab
     jupyter labextension install @jupyter-widgets/jupyterlab-manager@^0.33.1 && \
+    jupyter labextension install jupyterlab_bokeh@^0.4.0 && \
     npm cache clean && \
     rm -rf $CONDA_DIR/share/jupyter/lab/staging && \
     rm -rf /home/$NB_USER/.cache/yarn && \


### PR DESCRIPTION
Without the extension it is not possible to use all Bokeh functionalities in JupyterLab