### PR TITLE
Generate missing openssl.cnf

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,4 @@ dockerspawner.tar.gz
 *.orig
 .ipynb_checkpoints/
 .vscode/
+.pytest_cache/

--- a/base-notebook/jupyter_notebook_config.py
+++ b/base-notebook/jupyter_notebook_config.py
@@ -26,6 +26,17 @@ if 'GEN_CERT' in os.environ:
             pass
         else:
             raise
+
+    # Generate an openssl.cnf file to set the distinguished name
+    cnf_file = os.path.join(os.getenv('CONDA_DIR', '/usr/lib'), 'ssl', 'openssl.cnf')
+    if not os.path.isfile(cnf_file):
+        with open(cnf_file, 'w') as fh:
+            fh.write('''\
+[req]
+distinguished_name = req_distinguished_name
+[req_distinguished_name]
+''')
+
     # Generate a certificate if one doesn't exist on disk
     subprocess.check_call(['openssl', 'req', '-new',
                            '-newkey', 'rsa:2048',


### PR DESCRIPTION
Ensure `distinguished_name` is set when generating an ssl cert. Fixes master branch build regression due to change in upstream openssl conda package.