### PR TITLE
Remove the facets directory

### DIFF
--- a/scipy-notebook/Dockerfile
+++ b/scipy-notebook/Dockerfile
@@ -61,7 +61,7 @@ RUN cd /tmp && \
     git clone https://github.com/PAIR-code/facets.git && \
     cd facets && \
     jupyter nbextension install facets-dist/ --sys-prefix && \
-    rm -rf facets && \
+    rm -rf /tmp/facets && \
     fix-permissions $CONDA_DIR && \
     fix-permissions /home/$NB_USER
 


### PR DESCRIPTION
The facets directory is not truly being removed. You cd into `facets`, then install, then you have to either remove `../facets` or `/tmp/facets`.