### PR TITLE
Added missing conda clean to pyspark-notebook Dockerfile

### DIFF
--- a/pyspark-notebook/Dockerfile
+++ b/pyspark-notebook/Dockerfile
@@ -43,5 +43,6 @@ USER $NB_UID
 
 # Install pyarrow
 RUN conda install --quiet -y 'pyarrow' && \
+    conda clean -tipsy && \
     fix-permissions $CONDA_DIR && \
     fix-permissions /home/$NB_USER


### PR DESCRIPTION
Added conda clean to pyspark-notebook Dockerfile. Addresses #627.

Building locally, this reduces the image size from 5.16GB -> 5.08GB (~80 MB).