### PR TITLE
Adding link to a new Community Stack : csharp-notebook

### DIFF
--- a/docs/using/selecting.md
+++ b/docs/using/selecting.md
@@ -1,5 +1,9 @@
 # Selecting an Image
 
+* [Core Stacks](#core-stacks)
+* [Image Relationships](#image-relationships)
+* [Community Stacks](#community-stacks)
+
 Using one of the Jupyter Docker Stacks requires two choices:
 
 1. Which Docker image you wish to use
@@ -138,6 +142,8 @@ You must refer to git-SHA image tags when stability and reproducibility are impo
 
 The core stacks are just a tiny sample of what's possible when combining Jupyter with other technologies. We encourage members of the Jupyter community to create their own stacks based on the core images and link them below.
 
-*Nothing here yet! You can be the first!*
+*This list only have 1 example. You can be the next!*
 
-See the [contributing guide](contributing/stacks) for information about how to create your own Jupyter Docker Stack.
+* [csharp-notebook is a community Jupyter Docker Stack image. Try C# in Jupyter Notebooks. ](https://github.com/tlinnet/csharp-notebook). The image includes more than 200 Jupyter Notebooks with example C# code and can readily be tried online via mybinder.org. Click here to launch [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/tlinnet/csharp-notebook/master).
+
+See the [contributing guide](../contributing/stacks.md) for information about how to create your own Jupyter Docker Stack.


### PR DESCRIPTION
**csharp-notebook** is a community Jupyter Docker Stack image. Try C# in Jupyter Notebooks.

The image contain more than **200** Jupyter Notebooks with C# sample code. The image is prepared to run online through mybinder.org for easy link and C# code trying.

* GitHub [github.com/tlinnet/csharp-notebook](https://github.com/tlinnet/csharp-notebook)
* Docker Hub [hub.docker.com/r/tlinnet/csharp-notebook](https://hub.docker.com/r/tlinnet/csharp-notebook)
[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/tlinnet/csharp-notebook/master) [mybinder.org/v2/gh/tlinnet/csharp-notebook/master](https://mybinder.org/v2/gh/tlinnet/csharp-notebook/master)


