### PR TITLE
Made variable reference PYTHONPATH safe in case of set -eu.

### DIFF
--- a/base-notebook/start.sh
+++ b/base-notebook/start.sh
@@ -102,7 +102,7 @@ if [ $(id -u) == 0 ] ; then
     # the environment preserved
     run-hooks /usr/local/bin/before-notebook.d
     echo "Executing the command: ${cmd[@]}"
-    exec sudo -E -H -u $NB_USER PATH=$PATH XDG_CACHE_HOME=/home/$NB_USER/.cache PYTHONPATH=$PYTHONPATH "${cmd[@]}"
+    exec sudo -E -H -u $NB_USER PATH=$PATH XDG_CACHE_HOME=/home/$NB_USER/.cache PYTHONPATH=${PYTHONPATH:-} "${cmd[@]}"
 else
     if [[ "$NB_UID" == "$(id -u jovyan)" && "$NB_GID" == "$(id -g jovyan)" ]]; then
         # User is not attempting to override user/group via environment


### PR DESCRIPTION
I noticed this when a before-notebook hook script `set -eu` and didn't unset them.  `PYTHONPATH` wasn't set, resulting in:

`/usr/local/bin/start.sh: line 105: PYTHONPATH: unbound variable`

If we dereference as `PYTHONPATH=${PYTHONPATH:-}` this problem would be avoided, without any functionality changes.  The other variables in the same place seem less likely to be unset.