### PR TITLE
Use `MatchSpec` to force `blas` from `conda-forge`

### DIFF
--- a/scipy-notebook/Dockerfile
+++ b/scipy-notebook/Dockerfile
@@ -18,7 +18,7 @@ USER $NB_UID
 # Remove pyqt and qt pulled in for matplotlib since we're only ever going to
 # use notebook-friendly backends in these images
 RUN conda install --quiet --yes \
-    'blas=1.1*=openblas' \
+    'conda-forge::blas=*=openblas' \
     'ipywidgets=7.2*' \
     'pandas=0.22*' \
     'numexpr=2.6*' \


### PR DESCRIPTION
As it appears that `defaults` has added `blas` without a feature, the `conda` solver appears to be prioritizing the removal of features over channel priority. As a result, we leverage `MatchSpec` here to pin the `blas` package to `conda-forge` and the `openblas` feature. This should be respected by `conda` and thus avoid switching to the incompatible `blas` package from `defaults`.