### PR TITLE
Disable mounting of service account token under OpenShift.

### DIFF
--- a/examples/openshift/templates.json
+++ b/examples/openshift/templates.json
@@ -106,6 +106,7 @@
 				]
                             }
                         ],
+                        "automountServiceAccountToken": false,
                         "securityContext": {
                             "supplementalGroups": [
                                 100

--- a/examples/source-to-image/templates.json
+++ b/examples/source-to-image/templates.json
@@ -302,6 +302,7 @@
                                         ]
                                     }
                                 ],
+                                "automountServiceAccountToken": false,
                                 "securityContext": {
                                     "supplementalGroups": [
                                         100


### PR DESCRIPTION
For the OpenShift deployment examples, when deployed, the Jupyter Notebook instance runs as the default service account of a project/namespace in Kubernetes. Because of the default RBAC security profile of OpenShift, the default service account has no special role and so even though the service account access token is mounted in the container and could be read by the user of the Jupyter Notebook, they can't use it for anything.

Because however the default service account of a project is used for any deployments unless a specific service account is created and used, there is a small risk that a project admin may add additional roles to the default service account to satisfy the requirements of another application. In that case, the user of the Jupyter Notebook instance could use the service account token to perform whatever actions the role allowed.

As an extra layer of security, this change to the sample template disables mounting of the service account token inside of the container the Jupyter Notebook is running, meaning the user will never be able to get access to it in the first place. Thus changes to the roles granted to the default service account will not be an issue.

