### PR TITLE
Fixed README, Jupyter Lab launch sample command

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ The [User Guide on ReadTheDocs](http://jupyter-docker-stacks.readthedocs.io/) de
 
     docker run -p 8888:8888 jupyter/scipy-notebook:2c80cf3537ca
 
-**Example 2:** This command pulls the `jupyter/datascience-notebook` image tagged `e5c5a7d3e52d` from Docker Hub if it is not already present on the local host. It then starts an *ephemeral* container running a Jupyter Notebook server and exposes the server on host port 10000. The command mounts the current working directory on the host as `/home/jovyan/work` in the container. The server logs appear in the terminal. Visiting `http://<hostname>:10000/?token=<token>` in a browser loads JupyterLab, where `hostname` is the name of the computer running docker and `token` is the secret token printed in the console. Docker destroys the container after notebook server exit, but any files written to `~/work` in the container remain intact on the host.
+**Example 2:** This command pulls the `jupyter/datascience-notebook` image tagged `3772fffc4aa4` from Docker Hub if it is not already present on the local host. It then starts an *ephemeral* container running a Jupyter Notebook server and exposes the server on host port 10000. The command mounts the current working directory on the host as `/home/jovyan/work` in the container. The server logs appear in the terminal. Visiting `http://<hostname>:10000/?token=<token>` in a browser loads JupyterLab, where `hostname` is the name of the computer running docker and `token` is the secret token printed in the console. Docker destroys the container after notebook server exit, but any files written to `~/work` in the container remain intact on the host.
 
-    docker run --rm -p 10000:8888 -e JUPYTER_LAB_ENABLE=yes -v "$PWD":/home/jovyan/work jupyter/datascience-notebook:e5c5a7d3e52d
+    docker run --rm -p 10000:8888 -e JUPYTER_ENABLE_LAB=yes -v "$PWD":/home/jovyan/work jupyter/datascience-notebook:3772fffc4aa4
 
 ## Contributing
 


### PR DESCRIPTION
Fixed JupyterLab launch sample command options. Option name and image version was wrong