### PR TITLE
Update to official Toree 0.3.0-incubating release

### DIFF
--- a/all-spark-notebook/Dockerfile
+++ b/all-spark-notebook/Dockerfile
@@ -35,7 +35,7 @@ RUN conda install --quiet --yes \
 
 # Apache Toree kernel
 RUN pip install --no-cache-dir \
-    https://dist.apache.org/repos/dist/dev/incubator/toree/0.3.0-incubating-rc1/toree-pip/toree-0.3.0.tar.gz \
+    https://dist.apache.org/repos/dist/release/incubator/toree/0.3.0-incubating/toree-pip/toree-0.3.0.tar.gz \
     && \
     jupyter toree install --sys-prefix && \
     rm -rf /home/$NB_USER/.local && \


### PR DESCRIPTION
Apache Toree 0.3.0-incubating has officially released, and this update the pip install instructions to use the proper official release.