### PR TITLE
Remove writable group file due to issues with being able to give su access when shouldn't be allowed.

### DIFF
--- a/base-notebook/Dockerfile
+++ b/base-notebook/Dockerfile
@@ -50,7 +50,7 @@ ADD fix-permissions /usr/local/bin/fix-permissions
 RUN useradd -m -s /bin/bash -N -u $NB_UID $NB_USER && \
     mkdir -p $CONDA_DIR && \
     chown $NB_USER:$NB_GID $CONDA_DIR && \
-    chmod g+w /etc/passwd /etc/group && \
+    chmod g+w /etc/passwd && \
     fix-permissions $HOME && \
     fix-permissions $CONDA_DIR
 

--- a/base-notebook/start.sh
+++ b/base-notebook/start.sh
@@ -94,8 +94,7 @@ else
         # User is not attempting to override user/group via environment
         # variables, but they could still have overridden the uid/gid that
         # container runs as. Check that the user has an entry in the passwd
-        # file and if not add an entry. Also add a group file entry if the
-        # uid has its own distinct group but there is no entry.
+        # file and if not add an entry.
         whoami &> /dev/null || STATUS=$? && true
         if [[ "$STATUS" != "0" ]]; then
             if [[ -w /etc/passwd ]]; then
@@ -104,11 +103,6 @@ else
                 echo "jovyan:x:$(id -u):$(id -g):,,,:/home/jovyan:/bin/bash" >> /tmp/passwd
                 cat /tmp/passwd > /etc/passwd
                 rm /tmp/passwd
-                id -G -n 2>/dev/null | grep -q -w $(id -u) || STATUS=$? && true
-                if [[ "$STATUS" != "0" && "$(id -g)" == "0" ]]; then
-                    echo "Adding group file entry for $(id -u)"
-                    echo "jovyan:x:$(id -u):" >> /etc/group
-                fi
             else
                 echo 'Container must be run with group "root" to update passwd file'
             fi


### PR DESCRIPTION
This change is to revert making the ``/etc/group`` file writable as part solution to avoid issues as discussed in https://github.com/jupyter/docker-stacks/issues/560.

Although it means in environment where container run as group ID not in ``/etc/groups`` you will get a warning:

```
groups: cannot find name for group ID 100000
```

in certain situations when creating an interactive shell in the container, there is no known Python packages or applications which will fail if running with a group ID not in ``/etc/group``.

With the ``/etc/group`` file once again not writable, as part of https://github.com/jupyter/docker-stacks/issues/560 can then work out whether restricting ``su`` to members of ``wheel`` group can be done and lock down ``su`` for normal case.