### PR TITLE
Remove facets directory

### DIFF
--- a/scipy-notebook/Dockerfile
+++ b/scipy-notebook/Dockerfile
@@ -61,7 +61,8 @@ RUN cd /tmp && \
     git clone https://github.com/PAIR-code/facets.git && \
     cd facets && \
     jupyter nbextension install facets-dist/ --sys-prefix && \
-    rm -rf facets && \
+    cd && \
+    rm -rf /tmp/facets && \
     fix-permissions $CONDA_DIR && \
     fix-permissions /home/$NB_USER
 


### PR DESCRIPTION
The `cd` command switches to the user's home directory (away from the directory we want to delete)
Then we remove the facets directory using the full path