### PR TITLE
[ci skip] Add package manifest support

### DIFF
--- a/all-spark-notebook/hooks/manifest.tmpl
+++ b/all-spark-notebook/hooks/manifest.tmpl
@@ -1,0 +1,28 @@
+cat << EOF > "$MANIFEST_FILE"
+* Build datetime: $(date -u +%FT%TZ)
+* DockerHub build code: ${BUILD_CODE}
+* Docker image: ${DOCKER_REPO}:${GIT_SHA_TAG}
+* Git commit SHA: [${SOURCE_COMMIT}](https://github.com/jupyter/docker-stacks/commit/${SOURCE_COMMIT})
+* Git commit message:
+\`\`\`
+${COMMIT_MSG}
+\`\`\`
+
+## Apache Packages
+
+\`\`\`
+$(docker run --rm ${IMAGE_NAME} spark-submit --version)
+\`\`\`
+
+## Python Packages
+
+\`\`\`
+$(docker run --rm ${IMAGE_NAME} conda list)
+\`\`\`
+
+## Apt Packages
+
+\`\`\`
+$(docker run --rm ${IMAGE_NAME} apt list --installed)
+\`\`\`
+EOF

--- a/all-spark-notebook/hooks/post_push
+++ b/all-spark-notebook/hooks/post_push
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 # Tag the latest build with the short git sha. Push the tag in addition
 # to the "latest" tag already pushed.
@@ -6,7 +7,41 @@ GIT_SHA_TAG=${SOURCE_COMMIT:0:12}
 docker tag $IMAGE_NAME $DOCKER_REPO:$GIT_SHA_TAG
 docker push $DOCKER_REPO:$GIT_SHA_TAG
 
+# Create a working directory.
+WORKDIR=$(mktemp -d)
+GIT_URI="git@github.com:jupyter/docker-stacks.wiki.git"
+GIT_SANDBOX="${WORKDIR}/docker-stacks.wiki"
+IMAGE_SHORT_NAME=$(basename $DOCKER_REPO)
+MANIFEST_FILE="${GIT_SANDBOX}/manifests/${IMAGE_SHORT_NAME}-${SOURCE_COMMIT:0:12}.md"
+
+# Configure git so it can push back to GitHub.
+eval $(ssh-agent -s)
+ssh-add <(echo "$DEPLOY_KEY")
+ssh-add -l
+git config --global user.email "jupyter@googlegroups.com"
+git config --global user.name "Jupyter Docker Stacks"
+
+# Glone the GitHub project wiki.
+pushd "$WORKDIR"
+git clone "$GIT_URI"
+popd
+
+# Render the build manifest template.
+mkdir -p $(dirname "$MANIFEST_FILE")
+source hooks/manifest.tmpl
+
+# Push the wiki update back to GitHub.
+pushd "$GIT_SANDBOX"
+git add .
+git commit -m "DOC: Build ${MANIFEST_FILE}"
+git push -u origin master
+popd
+
+# Shutdown the ssh agent for good measure.
+ssh-agent -k
+
 # Invoke all downstream build triggers.
+set +e
 for url in $(echo $NEXT_BUILD_TRIGGERS | sed "s/,/ /g")
 do
     curl -X POST $url

--- a/base-notebook/hooks/manifest.tmpl
+++ b/base-notebook/hooks/manifest.tmpl
@@ -1,0 +1,22 @@
+cat << EOF > "$MANIFEST_FILE"
+* Build datetime: $(date -u +%FT%TZ)
+* DockerHub build code: ${BUILD_CODE}
+* Docker image: ${DOCKER_REPO}:${GIT_SHA_TAG}
+* Git commit SHA: [${SOURCE_COMMIT}](https://github.com/jupyter/docker-stacks/commit/${SOURCE_COMMIT})
+* Git commit message:
+\`\`\`
+${COMMIT_MSG}
+\`\`\`
+
+## Python Packages
+
+\`\`\`
+$(docker run --rm ${IMAGE_NAME} conda list)
+\`\`\`
+
+## Apt Packages
+
+\`\`\`
+$(docker run --rm ${IMAGE_NAME} apt list --installed)
+\`\`\`
+EOF

--- a/base-notebook/hooks/post_push
+++ b/base-notebook/hooks/post_push
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 # Tag the latest build with the short git sha. Push the tag in addition
 # to the "latest" tag already pushed.
@@ -6,7 +7,41 @@ GIT_SHA_TAG=${SOURCE_COMMIT:0:12}
 docker tag $IMAGE_NAME $DOCKER_REPO:$GIT_SHA_TAG
 docker push $DOCKER_REPO:$GIT_SHA_TAG
 
+# Create a working directory.
+WORKDIR=$(mktemp -d)
+GIT_URI="git@github.com:jupyter/docker-stacks.wiki.git"
+GIT_SANDBOX="${WORKDIR}/docker-stacks.wiki"
+IMAGE_SHORT_NAME=$(basename $DOCKER_REPO)
+MANIFEST_FILE="${GIT_SANDBOX}/manifests/${IMAGE_SHORT_NAME}-${SOURCE_COMMIT:0:12}.md"
+
+# Configure git so it can push back to GitHub.
+eval $(ssh-agent -s)
+ssh-add <(echo "$DEPLOY_KEY")
+ssh-add -l
+git config --global user.email "jupyter@googlegroups.com"
+git config --global user.name "Jupyter Docker Stacks"
+
+# Glone the GitHub project wiki.
+pushd "$WORKDIR"
+git clone "$GIT_URI"
+popd
+
+# Render the build manifest template.
+mkdir -p $(dirname "$MANIFEST_FILE")
+source hooks/manifest.tmpl
+
+# Push the wiki update back to GitHub.
+pushd "$GIT_SANDBOX"
+git add .
+git commit -m "DOC: Build ${MANIFEST_FILE}"
+git push -u origin master
+popd
+
+# Shutdown the ssh agent for good measure.
+ssh-agent -k
+
 # Invoke all downstream build triggers.
+set +e
 for url in $(echo $NEXT_BUILD_TRIGGERS | sed "s/,/ /g")
 do
     curl -X POST $url

--- a/datascience-notebook/hooks/manifest.tmpl
+++ b/datascience-notebook/hooks/manifest.tmpl
@@ -1,0 +1,34 @@
+cat << EOF > "$MANIFEST_FILE"
+* Build datetime: $(date -u +%FT%TZ)
+* DockerHub build code: ${BUILD_CODE}
+* Docker image: ${DOCKER_REPO}:${GIT_SHA_TAG}
+* Git commit SHA: [${SOURCE_COMMIT}](https://github.com/jupyter/docker-stacks/commit/${SOURCE_COMMIT})
+* Git commit message:
+\`\`\`
+${COMMIT_MSG}
+\`\`\`
+
+## Julia Packages
+
+\`\`\`
+$(docker run --rm ${IMAGE_NAME} julia -E 'import Pkg; Pkg.status()')
+\`\`\`
+
+## Python Packages
+
+\`\`\`
+$(docker run --rm ${IMAGE_NAME} conda list)
+\`\`\`
+
+## R Packages
+
+\`\`\`
+$(docker run --rm ${IMAGE_NAME} R --silent -e 'installed.packages(.Library)[, c(1,3)]')
+\`\`\`
+
+## Apt Packages
+
+\`\`\`
+$(docker run --rm ${IMAGE_NAME} apt list --installed)
+\`\`\`
+EOF

--- a/datascience-notebook/hooks/post_push
+++ b/datascience-notebook/hooks/post_push
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 # Tag the latest build with the short git sha. Push the tag in addition
 # to the "latest" tag already pushed.
@@ -6,7 +7,41 @@ GIT_SHA_TAG=${SOURCE_COMMIT:0:12}
 docker tag $IMAGE_NAME $DOCKER_REPO:$GIT_SHA_TAG
 docker push $DOCKER_REPO:$GIT_SHA_TAG
 
+# Create a working directory.
+WORKDIR=$(mktemp -d)
+GIT_URI="git@github.com:jupyter/docker-stacks.wiki.git"
+GIT_SANDBOX="${WORKDIR}/docker-stacks.wiki"
+IMAGE_SHORT_NAME=$(basename $DOCKER_REPO)
+MANIFEST_FILE="${GIT_SANDBOX}/manifests/${IMAGE_SHORT_NAME}-${SOURCE_COMMIT:0:12}.md"
+
+# Configure git so it can push back to GitHub.
+eval $(ssh-agent -s)
+ssh-add <(echo "$DEPLOY_KEY")
+ssh-add -l
+git config --global user.email "jupyter@googlegroups.com"
+git config --global user.name "Jupyter Docker Stacks"
+
+# Glone the GitHub project wiki.
+pushd "$WORKDIR"
+git clone "$GIT_URI"
+popd
+
+# Render the build manifest template.
+mkdir -p $(dirname "$MANIFEST_FILE")
+source hooks/manifest.tmpl
+
+# Push the wiki update back to GitHub.
+pushd "$GIT_SANDBOX"
+git add .
+git commit -m "DOC: Build ${MANIFEST_FILE}"
+git push -u origin master
+popd
+
+# Shutdown the ssh agent for good measure.
+ssh-agent -k
+
 # Invoke all downstream build triggers.
+set +e
 for url in $(echo $NEXT_BUILD_TRIGGERS | sed "s/,/ /g")
 do
     curl -X POST $url

--- a/minimal-notebook/hooks/manifest.tmpl
+++ b/minimal-notebook/hooks/manifest.tmpl
@@ -1,0 +1,22 @@
+cat << EOF > "$MANIFEST_FILE"
+* Build datetime: $(date -u +%FT%TZ)
+* DockerHub build code: ${BUILD_CODE}
+* Docker image: ${DOCKER_REPO}:${GIT_SHA_TAG}
+* Git commit SHA: [${SOURCE_COMMIT}](https://github.com/jupyter/docker-stacks/commit/${SOURCE_COMMIT})
+* Git commit message:
+\`\`\`
+${COMMIT_MSG}
+\`\`\`
+
+## Python Packages
+
+\`\`\`
+$(docker run --rm ${IMAGE_NAME} conda list)
+\`\`\`
+
+## Apt Packages
+
+\`\`\`
+$(docker run --rm ${IMAGE_NAME} apt list --installed)
+\`\`\`
+EOF

--- a/minimal-notebook/hooks/post_push
+++ b/minimal-notebook/hooks/post_push
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 # Tag the latest build with the short git sha. Push the tag in addition
 # to the "latest" tag already pushed.
@@ -6,7 +7,41 @@ GIT_SHA_TAG=${SOURCE_COMMIT:0:12}
 docker tag $IMAGE_NAME $DOCKER_REPO:$GIT_SHA_TAG
 docker push $DOCKER_REPO:$GIT_SHA_TAG
 
+# Create a working directory.
+WORKDIR=$(mktemp -d)
+GIT_URI="git@github.com:jupyter/docker-stacks.wiki.git"
+GIT_SANDBOX="${WORKDIR}/docker-stacks.wiki"
+IMAGE_SHORT_NAME=$(basename $DOCKER_REPO)
+MANIFEST_FILE="${GIT_SANDBOX}/manifests/${IMAGE_SHORT_NAME}-${SOURCE_COMMIT:0:12}.md"
+
+# Configure git so it can push back to GitHub.
+eval $(ssh-agent -s)
+ssh-add <(echo "$DEPLOY_KEY")
+ssh-add -l
+git config --global user.email "jupyter@googlegroups.com"
+git config --global user.name "Jupyter Docker Stacks"
+
+# Glone the GitHub project wiki.
+pushd "$WORKDIR"
+git clone "$GIT_URI"
+popd
+
+# Render the build manifest template.
+mkdir -p $(dirname "$MANIFEST_FILE")
+source hooks/manifest.tmpl
+
+# Push the wiki update back to GitHub.
+pushd "$GIT_SANDBOX"
+git add .
+git commit -m "DOC: Build ${MANIFEST_FILE}"
+git push -u origin master
+popd
+
+# Shutdown the ssh agent for good measure.
+ssh-agent -k
+
 # Invoke all downstream build triggers.
+set +e
 for url in $(echo $NEXT_BUILD_TRIGGERS | sed "s/,/ /g")
 do
     curl -X POST $url

--- a/pyspark-notebook/hooks/manifest.tmpl
+++ b/pyspark-notebook/hooks/manifest.tmpl
@@ -1,0 +1,28 @@
+cat << EOF > "$MANIFEST_FILE"
+* Build datetime: $(date -u +%FT%TZ)
+* DockerHub build code: ${BUILD_CODE}
+* Docker image: ${DOCKER_REPO}:${GIT_SHA_TAG}
+* Git commit SHA: [${SOURCE_COMMIT}](https://github.com/jupyter/docker-stacks/commit/${SOURCE_COMMIT})
+* Git commit message:
+\`\`\`
+${COMMIT_MSG}
+\`\`\`
+
+## Apache Packages
+
+\`\`\`
+$(docker run --rm ${IMAGE_NAME} spark-submit --version)
+\`\`\`
+
+## Python Packages
+
+\`\`\`
+$(docker run --rm ${IMAGE_NAME} conda list)
+\`\`\`
+
+## Apt Packages
+
+\`\`\`
+$(docker run --rm ${IMAGE_NAME} apt list --installed)
+\`\`\`
+EOF

--- a/pyspark-notebook/hooks/post_push
+++ b/pyspark-notebook/hooks/post_push
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 # Tag the latest build with the short git sha. Push the tag in addition
 # to the "latest" tag already pushed.
@@ -6,7 +7,41 @@ GIT_SHA_TAG=${SOURCE_COMMIT:0:12}
 docker tag $IMAGE_NAME $DOCKER_REPO:$GIT_SHA_TAG
 docker push $DOCKER_REPO:$GIT_SHA_TAG
 
+# Create a working directory.
+WORKDIR=$(mktemp -d)
+GIT_URI="git@github.com:jupyter/docker-stacks.wiki.git"
+GIT_SANDBOX="${WORKDIR}/docker-stacks.wiki"
+IMAGE_SHORT_NAME=$(basename $DOCKER_REPO)
+MANIFEST_FILE="${GIT_SANDBOX}/manifests/${IMAGE_SHORT_NAME}-${SOURCE_COMMIT:0:12}.md"
+
+# Configure git so it can push back to GitHub.
+eval $(ssh-agent -s)
+ssh-add <(echo "$DEPLOY_KEY")
+ssh-add -l
+git config --global user.email "jupyter@googlegroups.com"
+git config --global user.name "Jupyter Docker Stacks"
+
+# Glone the GitHub project wiki.
+pushd "$WORKDIR"
+git clone "$GIT_URI"
+popd
+
+# Render the build manifest template.
+mkdir -p $(dirname "$MANIFEST_FILE")
+source hooks/manifest.tmpl
+
+# Push the wiki update back to GitHub.
+pushd "$GIT_SANDBOX"
+git add .
+git commit -m "DOC: Build ${MANIFEST_FILE}"
+git push -u origin master
+popd
+
+# Shutdown the ssh agent for good measure.
+ssh-agent -k
+
 # Invoke all downstream build triggers.
+set +e
 for url in $(echo $NEXT_BUILD_TRIGGERS | sed "s/,/ /g")
 do
     curl -X POST $url

--- a/r-notebook/hooks/manifest.tmpl
+++ b/r-notebook/hooks/manifest.tmpl
@@ -1,0 +1,28 @@
+cat << EOF > "$MANIFEST_FILE"
+* Build datetime: $(date -u +%FT%TZ)
+* DockerHub build code: ${BUILD_CODE}
+* Docker image: ${DOCKER_REPO}:${GIT_SHA_TAG}
+* Git commit SHA: [${SOURCE_COMMIT}](https://github.com/jupyter/docker-stacks/commit/${SOURCE_COMMIT})
+* Git commit message:
+\`\`\`
+${COMMIT_MSG}
+\`\`\`
+
+## R Packages
+
+\`\`\`
+$(docker run --rm ${IMAGE_NAME} R --silent -e 'installed.packages(.Library)[, c(1,3)]')
+\`\`\`
+
+## Python Packages
+
+\`\`\`
+$(docker run --rm ${IMAGE_NAME} conda list)
+\`\`\`
+
+## Apt Packages
+
+\`\`\`
+$(docker run --rm ${IMAGE_NAME} apt list --installed)
+\`\`\`
+EOF

--- a/r-notebook/hooks/post_push
+++ b/r-notebook/hooks/post_push
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 # Tag the latest build with the short git sha. Push the tag in addition
 # to the "latest" tag already pushed.
@@ -6,7 +7,41 @@ GIT_SHA_TAG=${SOURCE_COMMIT:0:12}
 docker tag $IMAGE_NAME $DOCKER_REPO:$GIT_SHA_TAG
 docker push $DOCKER_REPO:$GIT_SHA_TAG
 
+# Create a working directory.
+WORKDIR=$(mktemp -d)
+GIT_URI="git@github.com:jupyter/docker-stacks.wiki.git"
+GIT_SANDBOX="${WORKDIR}/docker-stacks.wiki"
+IMAGE_SHORT_NAME=$(basename $DOCKER_REPO)
+MANIFEST_FILE="${GIT_SANDBOX}/manifests/${IMAGE_SHORT_NAME}-${SOURCE_COMMIT:0:12}.md"
+
+# Configure git so it can push back to GitHub.
+eval $(ssh-agent -s)
+ssh-add <(echo "$DEPLOY_KEY")
+ssh-add -l
+git config --global user.email "jupyter@googlegroups.com"
+git config --global user.name "Jupyter Docker Stacks"
+
+# Glone the GitHub project wiki.
+pushd "$WORKDIR"
+git clone "$GIT_URI"
+popd
+
+# Render the build manifest template.
+mkdir -p $(dirname "$MANIFEST_FILE")
+source hooks/manifest.tmpl
+
+# Push the wiki update back to GitHub.
+pushd "$GIT_SANDBOX"
+git add .
+git commit -m "DOC: Build ${MANIFEST_FILE}"
+git push -u origin master
+popd
+
+# Shutdown the ssh agent for good measure.
+ssh-agent -k
+
 # Invoke all downstream build triggers.
+set +e
 for url in $(echo $NEXT_BUILD_TRIGGERS | sed "s/,/ /g")
 do
     curl -X POST $url

--- a/scipy-notebook/hooks/manifest.tmpl
+++ b/scipy-notebook/hooks/manifest.tmpl
@@ -1,0 +1,22 @@
+cat << EOF > "$MANIFEST_FILE"
+* Build datetime: $(date -u +%FT%TZ)
+* DockerHub build code: ${BUILD_CODE}
+* Docker image: ${DOCKER_REPO}:${GIT_SHA_TAG}
+* Git commit SHA: [${SOURCE_COMMIT}](https://github.com/jupyter/docker-stacks/commit/${SOURCE_COMMIT})
+* Git commit message:
+\`\`\`
+${COMMIT_MSG}
+\`\`\`
+
+## Python Packages
+
+\`\`\`
+$(docker run --rm ${IMAGE_NAME} conda list)
+\`\`\`
+
+## Apt Packages
+
+\`\`\`
+$(docker run --rm ${IMAGE_NAME} apt list --installed)
+\`\`\`
+EOF

--- a/scipy-notebook/hooks/post_push
+++ b/scipy-notebook/hooks/post_push
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 # Tag the latest build with the short git sha. Push the tag in addition
 # to the "latest" tag already pushed.
@@ -6,7 +7,41 @@ GIT_SHA_TAG=${SOURCE_COMMIT:0:12}
 docker tag $IMAGE_NAME $DOCKER_REPO:$GIT_SHA_TAG
 docker push $DOCKER_REPO:$GIT_SHA_TAG
 
+# Create a working directory.
+WORKDIR=$(mktemp -d)
+GIT_URI="git@github.com:jupyter/docker-stacks.wiki.git"
+GIT_SANDBOX="${WORKDIR}/docker-stacks.wiki"
+IMAGE_SHORT_NAME=$(basename $DOCKER_REPO)
+MANIFEST_FILE="${GIT_SANDBOX}/manifests/${IMAGE_SHORT_NAME}-${SOURCE_COMMIT:0:12}.md"
+
+# Configure git so it can push back to GitHub.
+eval $(ssh-agent -s)
+ssh-add <(echo "$DEPLOY_KEY")
+ssh-add -l
+git config --global user.email "jupyter@googlegroups.com"
+git config --global user.name "Jupyter Docker Stacks"
+
+# Glone the GitHub project wiki.
+pushd "$WORKDIR"
+git clone "$GIT_URI"
+popd
+
+# Render the build manifest template.
+mkdir -p $(dirname "$MANIFEST_FILE")
+source hooks/manifest.tmpl
+
+# Push the wiki update back to GitHub.
+pushd "$GIT_SANDBOX"
+git add .
+git commit -m "DOC: Build ${MANIFEST_FILE}"
+git push -u origin master
+popd
+
+# Shutdown the ssh agent for good measure.
+ssh-agent -k
+
 # Invoke all downstream build triggers.
+set +e
 for url in $(echo $NEXT_BUILD_TRIGGERS | sed "s/,/ /g")
 do
     curl -X POST $url

--- a/tensorflow-notebook/hooks/manifest.tmpl
+++ b/tensorflow-notebook/hooks/manifest.tmpl
@@ -1,0 +1,22 @@
+cat << EOF > "$MANIFEST_FILE"
+* Build datetime: $(date -u +%FT%TZ)
+* DockerHub build code: ${BUILD_CODE}
+* Docker image: ${DOCKER_REPO}:${GIT_SHA_TAG}
+* Git commit SHA: [${SOURCE_COMMIT}](https://github.com/jupyter/docker-stacks/commit/${SOURCE_COMMIT})
+* Git commit message:
+\`\`\`
+${COMMIT_MSG}
+\`\`\`
+
+## Python Packages
+
+\`\`\`
+$(docker run --rm ${IMAGE_NAME} conda list)
+\`\`\`
+
+## Apt Packages
+
+\`\`\`
+$(docker run --rm ${IMAGE_NAME} apt list --installed)
+\`\`\`
+EOF

--- a/tensorflow-notebook/hooks/post_push
+++ b/tensorflow-notebook/hooks/post_push
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 # Tag the latest build with the short git sha. Push the tag in addition
 # to the "latest" tag already pushed.
@@ -6,7 +7,41 @@ GIT_SHA_TAG=${SOURCE_COMMIT:0:12}
 docker tag $IMAGE_NAME $DOCKER_REPO:$GIT_SHA_TAG
 docker push $DOCKER_REPO:$GIT_SHA_TAG
 
+# Create a working directory.
+WORKDIR=$(mktemp -d)
+GIT_URI="git@github.com:jupyter/docker-stacks.wiki.git"
+GIT_SANDBOX="${WORKDIR}/docker-stacks.wiki"
+IMAGE_SHORT_NAME=$(basename $DOCKER_REPO)
+MANIFEST_FILE="${GIT_SANDBOX}/manifests/${IMAGE_SHORT_NAME}-${SOURCE_COMMIT:0:12}.md"
+
+# Configure git so it can push back to GitHub.
+eval $(ssh-agent -s)
+ssh-add <(echo "$DEPLOY_KEY")
+ssh-add -l
+git config --global user.email "jupyter@googlegroups.com"
+git config --global user.name "Jupyter Docker Stacks"
+
+# Glone the GitHub project wiki.
+pushd "$WORKDIR"
+git clone "$GIT_URI"
+popd
+
+# Render the build manifest template.
+mkdir -p $(dirname "$MANIFEST_FILE")
+source hooks/manifest.tmpl
+
+# Push the wiki update back to GitHub.
+pushd "$GIT_SANDBOX"
+git add .
+git commit -m "DOC: Build ${MANIFEST_FILE}"
+git push -u origin master
+popd
+
+# Shutdown the ssh agent for good measure.
+ssh-agent -k
+
 # Invoke all downstream build triggers.
+set +e
 for url in $(echo $NEXT_BUILD_TRIGGERS | sed "s/,/ /g")
 do
     curl -X POST $url


### PR DESCRIPTION
The code in this PR generates "manifest" pages for #823 and pushes them to the docker-stacks GitHub wiki. The logic repeats in every image `hooks` subfolder because DockerHub only makes the directory containing the Dockerfile being built and its subdirs available at build time (i.e., the entire git repo is not available for code sharing). We could look at using a git submodule or similar to share code, but I think it's better to keep all the folders independent with an eye toward the day we might actually split up this monorepo.

I developed the hook logic over in https://github.com/parente/sandbox/. https://github.com/parente/sandbox/wiki/sandbox-cd5ba036b204 is an example result. I'm sure there will be sur

The `post_build` hook requires a GitHub deploy key with *write access* to this repo in order to push the manifest markdown pages to the project GitHub wiki. I've stored the private part of the key as a environment variable on DockerHub which is supposedly private and only visible to owners of the image. (FWIW, the deploy key DockerHub installs to pull the source is also available in an env var at build time.)

I plan to merge this, see what happens, and iterate. For instance, this PR just makes a new page named after the image and its tag (e.g. `base-notebook-abcdef123456.md`). We're definitely going to need something that updates a chronological index like we used to have and links to the individual manifest pages.