### PR TITLE
Update jupyter_notebook_config.py to fix bug introduced in notebook 5.7.0

### DIFF
--- a/base-notebook/jupyter_notebook_config.py
+++ b/base-notebook/jupyter_notebook_config.py
@@ -8,7 +8,7 @@ import errno
 import stat
 
 c = get_config()
-c.NotebookApp.ip = '*'
+c.NotebookApp.ip = '0.0.0.0'
 c.NotebookApp.port = 8888
 c.NotebookApp.open_browser = False
 


### PR DESCRIPTION
Latest release of notebook (5.7.0) introduces bug when `c.NotebookApp.ip` is set to '*'. See https://github.com/jupyter/notebook/issues/3946 for details.