### PR TITLE
[Doc] Change Spark Python Notebook entry point sentence

### DIFF
--- a/docs/using/specifics.md
+++ b/docs/using/specifics.md
@@ -13,12 +13,10 @@ Spark local mode is useful for experimentation on small data when you do not hav
 #### In a Python Notebook
 
 ```python
-import pyspark
-sc = pyspark.SparkContext('local[*]')
-
+from pyspark.sql import SparkSession
+spark = SparkSession.builder.appName("SimpleApp").getOrCreate()
 # do something to prove it works
-rdd = sc.parallelize(range(1000))
-rdd.takeSample(False, 5)
+spark.sql('SELECT "Test" as c1').show()
 ```
 
 #### In a R Notebook


### PR DESCRIPTION
I have changed the statement used to initialise the spark in _Python Notebook_ to keep up-to-date according to Spark docs. I have followed the same ideas as [**Spark Documentation**](http://spark.apache.org/docs/latest/quick-start.html#self-contained-applications) used for first _Hello World_ example.