### PR TITLE
Updated R packages in r-notebook to match all-spark-notebook update in PR #782

### DIFF
--- a/r-notebook/Dockerfile
+++ b/r-notebook/Dockerfile
@@ -20,24 +20,24 @@ USER $NB_UID
 
 # R packages
 RUN conda install --quiet --yes \
-    'r-base=3.4.1' \
+    'r-base=3.5.1' \
     'r-irkernel=0.8*' \
     'r-plyr=1.8*' \
     'r-devtools=1.13*' \
-    'r-tidyverse=1.1*' \
-    'r-shiny=1.0*' \
-    'r-rmarkdown=1.8*' \
+    'r-tidyverse=1.2*' \
+    'r-shiny=1.2*' \
+    'r-rmarkdown=1.11*' \
     'r-forecast=8.2*' \
-    'r-rsqlite=2.0*' \
+    'r-rsqlite=2.1*' \
     'r-reshape2=1.4*' \
-    'r-nycflights13=0.2*' \
+    'r-nycflights13=1.0*' \
     'r-caret=6.0*' \
     'r-rcurl=1.95*' \
     'r-crayon=1.3*' \
     'r-randomforest=4.6*' \
     'r-htmltools=0.3*' \
-    'r-sparklyr=0.7*' \
-    'r-htmlwidgets=1.0*' \
+    'r-sparklyr=0.9*' \
+    'r-htmlwidgets=1.2*' \
     'r-hexbin=1.27*' && \
     conda clean -tipsy && \
     fix-permissions $CONDA_DIR


### PR DESCRIPTION
Updated R packages in `r-notebook` to match `all-spark-notebook` update in PR #782

```bash
# First update to be 
r-base=3.4.1 -> 3.5.1
r-sparklyr=0.7* -> 0.9*
# Then to solve conflicts
r-shiny=1.0* -> 1.2*
r-htmlwidgets=1.0* -> 1.2*
r-nycflights13=0.2 -> 1.0*
r-rsqlite=2.0* -> 2.1*
r-tidyverse=1.1* -> 1.2*
r-rmarkdown=1.8* -> 1.11*
```