### PR TITLE
Fix bug where container user is "nayvoj"

### DIFF
--- a/base-notebook/start.sh
+++ b/base-notebook/start.sh
@@ -110,7 +110,7 @@ else
         # container runs as. Check that the user has an entry in the passwd
         # file and if not add an entry.
         whoami &> /dev/null || STATUS=$? && true
-        if [[ "$STATUS" != "0" ]]; then
+        if [[ -n "$STATUS" && "$STATUS" != "0" ]]; then
             if [[ -w /etc/passwd ]]; then
                 echo "Adding passwd file entry for $(id -u)"
                 cat /etc/passwd | sed -e "s/^jovyan:/nayvoj:/" > /tmp/passwd

--- a/base-notebook/start.sh
+++ b/base-notebook/start.sh
@@ -109,8 +109,8 @@ else
         # variables, but they could still have overridden the uid/gid that
         # container runs as. Check that the user has an entry in the passwd
         # file and if not add an entry.
-        whoami &> /dev/null || STATUS=$? && true
-        if [[ -n "$STATUS" && "$STATUS" != "0" ]]; then
+        STATUS=0 && whoami &> /dev/null || STATUS=$? && true
+        if [[ "$STATUS" != "0" ]]; then
             if [[ -w /etc/passwd ]]; then
                 echo "Adding passwd file entry for $(id -u)"
                 cat /etc/passwd | sed -e "s/^jovyan:/nayvoj:/" > /tmp/passwd


### PR DESCRIPTION
`whoami &> /dev/null || STATUS=$? && true` causes STATUS to be set to an empty string when the container starts with option `--add-group="root"` resulting in both `nayvoj` and `jovyan` having `uid=1000` and `gid=100`. The first match in `/etc/passwd` wins and so the container user ends up being `nayvoj` accidentally.

Avoid this by checking that `whoami`'s `STATUS` is neither blank nor 0 before adding a new `/etc/passwd` entry