### PR TITLE
chown: add logging and a test

### DIFF
--- a/base-notebook/start.sh
+++ b/base-notebook/start.sh
@@ -55,6 +55,7 @@ if [ $(id -u) == 0 ] ; then
     fi
     if [ ! -z "$CHOWN_EXTRA" ]; then
         for extra_dir in $(echo $CHOWN_EXTRA | tr ',' ' '); do
+            echo "Changing ownership of ${extra_dir} to $NB_UID:$NB_GID"
             chown $CHOWN_EXTRA_OPTS $NB_UID:$NB_GID $extra_dir
         done
     fi

--- a/base-notebook/start.sh
+++ b/base-notebook/start.sh
@@ -50,12 +50,12 @@ if [ $(id -u) == 0 ] ; then
     # Handle case where provisioned storage does not have the correct permissions by default
     # Ex: default NFS/EFS (no auto-uid/gid)
     if [[ "$CHOWN_HOME" == "1" || "$CHOWN_HOME" == 'yes' ]]; then
-        echo "Changing ownership of /home/$NB_USER to $NB_UID:$NB_GID"
+        echo "Changing ownership of /home/$NB_USER to $NB_UID:$NB_GID with options '${CHOWN_HOME_OPTS}'"
         chown $CHOWN_HOME_OPTS $NB_UID:$NB_GID /home/$NB_USER
     fi
     if [ ! -z "$CHOWN_EXTRA" ]; then
         for extra_dir in $(echo $CHOWN_EXTRA | tr ',' ' '); do
-            echo "Changing ownership of ${extra_dir} to $NB_UID:$NB_GID"
+            echo "Changing ownership of ${extra_dir} to $NB_UID:$NB_GID with options '${CHOWN_EXTRA_OPTS}'"
             chown $CHOWN_EXTRA_OPTS $NB_UID:$NB_GID $extra_dir
         done
     fi

--- a/base-notebook/test/test_container_options.py
+++ b/base-notebook/test/test_container_options.py
@@ -61,6 +61,23 @@ def test_gid_change(container):
     assert 'groups=110(jovyan),100(users)' in logs
 
 
+def test_chown_extra(container):
+    """Container should change the UID/GID of CHOWN_EXTRA."""
+    c = container.run(
+        tty=True,
+        user='root',
+        environment=['NB_UID=1010',
+                     'NB_GID=101',
+                     'CHOWN_EXTRA=/opt/conda',
+                     'CHOWN_EXTRA_OPTS=-R',
+        ],
+        command=['start.sh', 'bash', '-c', 'stat -c \'%n:%u:%g\' /opt/conda/LICENSE.txt']
+    )
+    # chown is slow so give it some time
+    c.wait(timeout=120)
+    assert '/opt/conda/LICENSE.txt:1010:101' in c.logs(stdout=True).decode('utf-8')
+
+
 def test_sudo(container):
     """Container should grant passwordless sudo to the default user."""
     c = container.run(


### PR DESCRIPTION
This adds logging-output for each `CHOWN_EXTRA` item, as well as mentioning `CHOWN_HOME_OPTS` and `CHOWN_EXTRA_OPTS` in output.

Added a test for `CHOWN_EXTRA`.