### PR TITLE
Update scikit libraries

### DIFF
--- a/scipy-notebook/Dockerfile
+++ b/scipy-notebook/Dockerfile
@@ -26,7 +26,7 @@ RUN conda install --quiet --yes \
     'scipy=0.19*' \
     'seaborn=0.7*' \
     'scikit-learn=0.19*' \
-    'scikit-image=0.12*' \
+    'scikit-image=0.13*' \
     'sympy=1.0*' \
     'cython=0.25*' \
     'patsy=0.4*' \

--- a/scipy-notebook/Dockerfile
+++ b/scipy-notebook/Dockerfile
@@ -25,7 +25,7 @@ RUN conda install --quiet --yes \
     'matplotlib=2.0*' \
     'scipy=0.19*' \
     'seaborn=0.7*' \
-    'scikit-learn=0.18*' \
+    'scikit-learn=0.19*' \
     'scikit-image=0.12*' \
     'sympy=1.0*' \
     'cython=0.25*' \


### PR DESCRIPTION
Update libraries in **scipy-notebook**:
* `scikit-learn=0.19*` [release notes](http://scikit-learn.org/stable/whats_new.html#version-0-19-1)
* `scikit-image=0.13*` [release notes](https://github.com/scikit-image/scikit-image/blob/master/doc/release/release_0.13.rst)

(follow up on issue https://github.com/jupyter/docker-stacks/issues/612)