### PR TITLE
Bump to latest point releases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,5 +8,5 @@ install:
     - make dev-env
 script:
     - set -e
-    - make test/docs docs
+    - make test/docs docs -d
     - make build-test-all DARGS="--build-arg TEST_ONLY_BUILD=1"

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,5 +8,5 @@ install:
     - make dev-env
 script:
     - set -e
-    - make test/docs docs -d
+    - make test/docs docs
     - make build-test-all DARGS="--build-arg TEST_ONLY_BUILD=1"

--- a/base-notebook/Dockerfile
+++ b/base-notebook/Dockerfile
@@ -91,11 +91,11 @@ RUN conda install --quiet --yes 'tini=0.18.0' && \
 # Do all this in a single RUN command to avoid duplicating all of the
 # files across image layers when the permissions change
 RUN conda install --quiet --yes \
-    'notebook=5.7.*' \
-    'jupyterhub=0.9.*' \
-    'jupyterlab=0.34.*' && \
+    'notebook=5.7.0' \
+    'jupyterhub=0.9.4' \
+    'jupyterlab=0.34.12' && \
     conda clean -tipsy && \
-    jupyter labextension install @jupyterlab/hub-extension@^0.11.0 && \
+    jupyter labextension install @jupyterlab/hub-extension@^0.12.0 && \
     npm cache clean --force && \
     jupyter notebook --generate-config && \
     rm -rf $CONDA_DIR/share/jupyter/lab/staging && \

--- a/base-notebook/Dockerfile
+++ b/base-notebook/Dockerfile
@@ -93,7 +93,7 @@ RUN conda install --quiet --yes 'tini=0.18.0' && \
 RUN conda install --quiet --yes \
     'notebook=5.7.0' \
     'jupyterhub=0.9.4' \
-    'jupyterlab=0.34.12' && \
+    'jupyterlab=0.35.2' && \
     conda clean -tipsy && \
     jupyter labextension install @jupyterlab/hub-extension@^0.12.0 && \
     npm cache clean --force && \

--- a/base-notebook/Dockerfile
+++ b/base-notebook/Dockerfile
@@ -93,9 +93,9 @@ RUN conda install --quiet --yes 'tini=0.18.0' && \
 RUN conda install --quiet --yes \
     'notebook=5.7.0' \
     'jupyterhub=0.9.4' \
-    'jupyterlab=0.35.2' && \
+    'jupyterlab=0.34.12' && \
     conda clean -tipsy && \
-    jupyter labextension install @jupyterlab/hub-extension@^0.12.0 && \
+    jupyter labextension install @jupyterlab/hub-extension@^0.11.0 && \
     npm cache clean --force && \
     jupyter notebook --generate-config && \
     rm -rf $CONDA_DIR/share/jupyter/lab/staging && \

--- a/scipy-notebook/Dockerfile
+++ b/scipy-notebook/Dockerfile
@@ -50,7 +50,7 @@ RUN conda install --quiet --yes \
     # Also activate ipywidgets extension for JupyterLab
     # Check this URL for most recent compatibilities
     # https://github.com/jupyter-widgets/ipywidgets/tree/master/packages/jupyterlab-manager
-    jupyter labextension install @jupyter-widgets/jupyterlab-manager@^0.38.0 && \
+    jupyter labextension install @jupyter-widgets/jupyterlab-manager@^0.37.0 && \
     # Pin to 0.6.2 until we can move to Lab 0.35 (jupyterlab_bokeh didn't bump to 0.7.0)
     jupyter labextension install jupyterlab_bokeh@0.6.2 && \
     npm cache clean --force && \

--- a/scipy-notebook/Dockerfile
+++ b/scipy-notebook/Dockerfile
@@ -48,7 +48,9 @@ RUN conda install --quiet --yes \
     # Activate ipywidgets extension in the environment that runs the notebook server
     jupyter nbextension enable --py widgetsnbextension --sys-prefix && \
     # Also activate ipywidgets extension for JupyterLab
-    jupyter labextension install @jupyter-widgets/jupyterlab-manager@^0.37.0 && \
+    # Check this URL for most recent compatibilities
+    # https://github.com/jupyter-widgets/ipywidgets/tree/master/packages/jupyterlab-manager
+    jupyter labextension install @jupyter-widgets/jupyterlab-manager@^0.38.0 && \
     # Pin to 0.6.2 until we can move to Lab 0.35 (jupyterlab_bokeh didn't bump to 0.7.0)
     jupyter labextension install jupyterlab_bokeh@0.6.2 && \
     npm cache clean --force && \


### PR DESCRIPTION
This PR specifies the exact point release of the packages of importance in base-notebook to fix the probiem in #716. It trades off automatically upgrading to the latest point release when there's other changes in base-notebook. Those have not been frequent updates of late and this also makes it explicit when and what version of these core libraries are being used.

I'm updating to the latest version of 

@parente , ~two~ three open questions:

1. Should we be conservative and bump to the last minor release of the 0.34 release line (0.34.12) instead of the 0.35.* major release of JLab?

2. I do not understand the semantics of the jupyterlab-hubextension versioning scheme versus the jupyterhub versioning scheme. Is what I have added here compatible? Though maybe this is a question for @blink1073 . Looking at [the diff](https://github.com/jupyterhub/jupyterlab-hub/compare/v0.11.0...v0.12.0), I suspect the jupyterlab-hub extension is more tightly pinned to jupyterlab versions than jupyterhub versions.

3. There are [two other spots where labextensions are installed](https://github.com/jupyter/docker-stacks/blob/master/scipy-notebook/Dockerfile#L50-L53) (in the scipy notebook). Any guidance for determining compatibility? 

```
    # Also activate ipywidgets extension for JupyterLab
    jupyter labextension install @jupyter-widgets/jupyterlab-manager@^0.37.0 && \
    # Pin to 0.6.2 until we can move to Lab 0.35 (jupyterlab_bokeh didn't bump to 0.7.0)
    jupyter labextension install jupyterlab_bokeh@0.6.2 && \
```