### PR TITLE
Use conda-forge's blas package w/openblas

### DIFF
--- a/scipy-notebook/Dockerfile
+++ b/scipy-notebook/Dockerfile
@@ -18,7 +18,7 @@ USER $NB_UID
 # Remove pyqt and qt pulled in for matplotlib since we're only ever going to
 # use notebook-friendly backends in these images
 RUN conda install --quiet --yes \
-    'nomkl' \
+    'blas=*=openblas' \
     'ipywidgets=7.1*' \
     'pandas=0.19*' \
     'numexpr=2.6*' \


### PR DESCRIPTION
As conda-forge does not use the `nomkl` package, but instead uses the `blas` package to select BLAS versions, install the `blas` package and select the `openblas` implementation.

xref: https://github.com/jupyter/docker-stacks/pull/296