### PR TITLE
Update jupyterlab and extensions

### DIFF
--- a/base-notebook/Dockerfile
+++ b/base-notebook/Dockerfile
@@ -80,9 +80,9 @@ RUN cd /tmp && \
 RUN conda install --quiet --yes \
     'notebook=5.4.*' \
     'jupyterhub=0.8.*' \
-    'jupyterlab=0.31.*' && \
+    'jupyterlab=0.32.*' && \
     conda clean -tipsy && \
-    jupyter labextension install @jupyterlab/hub-extension@^0.8.0 && \
+    jupyter labextension install @jupyterlab/hub-extension@^0.8.1 && \
     npm cache clean --force && \
     rm -rf $CONDA_DIR/share/jupyter/lab/staging && \
     rm -rf /home/$NB_USER/.cache/yarn && \

--- a/scipy-notebook/Dockerfile
+++ b/scipy-notebook/Dockerfile
@@ -47,8 +47,8 @@ RUN conda install --quiet --yes \
     # Activate ipywidgets extension in the environment that runs the notebook server
     jupyter nbextension enable --py widgetsnbextension --sys-prefix && \
     # Also activate ipywidgets extension for JupyterLab
-    jupyter labextension install @jupyter-widgets/jupyterlab-manager@^0.33.1 && \
-    jupyter labextension install jupyterlab_bokeh@^0.4.0 && \
+    jupyter labextension install @jupyter-widgets/jupyterlab-manager@^0.35 && \
+    jupyter labextension install jupyterlab_bokeh@^0.5.0 && \
     npm cache clean --force && \
     rm -rf $CONDA_DIR/share/jupyter/lab/staging && \
     rm -rf /home/$NB_USER/.cache/yarn && \


### PR DESCRIPTION
Update jupyterlab from 0.31 to 0.32.

Update the following extensions to matching versions:
- jupyterlab/hub-extension
- jupyter-widget/jupyterlab-manager
- jupyterlab_bokeh

fix #620 