### PR TITLE
Add netcat

### DIFF
--- a/minimal-notebook/Dockerfile
+++ b/minimal-notebook/Dockerfile
@@ -28,6 +28,7 @@ RUN apt-get update && apt-get install -yq --no-install-recommends \
     texlive-xetex \
     vim \
     unzip \
+    nc \
     && apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Netcat (nc) is often used as a tool to test socket server/client, 
and very useful to quickly get started with, f. e., Spark Streaming. 

See #583.