### PR TITLE
Adds config file initialization and updates Apache Mirror due to timeout issue

### DIFF
--- a/base-notebook/Dockerfile
+++ b/base-notebook/Dockerfile
@@ -79,14 +79,20 @@ RUN cd /tmp && \
     fix-permissions $CONDA_DIR && \
     fix-permissions /home/$NB_USER
 
-# Install Jupyter Notebook and Hub
+# Install Jupyter Notebook, Lab, and Hub
+# Generate a notebook server config
+# Cleanup temporary files
+# Correct permissions
+# Do all this in a single RUN command to avoid duplicating all of the
+# files across image layers when the permissions change
 RUN conda install --quiet --yes \
-    'notebook=5.5.*' \
+    'notebook=5.6.*' \
     'jupyterhub=0.8.*' \
     'jupyterlab=0.32.*' && \
     conda clean -tipsy && \
     jupyter labextension install @jupyterlab/hub-extension@^0.8.1 && \
     npm cache clean --force && \
+    jupyter notebook --generate-config && \
     rm -rf $CONDA_DIR/share/jupyter/lab/staging && \
     rm -rf /home/$NB_USER/.cache/yarn && \
     fix-permissions $CONDA_DIR && \

--- a/pyspark-notebook/Dockerfile
+++ b/pyspark-notebook/Dockerfile
@@ -16,7 +16,7 @@ RUN apt-get -y update && \
     rm -rf /var/lib/apt/lists/*
 
 RUN cd /tmp && \
-        wget -q http://apache.claz.org/spark/spark-${APACHE_SPARK_VERSION}/spark-${APACHE_SPARK_VERSION}-bin-hadoop${HADOOP_VERSION}.tgz && \
+        wget -q http://mirrors.ukfast.co.uk/sites/ftp.apache.org/spark/spark-${APACHE_SPARK_VERSION}/spark-${APACHE_SPARK_VERSION}-bin-hadoop${HADOOP_VERSION}.tgz && \
         echo "DC3A97F3D99791D363E4F70A622B84D6E313BD852F6FDBC777D31EAB44CBC112CEEAA20F7BF835492FB654F48AE57E9969F93D3B0E6EC92076D1C5E1B40B4696 *spark-${APACHE_SPARK_VERSION}-bin-hadoop${HADOOP_VERSION}.tgz" | sha512sum -c - && \
         tar xzf spark-${APACHE_SPARK_VERSION}-bin-hadoop${HADOOP_VERSION}.tgz -C /usr/local --owner root --group root --no-same-owner && \
         rm spark-${APACHE_SPARK_VERSION}-bin-hadoop${HADOOP_VERSION}.tgz


### PR DESCRIPTION
As described in issue #639, the config file is not created within the base image. As a result, setting the password in the Web interface after launching the container fails because the file cannot be found. This fix creates a default config file by running the appropriate command in a dedicated step.

When building this image, the build failed due to a timeout of the download of the Spark libraries. The Apache Mirror that was used for downloading was too slow and took more than 18min, which caused the build process to terminate after hitting the 10min timeout. I replaced it with a different official Apache Mirror that is already used in the recipes. I encourage the use of only one mirror in the whole project or fetch the closest mirror in the docker file like this:

```
curl 'https://www.apache.org/dyn/closer.cgi' |
  grep -o '<strong>[^<]*</strong>' |
  sed 's/<[^>]*>//g' |
  head -1
```