### PR TITLE
r-cran-rodbc is required for ODBC connection

### DIFF
--- a/r-notebook/Dockerfile
+++ b/r-notebook/Dockerfile
@@ -12,6 +12,7 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends \
     fonts-dejavu \
     tzdata \
+    r-cran-rodbc \
     gfortran \
     gcc && \
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Further information [here](https://superuser.com/questions/283272/problem-with-rodbc-installation-in-ubuntu/283274) and [here](https://stackoverflow.com/questions/54057120/odbc-driver-for-jupyter-r-notebook-based-on-jupyter-docker-stack).