### PR TITLE
Updated R packages in datascience-notebook to match r-notebook packages update in PR #786

### DIFF
--- a/datascience-notebook/Dockerfile
+++ b/datascience-notebook/Dockerfile
@@ -46,7 +46,7 @@ USER $NB_UID
 
 # R packages including IRKernel which gets installed globally.
 RUN conda install --quiet --yes \
-    'rpy2=2.8*' \
+    'rpy2=2.9*' \
     'r-base=3.5.1' \
     'r-irkernel=0.8*' \
     'r-plyr=1.8*' \

--- a/datascience-notebook/Dockerfile
+++ b/datascience-notebook/Dockerfile
@@ -47,24 +47,24 @@ USER $NB_UID
 # R packages including IRKernel which gets installed globally.
 RUN conda install --quiet --yes \
     'rpy2=2.8*' \
-    'r-base=3.4.1' \
+    'r-base=3.5.1' \
     'r-irkernel=0.8*' \
     'r-plyr=1.8*' \
     'r-devtools=1.13*' \
-    'r-tidyverse=1.1*' \
-    'r-shiny=1.0*' \
-    'r-rmarkdown=1.8*' \
+    'r-tidyverse=1.2*' \
+    'r-shiny=1.2*' \
+    'r-rmarkdown=1.11*' \
     'r-forecast=8.2*' \
-    'r-rsqlite=2.0*' \
+    'r-rsqlite=2.1*' \
     'r-reshape2=1.4*' \
-    'r-nycflights13=0.2*' \
+    'r-nycflights13=1.0*' \
     'r-caret=6.0*' \
     'r-rcurl=1.95*' \
     'r-crayon=1.3*' \
     'r-randomforest=4.6*' \
     'r-htmltools=0.3*' \
-    'r-sparklyr=0.7*' \
-    'r-htmlwidgets=1.0*' \
+    'r-sparklyr=0.9*' \
+    'r-htmlwidgets=1.2*' \
     'r-hexbin=1.27*' && \
     conda clean -tipsy && \
     fix-permissions $CONDA_DIR && \


### PR DESCRIPTION
Updated R packages in `datascience-notebook` to match `r-notebook` packages update in PR #786
Note: only  the `rpy2` package (also updated here) is in the `datascience-notebook` and not in  `r-notebook`, **other packages are identical**. 

We should think of finding a way to help us maintain the coherence of the images between them (at least some documentation). Let me know if you have an idea.
