### PR TITLE
[WIP] Multi stage demo

### DIFF
--- a/base-notebook/Dockerfile
+++ b/base-notebook/Dockerfile
@@ -136,10 +136,10 @@ ENV PATH=$CONDA_DIR/bin:$PATH \
     CONDA_VERSION=$CONDA_VERSION \
     JUPYTER=$CONDA_DIR/bin/jupyter
 
-USER $NB_UID
+USER root
 
-COPY --chown=$NB_GUID:$NB_UID --from=miniconda $CONDA_DIR $CONDA_DIR
-COPY --chown=$NB_GUID:$NB_UID --from=miniconda $HOME $HOME
+COPY --chown=1000:100 --from=miniconda $CONDA_DIR $CONDA_DIR
+COPY --chown=1000:100 --from=miniconda $HOME $HOME
 
 EXPOSE 8888
 WORKDIR $HOME

--- a/base-notebook/Dockerfile
+++ b/base-notebook/Dockerfile
@@ -1,10 +1,15 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 
+########################################
+# Stage 1
+#
+# Operating System stage taking an Official base and adding the minimal pieces to set us up for a basic Jupyter container
+
 # Ubuntu 18.04 (bionic) from 2018-05-26
 # https://github.com/docker-library/official-images/commit/aac6a45b9eb2bffb8102353c350d341a410fb169
 ARG BASE_CONTAINER=ubuntu:bionic-20180526@sha256:c8c275751219dadad8fa56b3ac41ca6cb22219ff117ca98fe82b42f24e1ba64e
-FROM $BASE_CONTAINER
+FROM $BASE_CONTAINER as base
 
 LABEL maintainer="Jupyter Project <jupyter@googlegroups.com>"
 ARG NB_USER="jovyan"
@@ -59,6 +64,14 @@ RUN echo "auth requisite pam_deny.so" >> /etc/pam.d/su && \
     fix-permissions $HOME && \
     fix-permissions "$(dirname $CONDA_DIR)"
 
+########################################
+# Stage 2
+#
+# This stage takes an OS base layer and builds in the miniconda package and Jupyter libraries.
+# RUN commands in this stage should only impact the `$CONDA_DIR` and `/home/$NB_USER` directories.
+
+FROM base as miniconda 
+
 USER $NB_UID
 
 # Setup work directory for backward-compatibility
@@ -110,7 +123,23 @@ RUN conda install --quiet --yes \
     fix-permissions $CONDA_DIR && \
     fix-permissions /home/$NB_USER
 
-USER root
+########################################
+# Stage 3
+# 
+# Copies the `$CONDA_DIR` and  `/home/$NB_USER` directories from the miniconda stage back into a fresh copy of the base stage
+
+FROM base  
+
+ENV CONDA_DIR=/opt/conda 
+ENV PATH=$CONDA_DIR/bin:$PATH \
+    MINICONDA_VERSION=$MINICONDA_VERSION \
+    CONDA_VERSION=$CONDA_VERSION \
+    JUPYTER=$CONDA_DIR/bin/jupyter
+
+USER $NB_UID
+
+COPY --chown=$NB_GUID:$NB_UID --from=miniconda $CONDA_DIR $CONDA_DIR
+COPY --chown=$NB_GUID:$NB_UID --from=miniconda $HOME $HOME
 
 EXPOSE 8888
 WORKDIR $HOME


### PR DESCRIPTION
**Please, don't accept this.**

This PR is only for demonstration, and to hold a better discussion on the topic of Multi stage building as raised in Issue:"Multi stage docker builds - reduce file size?" #775


This example (specifically commit 97d61fc) makes minimal additions to the Dockerfile of base-notebook, laying it out in three stages:

1. OS Stage
* provides the pull from Ubuntu
* installs minimal apt packages
* fixes locale and updates skel
* creates jovyan user
* does some permission patching and cleanup
2. Miniconda Stage
* installs miniconda
* sets up conda repos
* installs conda packages 
* installs lab extensions 
* does permission fixing and cleanup several  times
3. Final Stage
* starts with the image from Stage 1
* copies in the `/opt/conda` and `/home/jovyan` directories from Stage 2
* copies in all the various start-up scripts
* adds final setup pieces

Now, this all functions, and it should provide something that is nearly identical to the original version. 

That's the problem. This doesn't actually provide any benefit as-is. 

Multi stage works well in situations where you are building something that doesn't clean up well or that has bloated layers, but in the end you have a smaller, specific thing to copy into the final stage. There's enough clean-up happening in Stage 2 that I'm not seeing any size decreases in Stage 3. There doesn't seem to be cache bloat despite using multiple run statements instead of a single one, probably because of the repeated cleanup. 

Where it may be beneficial is if Stage 2 was rewritten a bit. Instead of doing permission fixes and cleanup in each run statement, if there were still multiple run statements with one additional at the end of Stage 2 cleaning everything up. This would possibly improve readability, and would very likely balloon cache sizes making the image at the end of Stage 2 much bigger. In theory, though, copying just the value-added parts from Stage 2 out and into a fresh copy of the Stage 1 base image would drop the size back down. 

I'm not sure if this is worth it, though, because I think it would drop the size back to about where you already have it. It wouldn't hurt anything, I don't think, and there may be something to stumble upon that winds up making a difference.  I'm happy to try to help by building variants, if you've got suggestions. 

For a different project, I'm playing with a variation on this container that reduces most of the fix permission statements, puts all of the package versions into ENV variables in one spot to make them easier to edit, and does some other cleanup and normalization -- all almost entirely cosmetic changes, so maybe not useful. I've also used `-f` with the `conda clean` command, which removes the copy of the install package and reduces the size considerably (at least in my case -- I have more packages initially installed). I'm not sure if there are negative repercussions to doing this, though.