### PR TITLE
Adding recipe for nbextension spellchecker for issue 675

### DIFF
--- a/docs/using/recipes.md
+++ b/docs/using/recipes.md
@@ -288,3 +288,20 @@ For jupyter classic:
 ```
 docker run jupyter/base-notebook:6d2a05346196 start.sh jupyter notebook --NotebookApp.token=''
 ```
+
+## Enable nbextension spellchecker for markdown (or any other nbextension)
+
+NB: this works for classic notebooks only
+```
+# Update with your base image of choice
+FROM jupyter/minimal-notebook:latest
+
+USER $NB_USER
+
+RUN pip install jupyter_contrib_nbextensions && \
+    jupyter contrib nbextension install --user && \
+    # can modify or enable additional extensions here
+    jupyter nbextension enable spellchecker/main --user
+```
+
+Ref: [https://github.com/jupyter/docker-stacks/issues/675](https://github.com/jupyter/docker-stacks/issues/675)


### PR DESCRIPTION
Adding recipe for including nbextensions (specifically spellchecker) per https://github.com/jupyter/docker-stacks/issues/675

The nbextension plugin does not cover jupyterlab, there is an option for that here https://github.com/ijmbarr/jupyterlab_spellchecker I haven't included.

Tested on Windows using minimal-notebook base image