### PR TITLE
Continued work on contributor doc

### DIFF
--- a/docs/contributing/features.md
+++ b/docs/contributing/features.md
@@ -1,6 +1,6 @@
 # New Features
 
-Thank you for contributing to docker-stacks! We review pull requests of new features (e.g., new packages, new scripts, new flags) to balance the value of the images to the Jupyter community with the cost of maintaining the images over time.
+Thank you for contributing to the Jupyter Docker Stacks! We review pull requests of new features (e.g., new packages, new scripts, new flags) to balance the value of the images to the Jupyter community with the cost of maintaining the images over time.
 
 ## Suggesting a New Feature
 

--- a/docs/contributing/packages.md
+++ b/docs/contributing/packages.md
@@ -1,12 +1,12 @@
 # Package Updates
 
-We are actively seeking pull requests which update packages already included in the project Dockerfiles. This is a great way for first-time contributors to participate in developing docker-stacks.
+We actively seek pull requests which update packages already included in the project Dockerfiles. This is a great way for first-time contributors to participate in developing the Jupyter Docker Stacks.
 
 Please follow the process below to update a package version:
 
 1. Locate the Dockerfile containing the library you wish to update (e.g., [base-notebook/Dockerfile](https://github.com/jupyter/docker-stacks/blob/master/base-notebook/Dockerfile), [scipy-notebook/Dockerfile](https://github.com/jupyter/docker-stacks/blob/master/scipy-notebook/Dockerfile))
-2. Adjust the version number for the package. We prefer to pin the major and minor version number of packages so as to minimize rebuild side-effects when users submit pull requests (PRs). For example, you'll find the Jupyter Notebook package, `notebook`, installed using conda with  `notebook=5.4.*`.
-3.  Please build the image locally before submitting a pull request. Building the image locally shortens the debugging cycle by taking some load off [Travis CI](http://travis-ci.org/), which graciously provides free build services for open source projects like this one.  If you use `make`, call:
+2. Adjust the version number for the package. We prefer to pin the major and minor version number of packages so as to minimize rebuild side-effects when users submit pull requests (PRs). For example, you'll find the Jupyter Notebook package, `notebook`, installed using conda with `notebook=5.4.*`.
+3. Please build the image locally before submitting a pull request. Building the image locally shortens the debugging cycle by taking some load off [Travis CI](http://travis-ci.org/), which graciously provides free build services for open source projects like this one. If you use `make`, call:
 ```
 make image/somestack-notebook
 ```

--- a/docs/contributing/stacks.md
+++ b/docs/contributing/stacks.md
@@ -1,1 +1,70 @@
 # Community Stacks
+
+We love to see the community create and share new Jupyter Docker images. We've created a [cookiecutter project](https://github.com/jupyter/cookiecutter-docker-stacks) and the documentation below as one way to get started defining, building, and sharing your Jupyter environments in Docker. If you choose to follow these steps, you will:
+
+1. Setup a project on GitHub containing a Dockerfile based on either the `jupyter/base-notebook` or `jupyter/minimal-notebook` image.
+2. Configure Travis CI to build and test your image when users submit pull requests to your repository.
+3. Configure Docker Cloud to build and host your images for others to use.
+4. Update the [list of community stacks](../using/selecting.html#community-stacks) in this documentation to include your image.
+
+This approach mirrors how we build and share the core stack images. Again, it just one of many approaches you might choose to take to share your creations.
+
+## Creating a Project
+
+First, install [cookiecutter](https://github.com/audreyr/cookiecutter) using pip or conda:
+
+```
+pip install cookiecutter   # or conda install cookiecutter
+```
+
+Run the cookiecutter command pointing to the [jupyter/cookiecutter-docker-stacks](https://github.com/jupyter/cookiecutter-docker-stacks) project on GitHub.
+
+```
+cookiecutter https://github.com/jupyter/cookiecutter-docker-stacks.git
+```
+
+Enter a name for your new stack image. This will serve as both the git repository
+name and the part of the Docker image name after the slash.
+
+```
+stack_name [my-jupyter-stack]:
+```
+
+Enter the user or organization name under which this stack will reside on
+Docker Cloud / Hub. You must have access to manage this Docker Cloud org in
+order to push images here and setup automated builds.
+
+```
+stack_org [my-project]:
+```
+
+Select an image from the jupyter/docker-stacks project that will serve as the
+base for your new image.
+
+```
+stack_base_image [jupyter/base-notebook]:
+```
+
+Enter a longer description of the stack for your README.
+
+```
+stack_description [my-jupyter-stack is a community maintained Jupyter Docker Stack image]:
+```
+
+Initialize your project as a Git repository and push it to GitHub.
+
+```
+cd <stack_name you chose>
+
+git init
+git add .
+git commit -m 'Seed repo'
+git remote add origin <url from github>
+git push -u origin master
+```
+
+## Configuring Travis
+
+## Configuring Docker Cloud
+
+## Sharing Your Image

--- a/docs/contributing/tests.md
+++ b/docs/contributing/tests.md
@@ -1,1 +1,22 @@
 # Image Tests
+
+We greatly appreciate pull requests that extend the automated tests that vet the basic functionality of the Docker images.
+
+## How the Tests Work
+
+Travis executes `make build-test-all` against every pull request submitted to the `jupyter/docker-stacks` repository. The `make` command builds every docker image. After building each image, the `make` command executes `pytest` to run both image-specific tests like those in [base-notebook/test/](https://github.com/jupyter/docker-stacks/tree/master/base-notebook/test) and common tests defined in [test/](https://github.com/jupyter/docker-stacks/tree/master/test). Both kinds of tests make use of global [pytest fixtures](https://docs.pytest.org/en/latest/fixture.html) defined in the [conftest.py](https://github.com/jupyter/docker-stacks/blob/master/conftest.py) file at the root of the projects.
+
+## Contributing New Tests
+
+Please follow the process below to add new tests:
+
+1. If the test should run against every image built, add your test code to one of the modules in [test/](https://github.com/jupyter/docker-stacks/tree/master/test) or create a new module.
+2. If your test should run against a single image, add your test code to one of the modules in `some-notebook/test/` or create a new module.
+3. Build one or more images you intend to test and run the tests locally. If you use `make`, call:
+```
+make image/somestack-notebook
+make test/somestack-notebook
+```
+4. [Submit a pull request](https://github.com/PointCloudLibrary/pcl/wiki/A-step-by-step-guide-on-preparing-and-submitting-a-pull-request) (PR) with your changes.
+5. Watch for Travis to report a build success or failure for your PR on GitHub.
+6. Discuss changes with the maintainers and address any issues running the tests on Travis.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -38,9 +38,9 @@ Table of Contents
    :caption: Contributor Guide
 
    contributing/packages
-   contributing/features
    contributing/recipes
    contributing/tests
+   contributing/features
    contributing/stacks
 
 .. toctree::


### PR DESCRIPTION
Work on test and community stack sections. The latter coincides with https://github.com/jupyter/cookiecutter-docker-stacks which will ultimately point to http://jupyter-docker-stacks.readthedocs.io/en/latest/contributing/stacks.html for instructions about how to use it. 