### PR TITLE
Fix logging bug in run-hooks (order of logging statement)

### DIFF
--- a/base-notebook/start.sh
+++ b/base-notebook/start.sh
@@ -32,8 +32,8 @@ run-hooks () {
                 fi
                 ;;
         esac
-    echo "$0: done running hooks in $1"
     done
+    echo "$0: done running hooks in $1"
 }
 
 run-hooks /usr/local/bin/start-notebook.d


### PR DESCRIPTION
- The "done running loop" log message was inside the loop, causing it
  to appear over and over again, making log quite confusing.

... I caused this in the first place.