### PR TITLE
Fix typo - Juptyer

### DIFF
--- a/docs/using/recipes.md
+++ b/docs/using/recipes.md
@@ -121,7 +121,7 @@ If you are mounting a host directory as `/home/jovyan/work` in your container an
 
 Ref: [https://github.com/jupyter/docker-stacks/issues/199](https://github.com/jupyter/docker-stacks/issues/199)
 
-## JuptyerHub
+## JupyterHub
 
 We also have contributed recipes for using JupyterHub.
 


### PR DESCRIPTION
Found a typo at http://jupyter-docker-stacks.readthedocs.io/en/latest/using/recipes.html#juptyerhub, `juptyer` should be `jupyter`