### PR TITLE
sparklyr add to r-notebook

### DIFF
--- a/r-notebook/Dockerfile
+++ b/r-notebook/Dockerfile
@@ -35,6 +35,7 @@ RUN conda install --quiet --yes \
     'r-crayon=1.3*' \
     'r-randomforest=4.6*' \
     'r-htmltools=0.3*' \
+    'r-sparklyr=0.5*' \
     'r-htmlwidgets=0.9*' \
     'r-hexbin=1.27*' && \
     conda clean -tipsy && \


### PR DESCRIPTION
sparklyr alone without any other spark package added to the install image. For user's who only use R and who want to access a spark cluster this is very useful.