### PR TITLE
Start jupyter-labhub instead of jupyter labhub

### DIFF
--- a/base-notebook/start-singleuser.sh
+++ b/base-notebook/start-singleuser.sh
@@ -35,7 +35,7 @@ if [ ! -z "$JPY_HUB_API_URL" ]; then
   NOTEBOOK_ARGS="--hub-api-url=$JPY_HUB_API_URL $NOTEBOOK_ARGS"
 fi
 if [ ! -z "$JUPYTER_ENABLE_LAB" ]; then
-  NOTEBOOK_BIN="jupyter labhub"
+  NOTEBOOK_BIN="jupyter-labhub"
 else
   NOTEBOOK_BIN=jupyterhub-singleuser
 fi


### PR DESCRIPTION
jupyter labhub lacks the hub menu in the top bar