### PR TITLE
Remove apt-get clean command. Unecessary on official Ubuntu images.

### DIFF
--- a/all-spark-notebook/Dockerfile
+++ b/all-spark-notebook/Dockerfile
@@ -17,7 +17,7 @@ RUN apt-get update && \
     fonts-dejavu \
     tzdata \
     gfortran \
-    gcc && apt-get clean && \
+    gcc && \
     rm -rf /var/lib/apt/lists/*
 
 USER $NB_UID

--- a/base-notebook/Dockerfile
+++ b/base-notebook/Dockerfile
@@ -24,7 +24,6 @@ RUN apt-get update && apt-get -yq dist-upgrade \
     sudo \
     locales \
     fonts-liberation \
- && apt-get clean \
  && rm -rf /var/lib/apt/lists/*
 
 RUN echo "en_US.UTF-8 UTF-8" > /etc/locale.gen && \

--- a/base-notebook/Dockerfile.ppc64le
+++ b/base-notebook/Dockerfile.ppc64le
@@ -21,7 +21,7 @@ RUN apt-get update && apt-get -yq dist-upgrade \
     locales \
     sudo \
     wget \
-    && apt-get clean && \
+    && \
     rm -rf /var/lib/apt/lists/*
 
 RUN echo "LANGUAGE=en_US.UTF-8" >> /etc/default/locale

--- a/datascience-notebook/Dockerfile
+++ b/datascience-notebook/Dockerfile
@@ -17,7 +17,7 @@ RUN apt-get update && \
     fonts-dejavu \
     tzdata \
     gfortran \
-    gcc && apt-get clean && \
+    gcc && \
     rm -rf /var/lib/apt/lists/*
 
 # Julia dependencies

--- a/minimal-notebook/Dockerfile
+++ b/minimal-notebook/Dockerfile
@@ -29,8 +29,7 @@ RUN apt-get update && apt-get install -yq --no-install-recommends \
     texlive-xetex \
     unzip \
     nano \
-    && apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
+    && rm -rf /var/lib/apt/lists/*
 
 # Switch back to jovyan to avoid accidental container runs as root
 USER $NB_UID

--- a/pyspark-notebook/Dockerfile
+++ b/pyspark-notebook/Dockerfile
@@ -13,7 +13,6 @@ ENV HADOOP_VERSION 2.7
 
 RUN apt-get -y update && \
     apt-get install --no-install-recommends -y openjdk-8-jre-headless ca-certificates-java && \
-    apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
 RUN cd /tmp && \
@@ -34,7 +33,6 @@ RUN apt-get -y update && \
     apt-get -y update && \
     apt-get --no-install-recommends -y install mesos=1.2\* && \
     apt-get purge --auto-remove -y gnupg && \
-    apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
 # Spark and Mesos config

--- a/r-notebook/Dockerfile
+++ b/r-notebook/Dockerfile
@@ -13,7 +13,7 @@ RUN apt-get update && \
     fonts-dejavu \
     tzdata \
     gfortran \
-    gcc && apt-get clean && \
+    gcc && \
     rm -rf /var/lib/apt/lists/*
 
 USER $NB_UID

--- a/scipy-notebook/Dockerfile
+++ b/scipy-notebook/Dockerfile
@@ -10,7 +10,6 @@ USER root
 # ffmpeg for matplotlib anim
 RUN apt-get update && \
     apt-get install -y --no-install-recommends ffmpeg && \
-    apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
 USER $NB_UID


### PR DESCRIPTION
References issue #776 

Removing apt-get clean commands from Dockerfiles.

Ran build against base-book with and without apt-get clean line and both came out to 738MB build.