### PR TITLE
Don't chown -R a user's home directory

### DIFF
--- a/base-notebook/start.sh
+++ b/base-notebook/start.sh
@@ -40,7 +40,7 @@ if [ $(id -u) == 0 ] ; then
     # Ex: default NFS/EFS (no auto-uid/gid)
     if [[ "$CHOWN_HOME" == "1" || "$CHOWN_HOME" == 'yes' ]]; then
         echo "Changing ownership of /home/$NB_USER to $NB_UID:$NB_GID"
-        chown -R $NB_UID:$NB_GID /home/$NB_USER
+        chown $NB_UID:$NB_GID /home/$NB_USER
     fi
 
     # handle home and working directory if the username changed

--- a/base-notebook/start.sh
+++ b/base-notebook/start.sh
@@ -40,11 +40,11 @@ if [ $(id -u) == 0 ] ; then
     # Ex: default NFS/EFS (no auto-uid/gid)
     if [[ "$CHOWN_HOME" == "1" || "$CHOWN_HOME" == 'yes' ]]; then
         echo "Changing ownership of /home/$NB_USER to $NB_UID:$NB_GID"
-        chown $NB_UID:$NB_GID /home/$NB_USER
+        chown $CHOWN_HOME_OPTS $NB_UID:$NB_GID /home/$NB_USER
     fi
     if [ ! -z "$CHOWN_EXTRA" ]; then
         for extra_dir in $(echo $CHOWN_EXTRA | tr ',' ' '); do
-            chown $NB_UID:$NB_GID $extra_dir
+            chown $CHOWN_EXTRA_OPTS $NB_UID:$NB_GID $extra_dir
         done
     fi
 

--- a/base-notebook/start.sh
+++ b/base-notebook/start.sh
@@ -42,6 +42,11 @@ if [ $(id -u) == 0 ] ; then
         echo "Changing ownership of /home/$NB_USER to $NB_UID:$NB_GID"
         chown $NB_UID:$NB_GID /home/$NB_USER
     fi
+    if [ ! -z "$CHOWN_EXTRA" ]; then
+        for extra_dir in $(echo $CHOWN_EXTRA | tr ',' ' '); do
+            chown $NB_UID:$NB_GID $extra_dir
+        done
+    fi
 
     # handle home and working directory if the username changed
     if [[ "$NB_USER" != "jovyan" ]]; then


### PR DESCRIPTION
Only the top level permissions are set wrong due to kubernetes not being able to do this automatically.

This hits significant problems when the chown takes more than 30s and the pod fails to start