### PR TITLE
Drop the `r` channel

### DIFF
--- a/datascience-notebook/Dockerfile
+++ b/datascience-notebook/Dockerfile
@@ -43,8 +43,7 @@ RUN mkdir /etc/julia && \
 USER $NB_UID
 
 # R packages including IRKernel which gets installed globally.
-RUN conda config --system --append channels r && \
-    conda install --quiet --yes \
+RUN conda install --quiet --yes \
     'rpy2=2.8*' \
     'r-base=3.4.1' \
     'r-irkernel=0.8*' \


### PR DESCRIPTION
The `r` channel has been considered part of `defaults` since `conda` version `4.3.0`. So it should already be taken into consideration by `conda` installs without having to explicitly add the channel. Further the `conda-forge` channel has incorporated an ever growing, healthy stack of R packages. As such it appears all of the R packages used in this stack now come from `conda-forge` and not `defaults`. Given all of this, it seems safe to drop the `r` channel from explicit addition to the channel list.

cc @parente

xref: https://github.com/conda/conda/pull/3677
xref: https://github.com/conda-forge/staged-recipes/issues/2009