### PR TITLE
fix: #749; datascience-notebook: for julia 1.0, JULIA_PKGDIR is repla…

### DIFF
--- a/datascience-notebook/Dockerfile
+++ b/datascience-notebook/Dockerfile
@@ -22,6 +22,7 @@ RUN apt-get update && \
 
 # Julia dependencies
 # install Julia packages in /opt/julia instead of $HOME
+ENV JULIA_DEPOT_PATH=/opt/julia
 ENV JULIA_PKGDIR=/opt/julia
 ENV JULIA_VERSION=1.0.0
 


### PR DESCRIPTION
fix: #749; datascience-notebook: for julia 1.0, JULIA_PKGDIR is replaced with JULIA_DEPOT_PATH