### PR TITLE
[WIP] Have start.sh run through both user and root parts

### DIFF
--- a/base-notebook/start.sh
+++ b/base-notebook/start.sh
@@ -2,6 +2,21 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 
+# This script can be executed as either a user or as root.  If it's
+# executed as root, then it does the basic setup and re-executes it as
+# a user, so that user-specific setup can also be done if any (this
+# would mainly be in the form of user hooks).
+
+# Default hook directories:
+# - start-notebook is before this script runs
+# - before-notebook is right before the Jupyter commmand is executed
+# /usr/local/bin/start-notebook.d/     - BOTH user and root, backwards compat
+# /usr/local/bin/start-notebook-root.d/
+# /usr/local/bin/start-notebook-user.d/
+# /usr/local/bin/before-notebook.d/    - BOTH user and root, backwards compat
+# /usr/local/bin/before-notebook-root.d/
+# /usr/local/bin/before-notebook-user.d/
+
 set -e
 
 # Exec the specified command or fall back on bash

--- a/base-notebook/start.sh
+++ b/base-notebook/start.sh
@@ -40,6 +40,7 @@ run-hooks /usr/local/bin/start-notebook.d
 
 # Handle special flags if we're root
 if [ $(id -u) == 0 ] ; then
+    run-hooks /usr/local/bin/start-notebook-root.d
 
     # Only attempt to change the jovyan username if it exists
     if id jovyan &> /dev/null ; then
@@ -102,9 +103,11 @@ if [ $(id -u) == 0 ] ; then
     # Exec the command as NB_USER with the PATH and the rest of
     # the environment preserved
     run-hooks /usr/local/bin/before-notebook.d
+    run-hooks /usr/local/bin/before-notebook-root.d
     echo "Executing the command: ${cmd[@]}"
-    exec sudo -E -H -u $NB_USER PATH=$PATH XDG_CACHE_HOME=/home/$NB_USER/.cache PYTHONPATH=${PYTHONPATH:-} "${cmd[@]}"
+    exec sudo -E -H -u $NB_USER PATH=$PATH XDG_CACHE_HOME=/home/$NB_USER/.cache PYTHONPATH=${PYTHONPATH:-} bash "$BASH_SOURCE" "${cmd[@]}"
 else
+    run-hooks /usr/local/bin/start-notebook-user.d
     if [[ "$NB_UID" == "$(id -u jovyan)" && "$NB_GID" == "$(id -g jovyan)" ]]; then
         # User is not attempting to override user/group via environment
         # variables, but they could still have overridden the uid/gid that
@@ -146,6 +149,7 @@ else
 
     # Execute the command
     run-hooks /usr/local/bin/before-notebook.d
+    run-hooks /usr/local/bin/before-notebook-user.d
     echo "Executing the command: ${cmd[@]}"
     exec "${cmd[@]}"
 fi

--- a/docs/using/common.md
+++ b/docs/using/common.md
@@ -40,12 +40,15 @@ the notebook server. You do so by passing arguments to the `docker run` command.
 ## Startup Hooks
 
 You can further customize the container environment by adding shell scripts (`*.sh`) to be sourced
-or executables (`chmod +x`) to be run to the paths below:
+or executables (`chmod +x`) to be run to the paths below.  To understand the order of the hooks, note that the setup is divided into two parts: root-mode setup and user-mode setup.  If you start as root, it runs both.  If you start as a user, it runs only the user-mode setup.
 
-* `/usr/local/bin/start-notebook.d/` - handled before any of the standard options noted above
-  are applied
-* `/usr/local/bin/before-notebook.d/` - handled after all of the standard options noted above are
-  applied and just before the notebook server launches
+* `/usr/local/bin/start-notebook-root.d/` - Run before any of the standard options are applied, only if running as root.
+* `/usr/local/bin/before-notebook-root.d/` - Run after all of the standard setup and just before switching from root to the user.
+* `/usr/local/bin/start-notebook-user.d/` - Run as the user's ID, before any of the user mode setup.  This is run whether you start the container as the user or as root.
+* `/usr/local/bin/before-notebook-user.d/` - Run right before the user notebook server is launched.
+
+* `/usr/local/bin/start-notebook.d/` - For backwards compatibility, similar to above.  If starting as root it will run before **both** root and the user.  If starting the container as a user, it is run only once.
+* `/usr/local/bin/before-notebook.d/` - For backwards compatibility, similar to above.  Run after all of the standard options noted above are applied: If running as root, right before switching to the user.  If running as a user, run just before the notebook server launches (as a user).
 
 See the `run-hooks` function in the [`jupyter/base-notebook start.sh`](https://github.com/jupyter/docker-stacks/blob/master/base-notebook/start.sh)
 script for execution details.


### PR DESCRIPTION
I'm using docker-stacks in a jupyterhub deployment.  I run as uid=0, and set NB_UID, NB_USER, etc.  I do extensive local customization at run time.  I even have a switch to swap between running as uid=0 with NB_UID and NB_UID directly.

One problem is that sometimes the hooks may run as root, and sometimes they may run as the user.  This could be handled with conditionals, but I'd rather more built-in flexibility.

The bigger issue is that sometimes, as running with uid=0, I want to be able to run hooks as the user.  (example: filesystems are mounted from NFS with root_squash, so root *can't* access and do the necessary things at all).  I've hacked this by having the root hooks run sudo themselves, but I wish there was a better way.  There are many other hacks I am ending up doing and I just feel there has to be a better way.

This PR adds one hack to replace many (but is not ready to use yet).  If `start.sh` is running as root, instead of starting `jupyter` at the end using sudo, re-execute the same `start.sh` script using sudo.  This way, the user-specific setup gets run (in its current form, this does nothing, but in the future).

As an initial useful feature, there are now six forms of hooks: `start-notebook.d`, `start-notebook-root.d`, `start-notebook-user.d`, and `before-notebook-{,root,user}.d`.  If this was accepted, most of my current hacks could be replaced.  As another example of what could be done, instead of doing system setup in `jupyter_notebook_config.py` where it doesn't belong, umask can easily be set here regardless of if you run as user or root (this would have helped me a lot six months ago).  Similar for generating a certificate.

But there are problems:
* This is a hack.  A much better way would be to split `start.sh` into a user and root part, maybe `start-singleuser.sh` could have some of this logic.
* A larger rearrangement would make more use of this.
* Is it worth making such a massive change for specialized use?  I think probably so, because it makes hooks more useful and thus ensure that special use cases are made easier, with fewer upstream changes, later.

I would say do *not* accept this PR yet, but it serves as a basis for discussion to see if the concept is useful.  If useful, discuss the right implementation and do that instead.

=====

Before, start.sh would run *either* its root or its user part.  If you
were running as uid=0 but wanted to run a user hook before starting,
it can't easily be done.  Also scripts in start-notebook.d and
before-notebook.d could be run as either the user or root, depending
on how things are run.

This is a simple, but unelegant solution, which re-invokes start.sh as
the user, if it was originally invoked as root.