### PR TITLE
Change XDG_CACHE_HOME when using NB_USER

### DIFF
--- a/base-notebook/start.sh
+++ b/base-notebook/start.sh
@@ -89,7 +89,7 @@ if [ $(id -u) == 0 ] ; then
     # Exec the command as NB_USER with the PATH and the rest of
     # the environment preserved
     echo "Executing the command: $cmd"
-    exec sudo -E -H -u $NB_USER PATH=$PATH PYTHONPATH=$PYTHONPATH $cmd
+    exec sudo -E -H -u $NB_USER PATH=$PATH XDG_CACHE_HOME=/home/$NB_USER/.cache PYTHONPATH=$PYTHONPATH $cmd
 else
     if [[ "$NB_UID" == "$(id -u jovyan)" && "$NB_GID" == "$(id -g jovyan)" ]]; then
         # User is not attempting to override user/group via environment


### PR DESCRIPTION
`pip` uses the directory `$XDG_CACHE_HOME/pip` for caching. If this directory exists and is writeable, all downloads are cached there, and pip will attempt to [build and cache a wheel for every package it installs](https://packaging.python.org/tutorials/installing-packages/#source-distributions-vs-wheels).

By default, `$XDG_CACHE_HOME` points to `/home/jovyan/.cache` and is not changed when `$NB_USER` is set. As a consequence, `pip` cannot cache downloads or wheels:

    sudo docker run --rm --name condatest --user root -e NB_USER=$(whoami) -e NB_GROUP=$(id -ng) -e NB_UID=$(id -u) -e NB_GID=$(id -g) -p 8888:8888 -v work:$HOME/jupyterhub jupyter/scipy-notebook:621b96ed75cb start.sh pip install librosa

prints

    [...]
    Executing the command: pip install librosa
    The directory '/home/jovyan/.cache/pip/http' or its parent directory is not owned by the current user and the cache has been disabled. Please check the permissions and owner of that directory. If executing pip with sudo, you may want sudo's -H flag.
    The directory '/home/jovyan/.cache/pip' or its parent directory is not owned by the current user and caching wheels has been disabled. check the permissions and owner of that directory. If executing pip with sudo, you may want sudo's -H flag.
    [...]
    Installing collected packages: audioread, joblib, resampy, librosa
      Running setup.py install for audioread: started
        Running setup.py install for audioread: finished with status 'done'
    [...]

However if this value is changed, i.e. using the option `-e XDG_CACHE_HOME=/home/$(whoami)/.cache/`

    sudo docker run --rm --name condatest --user root -e XDG_CACHE_HOME=/home/$(whoami)/.cache/ -e NB_USER=$(whoami) -e NB_GROUP=$(id -ng) -e NB_UID=$(id -u) -e NB_GID=$(id -g) -p 8888:8888 -v work:$HOME/jupyterhub jupyter/scipy-notebook:621b96ed75cb start.sh pip install librosa

The warning disappears and `pip` builds and caches wheels, as it should

    Executing the command: pip install librosa
    [...]
    Building wheels for collected packages: librosa, audioread, resampy
      Running setup.py bdist_wheel for librosa: started
      Running setup.py bdist_wheel for librosa: finished with status 'done'
      Stored in directory: /home/nwerner/.cache/pip/wheels/e7/58/3a/820767c35a26cdb7e9d70971454fc6e072524aa4edc934f710
    [...]

This PR changes the value of `$XDG_CACHE_HOME` in `start.sh` when `$NB_USER` is set.