### PR TITLE
Add a posibliity for a pre-start hook

### DIFF
--- a/base-notebook/start.sh
+++ b/base-notebook/start.sh
@@ -89,6 +89,7 @@ if [ $(id -u) == 0 ] ; then
 
     # Exec the command as NB_USER with the PATH and the rest of
     # the environment preserved
+    eval "$NB_PRE_START_HOOK"
     echo "Executing the command: $cmd"
     exec sudo -E -H -u $NB_USER PATH=$PATH XDG_CACHE_HOME=/home/$NB_USER/.cache PYTHONPATH=$PYTHONPATH $cmd
 else
@@ -133,5 +134,6 @@ else
 
     # Execute the command
     echo "Executing the command: $cmd"
+    eval "$NB_PRE_START_HOOK"
     exec $cmd
 fi

--- a/base-notebook/start.sh
+++ b/base-notebook/start.sh
@@ -11,22 +11,33 @@ else
     cmd=$*
 fi
 
-for f in /usr/local/bin/start-notebook.d/*; do
-  case "$f" in
-    *.sh)
-      echo "$0: running $f"; . "$f"
-      ;;
-    *)
-      if [ -x $f ]; then
-        echo "$0: running $f"
-        $f
-      else
-        echo "$0: ignoring $f"
-      fi
-      ;;
-  esac
-  echo
-done
+run-hooks () {
+    # Source scripts or run executable files in a directory
+    if [[ ! -d "$1" ]] ; then
+	return
+    fi
+    echo "$0: running hooks in $1"
+    for f in "$1"/*; do
+	case "$f" in
+	    *.sh)
+		echo "$0: running $f"
+		source "$f"
+		;;
+	    *)
+		if [[ -x "$f" ]] ; then
+		    echo "$0: running $f"
+		    "$f"
+		else
+		    echo "$0: ignoring $f"
+		fi
+		;;
+	esac
+    echo "$0: done running hooks in $1"
+    done
+}
+
+run-hooks /usr/local/bin/start-notebook.d
+
 # Handle special flags if we're root
 if [ $(id -u) == 0 ] ; then
 
@@ -89,7 +100,7 @@ if [ $(id -u) == 0 ] ; then
 
     # Exec the command as NB_USER with the PATH and the rest of
     # the environment preserved
-    eval "$NB_PRE_START_HOOK"
+    run-hooks /usr/local/bin/before-notebook.d
     echo "Executing the command: $cmd"
     exec sudo -E -H -u $NB_USER PATH=$PATH XDG_CACHE_HOME=/home/$NB_USER/.cache PYTHONPATH=$PYTHONPATH $cmd
 else
@@ -133,7 +144,7 @@ else
     fi
 
     # Execute the command
+    run-hooks /usr/local/bin/before-notebook.d
     echo "Executing the command: $cmd"
-    eval "$NB_PRE_START_HOOK"
     exec $cmd
 fi


### PR DESCRIPTION
I had to add some hooks to the end of `start.sh` in order to hack some custom image configuration (in this case, it was some stuff that had to be done after the users got set up).  It could also be used for debugging (which would have been quite useful for me a month ago).

This is a little bit of a hackish solution, but it seems that the problem is so minimal now that it's not worth making a more heavyweight solution.  But if this is deemed useful, I can improve some more.

Still possibly needs tests.

---
- The start.sh script does different operations on users, and
  sometimes one may need to do operations *after* that is done (as
  opposed to /usr/local/bin/start-notebook.d/ which is run before).
  This provides that possibility.  (One use case is hooks which must
  be run after the users are set up.)
- To be technically perfect, one might want to use something similar
  to /usr/local/bin/pre-start-notebook.d/.  But let's start with the
  simplest thing possible for now - the expected use of this command
  is only if people use NB_USER, etc in a way that requires small
  follow up commands to be run.
- If notebook is running as root, this allows users to run arbitrary
  commands pre-sudo.  Consider security model.