### PR TITLE
Adds config file initialization to the base image

### DIFF
--- a/base-notebook/Dockerfile
+++ b/base-notebook/Dockerfile
@@ -92,6 +92,9 @@ RUN conda install --quiet --yes \
     fix-permissions $CONDA_DIR && \
     fix-permissions /home/$NB_USER
 
+# Initialize configuration file
+RUN jupyter notebook --generate-config
+
 USER root
 
 EXPOSE 8888


### PR DESCRIPTION
Adds the initial creation of the configuration file jupyter_notebook_config.json to the image by running the generate-config command provided by jupyter notebook. This file was missing as reported in issue #639 and caused an error when trying to set a new password via the Web interface.