### PR TITLE
devtools install_github does not work

### DIFF
--- a/r-notebook/Dockerfile
+++ b/r-notebook/Dockerfile
@@ -19,6 +19,9 @@ RUN apt-get update && \
     gcc && \
     rm -rf /var/lib/apt/lists/*
 
+# Fix for devtools https://github.com/conda-forge/r-devtools-feedstock/issues/4
+RUN ln -s /bin/tar /bin/gtar
+
 USER $NB_UID
 
 # R packages
@@ -46,6 +49,3 @@ RUN conda install --quiet --yes \
     'r-hexbin=1.27*' && \
     conda clean -tipsy && \
     fix-permissions $CONDA_DIR
-
-# Fix for devtools https://github.com/conda-forge/r-devtools-feedstock/issues/4
-RUN echo "TAR=/bin/tar" > $HOME/.Renviron

--- a/r-notebook/Dockerfile
+++ b/r-notebook/Dockerfile
@@ -28,7 +28,7 @@ RUN conda install --quiet --yes \
     'unixodbc=2.3.*' \
     'r-irkernel=0.8*' \
     'r-plyr=1.8*' \
-    'r-devtools=1.13*' \
+    'r-devtools=2.0*' \
     'r-tidyverse=1.2*' \
     'r-shiny=1.2*' \
     'r-rmarkdown=1.11*' \
@@ -46,3 +46,6 @@ RUN conda install --quiet --yes \
     'r-hexbin=1.27*' && \
     conda clean -tipsy && \
     fix-permissions $CONDA_DIR
+
+# Fix for devtools https://github.com/conda-forge/r-devtools-feedstock/issues/4
+RUN echo "TAR=/bin/tar" > $HOME/.Renviron


### PR DESCRIPTION
`install_github` is an handy tool to install R packages directly from GitHub repositories (see [Putting your R package on GitHub](http://kbroman.org/pkg_primer/pages/github.html) for more information). In the `r-notebook` this method does not working.
```bash
$ R
> devtools::install_github("hadley/babynames")
# Downloading GitHub repo hadley/babynames@master
# from URL https://api.github.com/repos/hadley/babynames/zipball/master
# Installation failed: error in running command
```

To fix it I have bumped the version of devtools to `2.0*`, but it was still not OK. A problem related to the `tar` utility remains.
When telling R to give the content of the `TAR` environment variable this is its answer.
```bash
$ R
> Sys.getenv("TAR")
[1] "/bin/gtar"
```
Since `/bin/gtar` does not exist on the platform, it does not work.
This problem is known:
- [`install_github` fails in conda environment on Linux · Issue #4 · conda-forge/r-devtools-feedstock · GitHub](https://github.com/conda-forge/r-devtools-feedstock/issues/4)
 - [Installation failed: error in running command · Issue #1722 · r-lib/devtools · GitHub](https://github.com/r-lib/devtools/issues/1722)
 - [release function error · Issue #379 · r-lib/devtools · GitHub](https://github.com/r-lib/devtools/issues/379) 

To fix it two pragmatic approaches are
- To create a symlink `ln -s /bin/tar /bin/gtar`
- To fix the environment variable in the user  `.Renviron` file

I’ve chosen the latter.

```Dockerfile
RUN echo "TAR=/bin/tar" > $HOME/.Renviron
```