### PR TITLE
updated the base image to ubuntu:18.04

### DIFF
--- a/base-notebook/Dockerfile.ppc64le
+++ b/base-notebook/Dockerfile.ppc64le
@@ -2,7 +2,7 @@
 # Distributed under the terms of the Modified BSD License.
 
 # Ubuntu image 
-FROM ppc64le/ubuntu:trusty
+FROM ppc64le/ubuntu:18.04
 
 LABEL maintainer="Ilsiyar Gaynutdinov <ilsiyar_gaynutdinov@ru.ibm.com>"
 


### PR DESCRIPTION
I had to update the base image to Ubuntu:18.04 as with the Ubuntu:trusty, it failed on the following step:

` RUN yes | pip install --quiet --no-cache-dir     'notebook==5.2.*'     'jupyterhub==0.7.*'     'jupyterlab==0.18.*'` as the dependencies ( pyzmq ,cython ) could not be downloaded. 

PFA the errror log produced when the same commands were tried inside the container
[jupyter error log.txt](https://github.com/jupyter/docker-stacks/files/2595052/jupyter.error.log.txt)


 In addition to this, ppc64le/ubuntu:18.04 image size is 35Mb ,whereas  that of ppc64le/Ubuntu:trusty is 70Mb.

