### PR TITLE
Enable color terminal in common cases

### DIFF
--- a/base-notebook/Dockerfile
+++ b/base-notebook/Dockerfile
@@ -41,8 +41,16 @@ ENV CONDA_DIR=/opt/conda \
 ENV PATH=$CONDA_DIR/bin:$PATH \
     HOME=/home/$NB_USER
 
+# Add a script that we will use to correct permissions after running certain commands
 ADD fix-permissions /usr/local/bin/fix-permissions
-# Create jovyan user with UID=1000 and in the 'users' group
+
+# Enable prompt color in the skeleton .bashrc before creating the default NB_USER
+# and in the default bash.bashrc for the case where the user home directory gets
+# overridden.
+RUN sed -i 's/^#force_color_prompt=yes/force_color_prompt=yes/' /etc/skel/.bashrc && \
+    sed -i 's/^#force_color_prompt=yes/force_color_prompt=yes/' /etc/bash.bashrc
+
+# Create NB_USER wtih name jovyan user with UID=1000 and in the 'users' group
 # and make sure these dirs are writable by the `users` group.
 RUN groupadd wheel -g 11 && \
     echo "auth required pam_wheel.so use_uid" >> /etc/pam.d/su && \

--- a/base-notebook/Dockerfile
+++ b/base-notebook/Dockerfile
@@ -45,10 +45,7 @@ ENV PATH=$CONDA_DIR/bin:$PATH \
 ADD fix-permissions /usr/local/bin/fix-permissions
 
 # Enable prompt color in the skeleton .bashrc before creating the default NB_USER
-# and in the default bash.bashrc for the case where the user home directory gets
-# overridden.
-RUN sed -i 's/^#force_color_prompt=yes/force_color_prompt=yes/' /etc/skel/.bashrc && \
-    sed -i 's/^#force_color_prompt=yes/force_color_prompt=yes/' /etc/bash.bashrc
+RUN sed -i 's/^#force_color_prompt=yes/force_color_prompt=yes/' /etc/skel/.bashrc
 
 # Create NB_USER wtih name jovyan user with UID=1000 and in the 'users' group
 # and make sure these dirs are writable by the `users` group.


### PR DESCRIPTION
Sets `force_color_prompt=yes` in `/etc/skel/.bashrc` to configure color prompts when adding a new `NB_USER` at image build time. ~Sets the same key/value in `/etc/bash.bashrc` to configure color prompts when host mounting a `.bashrc` file that respects the setting at runtime.~

For #815 