### PR TITLE
Run additional scripts in /usr/local/bin/start-notebook.d/

### DIFF
--- a/all-spark-notebook/README.md
+++ b/all-spark-notebook/README.md
@@ -16,6 +16,7 @@
 * spylon-kernel
 * Unprivileged user `jovyan` (uid=1000, configurable, see options) in group `users` (gid=100) with ownership over `/home/jovyan` and `/opt/conda`
 * [tini](https://github.com/krallin/tini) as the container entrypoint and [start-notebook.sh](../base-notebook/start-notebook.sh) as the default command
+* `/usr/local/bin/start-notebook.d` directory for custom init scripts that you can add in derived images
 * A [start-singleuser.sh](../base-notebook/start-singleuser.sh) script useful for running a single-user instance of the Notebook server, as required by JupyterHub
 * A [start.sh](../base-notebook/start.sh) script useful for running alternative commands in the container (e.g. `ipython`, `jupyter kernelgateway`, `jupyter lab`)
 * Options for a self-signed HTTPS certificate and passwordless `sudo`

--- a/base-notebook/start.sh
+++ b/base-notebook/start.sh
@@ -11,6 +11,22 @@ else
     cmd=$*
 fi
 
+for f in /usr/local/bin/start-notebook.d/*; do
+  case "$f" in
+    *.sh)
+      echo "$0: running $f"; . "$f"
+      ;;
+    *)
+      if [ -x $f ]; then
+        echo "$0: running $f"
+        $f
+      else
+        echo "$0: ignoring $f"
+      fi
+      ;;
+  esac
+  echo
+done
 # Handle special flags if we're root
 if [ $(id -u) == 0 ] ; then
 

--- a/datascience-notebook/README.md
+++ b/datascience-notebook/README.md
@@ -13,6 +13,7 @@
 * Julia v0.6.x with Gadfly, RDatasets and HDF5 pre-installed
 * Unprivileged user `jovyan` (uid=1000, configurable, see options) in group `users` (gid=100) with ownership over `/home/jovyan` and `/opt/conda`
 * [tini](https://github.com/krallin/tini) as the container entrypoint and [start-notebook.sh](../base-notebook/start-notebook.sh) as the default command
+* `/usr/local/bin/start-notebook.d` directory for custom init scripts that you can add in derived images
 * A [start-singleuser.sh](../base-notebook/start-singleuser.sh) script useful for running a single-user instance of the Notebook server, as required by JupyterHub
 * A [start.sh](../base-notebook/start.sh) script useful for running alternative commands in the container (e.g. `ipython`, `jupyter kernelgateway`, `jupyter lab`)
 * Options for a self-signed HTTPS certificate and passwordless `sudo`

--- a/minimal-notebook/README.md
+++ b/minimal-notebook/README.md
@@ -12,6 +12,7 @@ Small image for working in the notebook and installing your own libraries
 * Unprivileged user `jovyan` (uid=1000, configurable, see options) in group `users` (gid=100) with ownership over `/home/jovyan` and `/opt/conda`
 * [tini](https://github.com/krallin/tini) as the container entrypoint and [start-notebook.sh](../base-notebook/start-notebook.sh) as the default command
 * A [start-singleuser.sh](../base-notebook/start-singleuser.sh) script useful for running a single-user instance of the Notebook server, as required by JupyterHub
+* `/usr/local/bin/start-notebook.d` directory for custom init scripts that you can add in derived images
 * A [start.sh](../base-notebook/start.sh) script useful for running alternative commands in the container (e.g. `ipython`, `jupyter kernelgateway`, `jupyter lab`)
 * Options for a self-signed HTTPS certificate and passwordless `sudo`
 

--- a/pyspark-notebook/README.md
+++ b/pyspark-notebook/README.md
@@ -12,6 +12,7 @@
 * Unprivileged user `jovyan` (uid=1000, configurable, see options) in group `users` (gid=100) with ownership over `/home/jovyan` and `/opt/conda`
 * [tini](https://github.com/krallin/tini) as the container entrypoint and [start-notebook.sh](../base-notebook/start-notebook.sh) as the default command
 * A [start-singleuser.sh](../base-notebook/start-singleuser.sh) script useful for running a single-user instance of the Notebook server, as required by JupyterHub
+* `/usr/local/bin/start-notebook.d` directory for custom init scripts that you can add in derived images
 * A [start.sh](../base-notebook/start.sh) script useful for running alternative commands in the container (e.g. `ipython`, `jupyter kernelgateway`, `jupyter lab`)
 * Options for a self-signed HTTPS certificate and passwordless `sudo`
 

--- a/r-notebook/README.md
+++ b/r-notebook/README.md
@@ -10,6 +10,7 @@
 * The [tidyverse](https://github.com/tidyverse/tidyverse) R packages are also installed, including ggplot2, dplyr, tidyr, readr, purrr, tibble, stringr, lubridate, and broom
 * Unprivileged user `jovyan` (uid=1000, configurable, see options) in group `users` (gid=100) with ownership over `/home/jovyan` and `/opt/conda`
 * [tini](https://github.com/krallin/tini) as the container entrypoint and [start-notebook.sh](../base-notebook/start-notebook.sh) as the default command
+* `/usr/local/bin/start-notebook.d` directory for custom init scripts that you can add in derived images
 * A [start-singleuser.sh](../base-notebook/start-singleuser.sh) script useful for running a single-user instance of the Notebook server, as required by JupyterHub
 * A [start.sh](../base-notebook/start.sh) script useful for running alternative commands in the container (e.g. `ipython`, `jupyter kernelgateway`, `jupyter lab`)
 * Options for a self-signed HTTPS certificate and passwordless `sudo`

--- a/scipy-notebook/README.md
+++ b/scipy-notebook/README.md
@@ -9,6 +9,7 @@
 * pandas, matplotlib, scipy, seaborn, scikit-learn, scikit-image, sympy, cython, patsy, statsmodel, cloudpickle, dill, numba, bokeh, vincent, beautifulsoup, xlrd pre-installed
 * Unprivileged user `jovyan` (uid=1000, configurable, see options) in group `users` (gid=100) with ownership over `/home/jovyan` and `/opt/conda`
 * [tini](https://github.com/krallin/tini) as the container entrypoint and [start-notebook.sh](../base-notebook/start-notebook.sh) as the default command
+* `/usr/local/bin/start-notebook.d` directory for custom init scripts that you can add in derived images
 * A [start-singleuser.sh](../base-notebook/start-singleuser.sh) script useful for running a single-user instance of the Notebook server, as required by JupyterHub
 * A [start.sh](../base-notebook/start.sh) script useful for running alternative commands in the container (e.g. `ipython`, `jupyter kernelgateway`, `jupyter lab`)
 * Options for HTTPS, password auth, and passwordless `sudo`


### PR DESCRIPTION
Actual use cases can be:
- impose more restrictive ulimit
- cleanup user trash directory
- whitelist env variables (eg kubernetes service endpoint info removal)