### PR TITLE
Lock down ability to run su command.

### DIFF
--- a/base-notebook/Dockerfile
+++ b/base-notebook/Dockerfile
@@ -50,7 +50,7 @@ ADD fix-permissions /usr/local/bin/fix-permissions
 RUN useradd -m -s /bin/bash -N -u $NB_UID $NB_USER && \
     mkdir -p $CONDA_DIR && \
     chown $NB_USER:$NB_GID $CONDA_DIR && \
-    chmod g+w /etc/passwd /etc/group && \
+    chmod g+w /etc/passwd && \
     fix-permissions $HOME && \
     fix-permissions $CONDA_DIR
 

--- a/base-notebook/Dockerfile
+++ b/base-notebook/Dockerfile
@@ -47,7 +47,9 @@ ENV PATH=$CONDA_DIR/bin:$PATH \
 ADD fix-permissions /usr/local/bin/fix-permissions
 # Create jovyan user with UID=1000 and in the 'users' group
 # and make sure these dirs are writable by the `users` group.
-RUN useradd -m -s /bin/bash -N -u $NB_UID $NB_USER && \
+RUN groupadd wheel -g 11 && \
+    echo "auth required pam_wheel.so use_uid" >> /etc/pam.d/su && \
+    useradd -m -s /bin/bash -N -u $NB_UID $NB_USER && \
     mkdir -p $CONDA_DIR && \
     chown $NB_USER:$NB_GID $CONDA_DIR && \
     chmod g+w /etc/passwd && \

--- a/base-notebook/start.sh
+++ b/base-notebook/start.sh
@@ -94,8 +94,7 @@ else
         # User is not attempting to override user/group via environment
         # variables, but they could still have overridden the uid/gid that
         # container runs as. Check that the user has an entry in the passwd
-        # file and if not add an entry. Also add a group file entry if the
-        # uid has its own distinct group but there is no entry.
+        # file and if not add an entry.
         whoami &> /dev/null || STATUS=$? && true
         if [[ "$STATUS" != "0" ]]; then
             if [[ -w /etc/passwd ]]; then
@@ -104,11 +103,6 @@ else
                 echo "jovyan:x:$(id -u):$(id -g):,,,:/home/jovyan:/bin/bash" >> /tmp/passwd
                 cat /tmp/passwd > /etc/passwd
                 rm /tmp/passwd
-                id -G -n 2>/dev/null | grep -q -w $(id -u) || STATUS=$? && true
-                if [[ "$STATUS" != "0" && "$(id -g)" == "0" ]]; then
-                    echo "Adding group file entry for $(id -u)"
-                    echo "jovyan:x:$(id -u):" >> /etc/group
-                fi
             else
                 echo 'Container must be run with group "root" to update passwd file'
             fi


### PR DESCRIPTION
This change enables ``pam_wheel`` so that execution of ``su`` can be restricted to just the ``root`` user or any users in the ``wheel`` group. By default, no users would be in the ``wheel`` group, so only the ``root`` user can execute ``su``. It is believed this will not interfere with ``sudo`` mechanism used by the image.

This is being done to partly address issues raised in https://github.com/jupyter/docker-stacks/issues/560 as raised by @minrk.

It should eliminate the current problem that when running as a random user ID which is not in the ``/etc/passwd`` file, and ``setuid`` capabilities has not been dropped for the container, that the user can run ``su`` by adding a password for a target user, by virtue of being placed in the ``root`` group as fallback when user ID has no group.

The reason ``/etc/passwd`` file is writable to ``root`` group in the first place was due to the need to add an entry into the file when being run as a random user ID. Without it, Jupyter notebooks or third party packages it relies on, can fail due to the lack of the entry.

Write access to ``/etc/group`` by members of the ``root`` group is also dropped by this change because leaving that would mean they would have been able to add themselves to the ``wheel`` group and give themselves the ability to run ``su`` still.

Write access to ``/etc/group`` wasn't essential. Adding group entries for random primary group ID running eliminated warning messages from interactive shells created, but lack of the group entry is not known to cause Jupyter notebooks or any other Python package to fail.

Presuming no one can see any other avenues for still running ``su``, and this doesn't interfere with use of ``sudo``, this change is necessary before consideration can be given for changing ``NB_GID`` to group ID ``0`` instead or ``100``. The later point of changing ``NB_GID`` being to allow image to be run as random user ID, without still needing to add group ID ``100`` as a supplemental group for the container.