### PR TITLE
Update jupyterlab & extensions

### DIFF
--- a/base-notebook/Dockerfile
+++ b/base-notebook/Dockerfile
@@ -89,9 +89,9 @@ RUN conda install --quiet --yes 'tini=0.18.0' && \
 RUN conda install --quiet --yes \
     'notebook=5.6.*' \
     'jupyterhub=0.9.*' \
-    'jupyterlab=0.33.*' && \
+    'jupyterlab=0.34.*' && \
     conda clean -tipsy && \
-    jupyter labextension install @jupyterlab/hub-extension@^0.10.0 && \
+    jupyter labextension install @jupyterlab/hub-extension@^0.11.0 && \
     npm cache clean --force && \
     jupyter notebook --generate-config && \
     rm -rf $CONDA_DIR/share/jupyter/lab/staging && \

--- a/scipy-notebook/Dockerfile
+++ b/scipy-notebook/Dockerfile
@@ -47,7 +47,7 @@ RUN conda install --quiet --yes \
     # Activate ipywidgets extension in the environment that runs the notebook server
     jupyter nbextension enable --py widgetsnbextension --sys-prefix && \
     # Also activate ipywidgets extension for JupyterLab
-    jupyter labextension install @jupyter-widgets/jupyterlab-manager@^0.36.0 && \
+    jupyter labextension install @jupyter-widgets/jupyterlab-manager@^0.37.0 && \
     jupyter labextension install jupyterlab_bokeh@^0.6.0 && \
     npm cache clean --force && \
     rm -rf $CONDA_DIR/share/jupyter/lab/staging && \


### PR DESCRIPTION
Updating `jupyterlab`, `hub-extension` and `jupyterlab-manager` to last versions. `jupyterlab_bokeh 0.6.2` seems to work fine with jupyterlab 0.34.

`make build-test-all` succeeded locally.