### PR TITLE
More translation fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,7 @@ tx-en: ## rebuild en locale strings and push to master (req: GH_TOKEN)
 	@cd docs && sphinx-intl update -p _build/gettext -l en
 
 	@git add docs/locale/en
-	@git commit -m "Update en source strings for $$TRAVIS_COMMIT"
+	@git commit -m "[ci skip] Update en source strings (build: $$TRAVIS_JOB_NUMBER)"
 
 	@git remote add origin-tx https://$${GH_TOKEN}@github.com/jupyter/docker-stacks.git
 	@git push -u origin-tx master

--- a/base-notebook/hooks/post_checkout
+++ b/base-notebook/hooks/post_checkout
@@ -1,0 +1,4 @@
+#!/bin/bash
+if [[ "$COMMIT_MSG" = *"skip ci"* || "$COMMIT_MSG" = *"ci skip"* ]]; then
+    exit 1;
+fi

--- a/docs/.tx/config
+++ b/docs/.tx/config
@@ -9,19 +9,19 @@ type = PO
 
 [jupyter-docker-stacks-1.maintaining-po--master]
 file_filter = locale/<lang>/LC_MESSAGES/maintaining.po
-source_file = locale/en/LC_MESSAGES/maintaining.pot
+source_file = locale/en/LC_MESSAGES/maintaining.po
 source_lang = en
 type = PO
 
 [jupyter-docker-stacks-1.index-po--master]
 file_filter = locale/<lang>/LC_MESSAGES/index.po
-source_file = locale/en/LC_MESSAGES/index.pot
+source_file = locale/en/LC_MESSAGES/index.po
 source_lang = en
 type = PO
 
 [jupyter-docker-stacks-1.contributing-po--master]
 file_filter = locale/<lang>/LC_MESSAGES/contributing.po
-source_file = locale/en/LC_MESSAGES/contributing.pot
+source_file = locale/en/LC_MESSAGES/contributing.po
 source_lang = en
 type = PO
 

--- a/docs/locale/en/LC_MESSAGES/contributing.po
+++ b/docs/locale/en/LC_MESSAGES/contributing.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docker-stacks latest\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-05-05 23:06+0000\n"
+"POT-Creation-Date: 2019-05-05 19:53-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,12 +18,12 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.6.0\n"
 
-# 42ed854eff814cd889be11aac1e95d42
+# d5ee2bafb9214b8ab9ce05ae9bc2ff43
 #: ../../contributing/features.md:1
 msgid "New Features"
-msgstr "New Features"
+msgstr ""
 
-# 7a6a02a470144cf791c9b495c7d85a95
+# 64c3ecc68ada47afada78f945253c9e9
 #: ../../contributing/features.md:3
 msgid ""
 "Thank you for contributing to the Jupyter Docker Stacks! We review pull "
@@ -31,78 +31,61 @@ msgid ""
 "balance the value of the images to the Jupyter community with the cost of"
 " maintaining the images over time."
 msgstr ""
-"Thank you for contributing to the Jupyter Docker Stacks! We review pull "
-"requests of new features (e.g., new packages, new scripts, new flags) to "
-"balance the value of the images to the Jupyter community with the cost of"
-" maintaining the images over time."
 
-# a7f03d3bde234e279764940e78e4aac4
+# 5a3b2e0c02d04cd0913b53f5d7f7421d
 #: ../../contributing/features.md:5
 msgid "Suggesting a New Feature"
-msgstr "Suggesting a New Feature"
+msgstr ""
 
-# 5cc4fc3459b444498e0b059b5beb042a
+# c995f8cabb1d4b4fb53a9c56ae8e017b
 #: ../../contributing/features.md:7
 msgid ""
 "Please follow the process below to suggest a new feature for inclusion in"
 " one of the core stacks:"
 msgstr ""
-"Please follow the process below to suggest a new feature for inclusion in"
-" one of the core stacks:"
 
-# 0444a2939ab1494fbe9dc2b92d46aafc
+# 851e3743c7044fa6bec396a46e06937d
 #: ../../contributing/features.md:9
 msgid "Open a GitHub issue describing the feature you'd like to contribute."
-msgstr "Open a GitHub issue describing the feature you'd like to contribute."
+msgstr ""
 
-# 18905854e8f3445d9d2008b3592e9b6a
+# da218fda29544532b12be50dead6e2d0
 #: ../../contributing/features.md:10
 msgid ""
 "Discuss with the maintainers whether the addition makes sense in one of "
 "the core stacks, as a recipe in the documentation, as a community stack, "
 "or as something else entirely."
 msgstr ""
-"Discuss with the maintainers whether the addition makes sense in one of "
-"the core stacks, as a recipe in the documentation, as a community stack, "
-"or as something else entirely."
 
-# f36db2efd80a47faa3a8174ba86dd27d
+# 26fa58bfa79f4fe7b7d0294f9f4f934a
 #: ../../contributing/features.md:12
 msgid "Selection Criteria"
-msgstr "Selection Criteria"
+msgstr ""
 
-# 845cb83095fb46769fb79f07b0ff55dd
+# ca139cf0df684011bdf6f6f68e151796
 #: ../../contributing/features.md:14
 msgid ""
 "Roughly speaking, we evaluate new features based on the following "
 "criteria:"
 msgstr ""
-"Roughly speaking, we evaluate new features based on the following "
-"criteria:"
 
-# 84bfdc47b0fd4ce2a2e736ad38b70bd8
+# 55d41192f6bd4592aa15bf2fca333e4a
 #: ../../contributing/features.md:16
 msgid ""
 "Usefulness to Jupyter users: Is the feature generally applicable across "
 "domains? Does it work with Jupyter Notebook, JupyterLab, JupyterHub, "
 "etc.?"
 msgstr ""
-"Usefulness to Jupyter users: Is the feature generally applicable across "
-"domains? Does it work with Jupyter Notebook, JupyterLab, JupyterHub, "
-"etc.?"
 
-# 4022e9f60b964f26b2056aea8378011b
+# 97f3898d0a1a4ff8afa82de9d30775bc
 #: ../../contributing/features.md:17
 msgid ""
 "Fit with the image purpose: Does the feature match the theme of the stack"
 " in which it will be added? Would it fit better in a new, community "
 "stack?"
 msgstr ""
-"Fit with the image purpose: Does the feature match the theme of the stack"
-" in which it will be added? Would it fit better in a new, community "
-"stack?"
 
-# d1c38e84148b4e3694b5e1377e6169f8
+# b4ac38d7ada6485da90e64186d54dc57
 #: ../../contributing/features.md:18
 msgid ""
 "Complexity of build / runtime configuration: How many lines of code does "
@@ -110,23 +93,16 @@ msgid ""
 " require new scripts entirely? Do users need to adjust how they use the "
 "images?"
 msgstr ""
-"Complexity of build / runtime configuration: How many lines of code does "
-"the feature require in one of the Dockerfiles or startup scripts? Does it"
-" require new scripts entirely? Do users need to adjust how they use the "
-"images?"
 
-# 1b50c53660f649b4aa4dabebdd8d7f51
+# 811968d07486412bbe8d9533a429e347
 #: ../../contributing/features.md:19
 msgid ""
 "Impact on image metrics: How many bytes does the feature and its "
 "dependencies add to the image(s)? How many minutes do they add to the "
 "build time?"
 msgstr ""
-"Impact on image metrics: How many bytes does the feature and its "
-"dependencies add to the image(s)? How many minutes do they add to the "
-"build time?"
 
-# f6c186939cbe435bbb33bc1e787d733a
+# 48f6c6506d504118972db4cc965ad54b
 #: ../../contributing/features.md:20
 msgid ""
 "Ability to support the addition: Can existing maintainers answer user "
@@ -134,35 +110,27 @@ msgid ""
 "interested in helping with long-term maintenance? Can we write tests to "
 "ensure the feature continues to work over time?"
 msgstr ""
-"Ability to support the addition: Can existing maintainers answer user "
-"questions and address future build issues? Are the contributors "
-"interested in helping with long-term maintenance? Can we write tests to "
-"ensure the feature continues to work over time?"
 
-# 96a1fc99876d4a7a8872dd1448dc0efd
+# 813c0aa67a644056b5ca9b474f2edd94
 #: ../../contributing/features.md:22
 msgid "Submitting a Pull Request"
-msgstr "Submitting a Pull Request"
+msgstr ""
 
-# 0b56226c23bb459fb0bf857419d8a73f
+# f7ca9b40be90476eb97c8fcd67205e9d
 #: ../../contributing/features.md:24
 msgid ""
 "If there's agreement that the feature belongs in one or more of the core "
 "stacks:"
 msgstr ""
-"If there's agreement that the feature belongs in one or more of the core "
-"stacks:"
 
-# a57ff4b10bcc46a191df51e6feec6ff0
+# 090e533a7c02452587ee9ae774ffab49
 #: ../../contributing/features.md:26
 msgid ""
 "Implement the feature in a local clone of the jupyter/docker-stacks "
 "project."
 msgstr ""
-"Implement the feature in a local clone of the jupyter/docker-stacks "
-"project."
 
-# 2e0be99a40f942c3bf7db2ea809aedcd
+# 1532dda80ffb43ffb1617fe628c00809
 #: ../../contributing/features.md:27
 msgid ""
 "Please build the image locally before submitting a pull request. Building"
@@ -170,53 +138,44 @@ msgid ""
 "Travis CI, which graciously provides free build services for open source "
 "projects like this one.  If you use make, call:"
 msgstr ""
-"Please build the image locally before submitting a pull request. Building"
-" the image locally shortens the debugging cycle by taking some load off "
-"Travis CI, which graciously provides free build services for open source "
-"projects like this one.  If you use make, call:"
 
-# cd8681cbaebc4171a5904aaf9735a244
-# bb13ed5ba8544658a05a9bdcac4d73cf
-# 1405cd2200354bdc88479fa010412604
+# f054869250084c329c5c24debe355d38
+# bde1ad63b1e04dae9a965862b0146dd9
+# 7cbd48f6b3684c5997ac862300c43899
 #: ../../contributing/features.md:31 ../../contributing/packages.md:13
 #: ../../contributing/tests.md:20
 msgid "Submit a pull request (PR) with your changes."
-msgstr "Submit a pull request (PR) with your changes."
+msgstr ""
 
-# 20bc8ff25f634deba5e815acedddc9c1
-# 715c60cea721492a886e37c3da3b13f7
-# 8eadb0294b8d4a34b2976f6bf543237b
+# fa69df66887f47d9a9abcd75fa8a8497
+# 7083b6579dca40a487ab6bd7a21e20eb
+# 2fbcbd3f9a63431294360d65dac1734a
 #: ../../contributing/features.md:32 ../../contributing/packages.md:14
 #: ../../contributing/tests.md:21
 msgid ""
 "Watch for Travis to report a build success or failure for your PR on "
 "GitHub."
 msgstr ""
-"Watch for Travis to report a build success or failure for your PR on "
-"GitHub."
 
-# bbe0dd3831d6483aa10f7f34a6032f72
+# b6f9117aeb68454aa8a7abca30656eaa
 #: ../../contributing/features.md:33
 msgid "Discuss changes with the maintainers and address any build issues."
-msgstr "Discuss changes with the maintainers and address any build issues."
+msgstr ""
 
-# 458574c522a6409998d7072642a9c111
+# 42d6a0e44b104e1dbb87efffd722f75f
 #: ../../contributing/issues.md:1
 msgid "Project Issues"
-msgstr "Project Issues"
+msgstr ""
 
-# cd97c3e6d3734bcf8e961e54260eb2b7
+# 9c2a6e9f67354e86aca23758676fca43
 #: ../../contributing/issues.md:3
 msgid ""
 "We appreciate your taking the time to report an issue you encountered "
 "using the Jupyter Docker Stacks. Please review the following guidelines "
 "when reporting your problem."
 msgstr ""
-"We appreciate your taking the time to report an issue you encountered "
-"using the Jupyter Docker Stacks. Please review the following guidelines "
-"when reporting your problem."
 
-# a789fa906d744092a821af431c0efd64
+# 6a629d63e2df4d63a6d46b008639cc37
 #: ../../contributing/issues.md:7
 msgid ""
 "If you believe you’ve found a security vulnerability in any of the "
@@ -224,12 +183,8 @@ msgid ""
 "it to security@ipython.org, not in the issue trackers on GitHub. If you "
 "prefer to encrypt your security reports, you can use this PGP public key."
 msgstr ""
-"If you believe you’ve found a security vulnerability in any of the "
-"Jupyter projects included in Jupyter Docker Stacks images, please report "
-"it to security@ipython.org, not in the issue trackers on GitHub. If you "
-"prefer to encrypt your security reports, you can use this PGP public key."
 
-# c6bfa1b6c59748d4b43dae756cec5429
+# 530d75c287e542b194e6e6d1f2982ea7
 #: ../../contributing/issues.md:13
 msgid ""
 "If you think your problem is unique to the Jupyter Docker Stacks images, "
@@ -237,23 +192,16 @@ msgid ""
 "else has already reported the same problem. If not, please open a new "
 "issue and provide all of the information requested in the issue template."
 msgstr ""
-"If you think your problem is unique to the Jupyter Docker Stacks images, "
-"please search the jupyter/docker-stacks issue tracker to see if someone "
-"else has already reported the same problem. If not, please open a new "
-"issue and provide all of the information requested in the issue template."
 
-# 69b4949f6451443894d29213d7945498
+# 69a18cc239b34b94800599bf185f58d6
 #: ../../contributing/issues.md:19
 msgid ""
 "If the issue you're seeing is with one of the open source libraries "
 "included in the Docker images and is reproducible outside the images, "
 "please file a bug with the appropriate open source project."
 msgstr ""
-"If the issue you're seeing is with one of the open source libraries "
-"included in the Docker images and is reproducible outside the images, "
-"please file a bug with the appropriate open source project."
 
-# 9783f3cab19c4139bd21d325c4185e13
+# d60d9c017ea7411499fc4b8844685e8a
 #: ../../contributing/issues.md:22
 msgid ""
 "If you have a general question about how to use the Jupyter Docker Stacks"
@@ -261,42 +209,33 @@ msgid ""
 "customizations, and so on, please post your question on the Jupyter "
 "Discourse site."
 msgstr ""
-"If you have a general question about how to use the Jupyter Docker Stacks"
-" in your environment, in conjunction with other tools, with "
-"customizations, and so on, please post your question on the Jupyter "
-"Discourse site."
 
-# 9bce5a7d9ddd436cab0f2957c2cce182
+# 92d4aa6314a14654a1bfb74f8768cff7
 #: ../../contributing/packages.md:1
 msgid "Package Updates"
-msgstr "Package Updates"
+msgstr ""
 
-# b9ff8d01a42c4c0f89f2bf722c4e781e
+# 5f269a667f9a4c3ca342cfb49ecaefb2
 #: ../../contributing/packages.md:3
 msgid ""
 "We actively seek pull requests which update packages already included in "
 "the project Dockerfiles. This is a great way for first-time contributors "
 "to participate in developing the Jupyter Docker Stacks."
 msgstr ""
-"We actively seek pull requests which update packages already included in "
-"the project Dockerfiles. This is a great way for first-time contributors "
-"to participate in developing the Jupyter Docker Stacks."
 
-# b8d55953b3584aab83a7113c9a7d78b0
+# 30d4a79bce8d439d97e6e3555a088548
 #: ../../contributing/packages.md:5
 msgid "Please follow the process below to update a package version:"
-msgstr "Please follow the process below to update a package version:"
+msgstr ""
 
-# f2d554579cb049b38c04ee22e9b6715e
+# ba2bf1a38d6d4e42b9cb01d0aceb569f
 #: ../../contributing/packages.md:7
 msgid ""
 "Locate the Dockerfile containing the library you wish to update (e.g., "
 "base-notebook/Dockerfile, scipy-notebook/Dockerfile)"
 msgstr ""
-"Locate the Dockerfile containing the library you wish to update (e.g., "
-"base-notebook/Dockerfile, scipy-notebook/Dockerfile)"
 
-# 51b5ad7a8d844bc9bdbc1c4663bc527f
+# 837f2edd02f340a7b903654a976afd34
 #: ../../contributing/packages.md:8
 msgid ""
 "Adjust the version number for the package. We prefer to pin the major and"
@@ -305,13 +244,8 @@ msgid ""
 "Jupyter Notebook package, notebook, installed using conda with "
 "notebook=5.4.*."
 msgstr ""
-"Adjust the version number for the package. We prefer to pin the major and"
-" minor version number of packages so as to minimize rebuild side-effects "
-"when users submit pull requests (PRs). For example, you'll find the "
-"Jupyter Notebook package, notebook, installed using conda with "
-"notebook=5.4.*."
 
-# 5b7ac3a1842d408a853237d5775419ed
+# f81a7974c2ea4016b2ba58da4c04be68
 #: ../../contributing/packages.md:9
 msgid ""
 "Please build the image locally before submitting a pull request. Building"
@@ -319,78 +253,61 @@ msgid ""
 "Travis CI, which graciously provides free build services for open source "
 "projects like this one. If you use make, call:"
 msgstr ""
-"Please build the image locally before submitting a pull request. Building"
-" the image locally shortens the debugging cycle by taking some load off "
-"Travis CI, which graciously provides free build services for open source "
-"projects like this one. If you use make, call:"
 
-# 8f8307e6ce8c42038ab951d7fb356f63
+# 2fb7c7978a604dc9a758890e633913f3
 #: ../../contributing/packages.md:15
 msgid ""
 "Discuss changes with the maintainers and address any build issues. "
 "Version conflicts are the most common problem. You may need to upgrade "
 "additional packages to fix build failures."
 msgstr ""
-"Discuss changes with the maintainers and address any build issues. "
-"Version conflicts are the most common problem. You may need to upgrade "
-"additional packages to fix build failures."
 
-# b3015ce9181643cfb67f47b2bf56c91a
+# 8df94bc571bb4beabe013aab3de18311
 #: ../../contributing/recipes.md:1
 msgid "New Recipes"
-msgstr "New Recipes"
+msgstr ""
 
-# 33b0cb1bc2e843e08212429fbf434868
+# 8c8691f0a2734bc78005b61f4b0ab06b
 #: ../../contributing/recipes.md:3
 msgid ""
 "We welcome contributions of recipes, short examples of using, "
 "configuring, or extending the Docker Stacks, for inclusion in the "
 "documentation site. Follow the process below to add a new recipe:"
 msgstr ""
-"We welcome contributions of recipes, short examples of using, "
-"configuring, or extending the Docker Stacks, for inclusion in the "
-"documentation site. Follow the process below to add a new recipe:"
 
-# 4ffc3803bb114644b041e336a5010316
+# f5d1aba922b64f9783587c8f1d774c61
 #: ../../contributing/recipes.md:5
 msgid "Open the docs/using/recipes.md source file."
-msgstr "Open the docs/using/recipes.md source file."
+msgstr ""
 
-# 138a5432f8e54b22963409b8926f4821
+# 131d0a36cdf64d50b2fa88a9f6aa3db7
 #: ../../contributing/recipes.md:6
-#, fuzzy
 msgid ""
 "Add a second-level Markdown heading naming your recipe at the bottom of "
 "the file (e.g., ## Add the RISE extension)"
 msgstr ""
-"Add a second-level Markdown heading naming your recipe at the bottom of "
-"the file (e.g., `## Add the RISE extension``)"
 
-# 3fc885ac47c640daa794c08d187161b9
+# 8838b0ff2be24c23afaca9a6f43a9b66
 #: ../../contributing/recipes.md:7
 msgid ""
 "Write the body of your recipe under the heading, including whatever "
 "command line, Dockerfile, links, etc. you need."
 msgstr ""
-"Write the body of your recipe under the heading, including whatever "
-"command line, Dockerfile, links, etc. you need."
 
-# 0b4f144a94634e6ea20bbefb15139f9e
-# fc3a52f7f3ae4587af23e7882689ab08
+# 31dad868af94494b91992050c12ec1d7
+# ee54777f272048c4919f263f299c5104
 #: ../../contributing/recipes.md:8 ../../contributing/stacks.md:111
 msgid ""
 "Submit a pull request (PR) with your changes. Maintainers will respond "
 "and work with you to address any formatting or content issues."
 msgstr ""
-"Submit a pull request (PR) with your changes. Maintainers will respond "
-"and work with you to address any formatting or content issues."
 
-# 6aec499771274ebd98887c6eea529dfc
+# 27c1019878c14639a9f4b418195821fc
 #: ../../contributing/stacks.md:1
 msgid "Community Stacks"
-msgstr "Community Stacks"
+msgstr ""
 
-# f13229a04d7c4ad09a143dd8c79e4e6e
+# 5e68ee416aa841b1a7cbb957b0180bea
 #: ../../contributing/stacks.md:3
 msgid ""
 "We love to see the community create and share new Jupyter Docker images. "
@@ -398,258 +315,216 @@ msgid ""
 "help you get started defining, building, and sharing your Jupyter "
 "environments in Docker. Following these steps will:"
 msgstr ""
-"We love to see the community create and share new Jupyter Docker images. "
-"We've put together a cookiecutter project and the documentation below to "
-"help you get started defining, building, and sharing your Jupyter "
-"environments in Docker. Following these steps will:"
 
-# f7193c8b7ef64a719237295040c1bbf2
+# f0bac1d3b53d406896f6d63c93612805
 #: ../../contributing/stacks.md:5
 msgid ""
 "Setup a project on GitHub containing a Dockerfile based on either the "
 "jupyter/base-notebook or jupyter/minimal-notebook image."
 msgstr ""
-"Setup a project on GitHub containing a Dockerfile based on either the "
-"jupyter/base-notebook or jupyter/minimal-notebook image."
 
-# 5d3ee265bf1143509880e3750f1e213b
+# 8fa22b86dc9f4750b0b903371f16c1e6
 #: ../../contributing/stacks.md:6
 msgid ""
 "Configure Travis CI to build and test your image when users submit pull "
 "requests to your repository."
 msgstr ""
-"Configure Travis CI to build and test your image when users submit pull "
-"requests to your repository."
 
-# 2b492b871eca4b4192a66f9963fd3d85
+# cb04d6b8877b47e78277b7025f642ae3
 #: ../../contributing/stacks.md:7
 msgid "Configure Docker Cloud to build and host your images for others to use."
-msgstr "Configure Docker Cloud to build and host your images for others to use."
+msgstr ""
 
-# da432fd45cdd47a986419035bc9b7dbb
+# 2663c2d034934a7b81d81845288eb18c
 #: ../../contributing/stacks.md:8
 msgid ""
 "Update the list of community stacks in this documentation to include your"
 " image."
 msgstr ""
-"Update the list of community stacks in this documentation to include your"
-" image."
 
-# d4a4e24c2326462a8916f227d827a872
+# 8e0fd1dc73cc40ceab19307d0cd809c1
 #: ../../contributing/stacks.md:10
 msgid ""
 "This approach mirrors how we build and share the core stack images. Feel "
 "free to follow it or pave your own path using alternative services and "
 "build tools."
 msgstr ""
-"This approach mirrors how we build and share the core stack images. Feel "
-"free to follow it or pave your own path using alternative services and "
-"build tools."
 
-# 4ca9c782b9ac41ac95ca64b0496f22af
+# a959f079576b42e7aad7961aa18c711e
 #: ../../contributing/stacks.md:12
 msgid "Creating a Project"
-msgstr "Creating a Project"
+msgstr ""
 
-# 58bb566813774168899c9d85157b4543
+# b531336cf1e44916934b6439c16e59d8
 #: ../../contributing/stacks.md:14
 msgid "First, install cookiecutter using pip or conda:"
-msgstr "First, install cookiecutter using pip or conda:"
+msgstr ""
 
-# e8fee26c261a417b8f52263c3e829870
+# 02a8355204114fedbff0806aa1c0cfe7
 #: ../../contributing/stacks.md:20
 msgid ""
 "Run the cookiecutter command pointing to the jupyter/cookiecutter-docker-"
 "stacks project on GitHub."
 msgstr ""
-"Run the cookiecutter command pointing to the jupyter/cookiecutter-docker-"
-"stacks project on GitHub."
 
-# 0f30eb548b8740b2b83fec1301317ba7
+# 676ff068156d4ca7b1043b4a4fe2d1f1
 #: ../../contributing/stacks.md:26
 msgid ""
 "Enter a name for your new stack image. This will serve as both the git "
 "repository name and the part of the Docker image name after the slash."
 msgstr ""
-"Enter a name for your new stack image. This will serve as both the git "
-"repository name and the part of the Docker image name after the slash."
 
-# 10a7c00686be4cd3939f2a515735ba96
+# 96deffa98bab47da82e5598e549c8a39
 #: ../../contributing/stacks.md:33
 msgid ""
 "Enter the user or organization name under which this stack will reside on"
 " Docker Cloud / Hub. You must have access to manage this Docker Cloud org"
 " in order to push images here and setup automated builds."
 msgstr ""
-"Enter the user or organization name under which this stack will reside on"
-" Docker Cloud / Hub. You must have access to manage this Docker Cloud org"
-" in order to push images here and setup automated builds."
 
-# d18c1701255141cb8a76a5ae702a8e27
+# b796c2d7c08b4a1db5cdfd3de7d84c16
 #: ../../contributing/stacks.md:41
 msgid ""
 "Select an image from the jupyter/docker-stacks project that will serve as"
 " the base for your new image."
 msgstr ""
-"Select an image from the jupyter/docker-stacks project that will serve as"
-" the base for your new image."
 
-# 2a944cd68304484b8a606c07d6605b4c
+# 7ef9d73286d04b12a1350e8d9565df65
 #: ../../contributing/stacks.md:48
 msgid "Enter a longer description of the stack for your README."
-msgstr "Enter a longer description of the stack for your README."
+msgstr ""
 
-# b754546f86cb49c5b84e943466828bf5
+# 479d3a5c6ef9481a9dc4033224c540fa
 #: ../../contributing/stacks.md:54
 msgid "Initialize your project as a Git repository and push it to GitHub."
-msgstr "Initialize your project as a Git repository and push it to GitHub."
+msgstr ""
 
-# 44050d086b694e68ae8edf104d26ef16
+# 6edd8157d77d472ca6d1306223c91777
 #: ../../contributing/stacks.md:66
 msgid "Configuring Travis"
-msgstr "Configuring Travis"
+msgstr ""
 
-# 591f9a2fd2f4487c9458ab1b40ca5696
+# 38e3784d96f64d7481f0e1fd17aff9cb
 #: ../../contributing/stacks.md:68
 msgid ""
 "Next, link your GitHub project to Travis CI to build your Docker image "
 "whenever you or someone else submits a pull request."
 msgstr ""
-"Next, link your GitHub project to Travis CI to build your Docker image "
-"whenever you or someone else submits a pull request."
 
-# 39623b5e06bb44449d9fee64f0c06cd7
+# 2c032b71ddcb4495a9f609d9a35aedd7
 #: ../../contributing/stacks.md:70
 msgid ""
 "Visit https://docs.travis-ci.com/user/getting-started/#To-get-started-"
 "with-Travis-CI and follow the instructions to add the Travis CI "
 "application to your GitHub account."
 msgstr ""
-"Visit https://docs.travis-ci.com/user/getting-started/#To-get-started-"
-"with-Travis-CI and follow the instructions to add the Travis CI "
-"application to your GitHub account."
 
-# 7d9d116c675a4542b3d01c3f7a19e7c0
+# 3bbb8357183241f7b5b82c7dd4b94b66
 #: ../../contributing/stacks.md:71
 msgid "Visit https://travis-ci.org."
-msgstr "Visit https://travis-ci.org."
+msgstr ""
 
-# 6f25d79f47c54e798268bc172985945d
+# d6d51a4bd0a54432a6fdd835ff9064c5
 #: ../../contributing/stacks.md:72
 msgid "Click the + symbol at the top of the left sidebar."
-msgstr "Click the + symbol at the top of the left sidebar."
+msgstr ""
 
-# efd68c120341467b80071294ff445baf
+# ac370ece6fb24becb8034cb994ad8f4b
 #: ../../contributing/stacks.md:74
 msgid ""
 "Locate your project repository either in your primary user account or in "
 "one of the organizations to which you belong."
 msgstr ""
-"Locate your project repository either in your primary user account or in "
-"one of the organizations to which you belong."
 
-# b57fc1c84b094134a7543db0e4d6d051
+# 6b6a7bab547d4e25bd930009a6a9ea44
 #: ../../contributing/stacks.md:75
 msgid "Click the toggle to enable builds for the project repository."
-msgstr "Click the toggle to enable builds for the project repository."
+msgstr ""
 
-# dd3ae48f89d340538fa7844aff123231
+# 78e190712611492fade3d0c8ddded057
 #: ../../contributing/stacks.md:76
 msgid "Click the Settings button for that repository."
-msgstr "Click the Settings button for that repository."
+msgstr ""
 
-# 15b785ab06204b8eb7f6a7b166d8c7d7
+# f8f7e84ec3754ea6b3641002d4ef764a
 #: ../../contributing/stacks.md:78
 msgid ""
 "Enable Build only if .travis.yml is present and Build pushed pull "
 "requests."
 msgstr ""
-"Enable Build only if .travis.yml is present and Build pushed pull "
-"requests."
 
-# bbf3745e119b44c9814bf0ceb1e26d64
+# 03ef310b054e4a60aaa09b3b1b14f94c
 #: ../../contributing/stacks.md:80
 msgid "Disable Build pushed branches."
-msgstr "Disable Build pushed branches."
+msgstr ""
 
-# 3d86fa8713364ee085d79a550902e6fd
+# 26ed9349e73f4a65b8195acfcada213b
 #: ../../contributing/stacks.md:82
 msgid "Configuring Docker Cloud"
-msgstr "Configuring Docker Cloud"
+msgstr ""
 
-# 3ed5b8c6932c4bcbaac1e0a878e6bcf0
+# f0c01a2906494d039d73324e90cbae44
 #: ../../contributing/stacks.md:84
 msgid ""
 "Now, configure Docker Cloud to build your stack image and push it to "
 "Docker Hub repository whenever you merge a GitHub pull request to the "
 "master branch of your project."
 msgstr ""
-"Now, configure Docker Cloud to build your stack image and push it to "
-"Docker Hub repository whenever you merge a GitHub pull request to the "
-"master branch of your project."
 
-# 5864d84b0c554bcf984743943189fb6d
+# 67de7e2035dc4a329091875f97fb0ee4
 #: ../../contributing/stacks.md:86
 msgid "Visit https://cloud.docker.com/ and login."
-msgstr "Visit https://cloud.docker.com/ and login."
+msgstr ""
 
-# 96b12f906e7f42aeaed17ee73c6705ff
+# f32a2dc2e1ec45b39867be18be6cbd79
 #: ../../contributing/stacks.md:87
 msgid ""
 "Select the account or organization matching the one you entered when "
 "prompted with stack_org by the cookiecutter."
 msgstr ""
-"Select the account or organization matching the one you entered when "
-"prompted with stack_org by the cookiecutter."
 
-# 3b759149832d4578bcd3773ec6c03b7a
+# e6518d4caa3b418abf3ae0c90311dddf
 #: ../../contributing/stacks.md:89
 msgid "Scroll to the bottom of the page and click Create repository."
-msgstr "Scroll to the bottom of the page and click Create repository."
+msgstr ""
 
-# c5f92b7adc094ff5b1e8fa6fa62dce32
+# 4763c352de32492c9a843574846adb59
 #: ../../contributing/stacks.md:90
 msgid ""
 "Enter the name of the image matching the one you entered when prompted "
 "with stack_name by the cookiecutter."
 msgstr ""
-"Enter the name of the image matching the one you entered when prompted "
-"with stack_name by the cookiecutter."
 
-# 46a0b6430f424232a18c41d19f58a0f8
+# 79092e5007ba4bdead594a71e30cd58a
 #: ../../contributing/stacks.md:92
 msgid "Enter a description for your image."
-msgstr "Enter a description for your image."
+msgstr ""
 
-# 131388815a754031a66392f1271c74d1
+# 720800dc73ee497689251633489e09ff
 #: ../../contributing/stacks.md:93
 msgid ""
 "Click GitHub under the Build Settings and follow the prompts to connect "
 "your account if it is not already connected."
 msgstr ""
-"Click GitHub under the Build Settings and follow the prompts to connect "
-"your account if it is not already connected."
 
-# 6852bd6744a6477596cdc957f0abff14
+# e085cfd6d7664d04bcd14ce89f24b75a
 #: ../../contributing/stacks.md:94
 msgid ""
 "Select the GitHub organization and repository containing your image "
 "definition from the dropdowns."
 msgstr ""
-"Select the GitHub organization and repository containing your image "
-"definition from the dropdowns."
 
-# a507eb89bc87484ab6f325f10c88117f
+# 700a2f14a3df44459dc7c4fb5627dff6
 #: ../../contributing/stacks.md:96
 msgid "Click the Create and Build button."
-msgstr "Click the Create and Build button."
+msgstr ""
 
-# 34b69f9822d94ccab45a52d661a24e26
+# 90bca72ef3f848c8bcd46aacc3362448
 #: ../../contributing/stacks.md:98
 msgid "Defining Your Image"
-msgstr "Defining Your Image"
+msgstr ""
 
-# 05859709367e4fa58b58954dc9769886
+# fa24b82e07b54a63bf24c3126d9c90b0
 #: ../../contributing/stacks.md:100
 msgid ""
 "Make edits the Dockerfile in your project to add third-party libraries "
@@ -657,81 +532,65 @@ msgid ""
 " stacks (e.g., jupyter/datascience-notebook) to get a feel for what's "
 "possible and best practices."
 msgstr ""
-"Make edits the Dockerfile in your project to add third-party libraries "
-"and configure Jupyter applications. Refer to the Dockerfiles for the core"
-" stacks (e.g., jupyter/datascience-notebook) to get a feel for what's "
-"possible and best practices."
 
-# 8d39a42dda4a4ea78611c34a25c086d9
+# 6fd6540df8a64d769f3f0734b976d12e
 #: ../../contributing/stacks.md:102
 msgid ""
 "Submit pull requests to your project repository on GitHub. Ensure your "
 "image builds properly on Travis before merging to master. Refer to Docker"
 " Cloud for builds of your master branch that you can docker pull."
 msgstr ""
-"Submit pull requests to your project repository on GitHub. Ensure your "
-"image builds properly on Travis before merging to master. Refer to Docker"
-" Cloud for builds of your master branch that you can docker pull."
 
-# b843ce85483f40ef870c287241af10b1
+# ac1f142f0d8745428be05d7ff3549c13
 #: ../../contributing/stacks.md:104
 msgid "Sharing Your Image"
-msgstr "Sharing Your Image"
+msgstr ""
 
-# 87acc80295a842519812b325627ca386
+# d8e9f1a37f4c4a72bb630e7a3b265b92
 #: ../../contributing/stacks.md:106
 msgid ""
 "Finally, if you'd like to add a link to your project to this "
 "documentation site, please do the following:"
 msgstr ""
-"Finally, if you'd like to add a link to your project to this "
-"documentation site, please do the following:"
 
-# 2a600b83376947dc8ea0b5da0c5a74a6
+# 200610af72b540c9896d206dd27623e8
 #: ../../contributing/stacks.md:108
 msgid "Clone ths jupyter/docker-stacks GitHub repository."
-msgstr "Clone ths jupyter/docker-stacks GitHub repository."
+msgstr ""
 
-# f7be43601f1e49eaa58d68d93734ad01
+# 7316f6af4b6f44468a68c8890a419aee
 #: ../../contributing/stacks.md:109
 msgid ""
 "Open the docs/using/selecting.md source file and locate the Community "
 "Stacks section."
 msgstr ""
-"Open the docs/using/selecting.md source file and locate the Community "
-"Stacks section."
 
-# 4438e0314cd049738a9540510b991c52
+# 9d37dfec6fba48e6966c254b476e1e81
 #: ../../contributing/stacks.md:110
 msgid ""
 "Add a bullet with a link to your project and a short description of what "
 "your Docker image contains."
 msgstr ""
-"Add a bullet with a link to your project and a short description of what "
-"your Docker image contains."
 
-# 120b0e2c0ac34107919b2b7155c46213
+# 8d835a3452014d62a974286f209f84ce
 #: ../../contributing/tests.md:1
 msgid "Image Tests"
-msgstr "Image Tests"
+msgstr ""
 
-# c1e454ec3dae44699e4f7794ae3f3c52
+# 6dbd44985f3c4ba1a3823c90c5944ad0
 #: ../../contributing/tests.md:3
 msgid ""
 "We greatly appreciate pull requests that extend the automated tests that "
 "vet the basic functionality of the Docker images."
 msgstr ""
-"We greatly appreciate pull requests that extend the automated tests that "
-"vet the basic functionality of the Docker images."
 
-# dde69af7a4ae4648bd3a3d5cdd6e0633
+# 4642bf6f1d2649c381a13b97b7d29d42
 #: ../../contributing/tests.md:5
 msgid "How the Tests Work"
-msgstr "How the Tests Work"
+msgstr ""
 
-# a483721133de493e98596e01e7439b86
+# 8cf4546daeba45a6abd2eb0cd7fc2b73
 #: ../../contributing/tests.md:7
-#, fuzzy
 msgid ""
 "Travis executes make build-test-all against pull requests submitted to "
 "the jupyter/docker-stacks repository. This make command builds every "
@@ -741,66 +600,51 @@ msgid ""
 "pytest fixtures defined in the conftest.py file at the root of the "
 "projects."
 msgstr ""
-"Travis executes make build-test-all against every pull request submitted "
-"to the jupyter/docker-stacks repository. The make command builds every "
-"docker image. After building each image, the make command executes pytest"
-" to run both image-specific tests like those in base-notebook/test/ and "
-"common tests defined in test/. Both kinds of tests make use of global "
-"pytest fixtures defined in the conftest.py file at the root of the "
-"projects."
 
-# 04158d1543c4457b94e1e37ed6b70937
+# 02fe04b413994b57af9c948cb25ce53d
 #: ../../contributing/tests.md:9
 msgid "Contributing New Tests"
-msgstr "Contributing New Tests"
+msgstr ""
 
-# da8dc9df5367484b9b5738bad494a6fc
+# d317e6be0fbf487e8528ff1fe0bbdb78
 #: ../../contributing/tests.md:11
 msgid "Please follow the process below to add new tests:"
-msgstr "Please follow the process below to add new tests:"
+msgstr ""
 
-# 7d1b911560634ea98593c47169fd7dd9
+# 5db827e3a1a34a7097fda2c23743116f
 #: ../../contributing/tests.md:13
 msgid ""
 "If the test should run against every image built, add your test code to "
 "one of the modules in test/ or create a new module."
 msgstr ""
-"If the test should run against every image built, add your test code to "
-"one of the modules in test/ or create a new module."
 
-# daa6dce541fa4975b6d4773a76cad087
+# 58c90865c96f43138ec9089b67c7d5ba
 #: ../../contributing/tests.md:14
 msgid ""
 "If your test should run against a single image, add your test code to one"
 " of the modules in some-notebook/test/ or create a new module."
 msgstr ""
-"If your test should run against a single image, add your test code to one"
-" of the modules in some-notebook/test/ or create a new module."
 
-# c48caffeb27e4490b1a5af8416eacf03
+# 332e0f9399a54ef4a488a7392a18a2a0
 #: ../../contributing/tests.md:15
 msgid ""
 "Build one or more images you intend to test and run the tests locally. If"
 " you use make, call:"
 msgstr ""
-"Build one or more images you intend to test and run the tests locally. If"
-" you use make, call:"
 
-# 500bd3b120bc4f42afcc7c073f8e4209
+# 760abcc7be7744858eda5ee0b7be3107
 #: ../../contributing/tests.md:22
 msgid ""
 "Discuss changes with the maintainers and address any issues running the "
 "tests on Travis."
 msgstr ""
-"Discuss changes with the maintainers and address any issues running the "
-"tests on Travis."
 
-# fef5bac0c6f14b5997f729da99cb5542
+# 3bf94cce9dcd4567b7414c40d7db827c
 #: ../../contributing/translations.md:1
 msgid "Doc Translations"
 msgstr ""
 
-# cd9c10a7ed61493ebdc911db42e1152f
+# caa387c3e37b492fb588b5d54d9e092f
 #: ../../contributing/translations.md:3
 msgid ""
 "We are delighted when members of the Jupyter community want to help "
@@ -810,12 +654,12 @@ msgid ""
 "Jupyter Docker Stacks documentation."
 msgstr ""
 
-# c8360556ab514965af3de36ecd14345b
+# 78f5029763cc4c3f9c4132202f30b083
 #: ../../contributing/translations.md:5
 msgid "Follow the steps documented on the Getting Started as a Translator page."
 msgstr ""
 
-# 20ff051bd9184346b79f7ba88d8b5092
+# 44a72a4bb6934e56b0e3d1eb78280d01
 #: ../../contributing/translations.md:6
 msgid ""
 "Look for jupyter-docker-stacks when prompted to choose a translation "
@@ -824,7 +668,7 @@ msgid ""
 "the project."
 msgstr ""
 
-# 9cc4615b079645a59e5417e7eadd5aca
+# 24a937946b16417a8bfe6715ea9a9eea
 #: ../../contributing/translations.md:7
 msgid "See Translating with the Web Editor in the Transifex documentation."
 msgstr ""

--- a/docs/locale/en/LC_MESSAGES/index.po
+++ b/docs/locale/en/LC_MESSAGES/index.po
@@ -1,78 +1,77 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) 2018- Project Jupyter
-# This file is distributed under the same license as the docker-stacks package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-# 
+# This file is distributed under the same license as the docker-stacks
+# package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2019.
+#
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: docker-stacks latest\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-04-21 17:25-0400\n"
+"POT-Creation-Date: 2019-05-05 19:53-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.6.0\n"
 
-# 85291a2c92d440a089cf156fba58b86a
-#: ../../index.rst:32 ../../index.rst:32
+# 22f1bd46933144e092bf92e3af4c6f4f
+#: ../../index.rst:32
 msgid "User Guide"
-msgstr "User Guide"
+msgstr ""
 
-# e4a3fd32059d4486b6b0f3a6fb5065b5
-#: ../../index.rst:42 ../../index.rst:42
+# f35d75046f8c42ae8cab58d826154823
+#: ../../index.rst:42
 msgid "Contributor Guide"
-msgstr "Contributor Guide"
+msgstr ""
 
-# 45de48c8617d4ebe83b7ff7141295836
-#: ../../index.rst:53 ../../index.rst:53
+# a737afe726cd49c4986d75b7d74eeed3
+#: ../../index.rst:54
 msgid "Maintainer Guide"
-msgstr "Maintainer Guide"
+msgstr ""
 
-# aa99c4562d8d4cb3abfea375470e8af3
-#: ../../index.rst:59 ../../index.rst:59
+# 9cd216fa91ef40bbb957373faaf93732
+#: ../../index.rst:60
 msgid "Getting Help"
-msgstr "Getting Help"
+msgstr ""
 
-# 76df09037a6147c8a85be8ef14c15532
+# a0aa0bcd999c4c5e96cc57fd77780f96
 #: ../../index.rst:2
 msgid "Jupyter Docker Stacks"
-msgstr "Jupyter Docker Stacks"
+msgstr ""
 
-# b3fb253184e64174b26a2da73f221cc1
+# 5d06f458dc524214b2c97e865dd2dc81
 #: ../../index.rst:4
 msgid ""
 "Jupyter Docker Stacks are a set of ready-to-run Docker images containing "
-"Jupyter applications and interactive computing tools. You can use a stack "
-"image to do any of the following (and more):"
+"Jupyter applications and interactive computing tools. You can use a stack"
+" image to do any of the following (and more):"
 msgstr ""
-"Jupyter Docker Stacks are a set of ready-to-run Docker images containing "
-"Jupyter applications and interactive computing tools. You can use a stack "
-"image to do any of the following (and more):"
 
-# 8cd55fb113a049e7be445b21084df7ea
+# c69f151c806e4cdf9bebda05b06c760e
 #: ../../index.rst:6
 msgid "Start a personal Jupyter Notebook server in a local Docker container"
-msgstr "Start a personal Jupyter Notebook server in a local Docker container"
+msgstr ""
 
-# 285fa13bed8547b4af0cfc480adf4861
+# b26271409ab743b2a349b3a8ca95233e
 #: ../../index.rst:7
 msgid "Run JupyterLab servers for a team using JupyterHub"
-msgstr "Run JupyterLab servers for a team using JupyterHub"
+msgstr ""
 
-# a49d31cedd4946ea98d7a4c720340d84
+# 4d60f4325fff4ffcad12703a4b9d6781
 #: ../../index.rst:8
 msgid "Write your own project Dockerfile"
-msgstr "Write your own project Dockerfile"
+msgstr ""
 
-# 0aff0df2e46a44b4bc8070545e83c42c
+# 78b0d31eb6e9462888eef92e6a84cdb7
 #: ../../index.rst:11
 msgid "Quick Start"
-msgstr "Quick Start"
+msgstr ""
 
-# 3262accd283140058db73005072be200
+# d4c0e237dbe74e0d9afbf2b2f0e219c8
 #: ../../index.rst:13
 msgid ""
 "You can try a `recent build of the jupyter/base-notebook image on "
@@ -83,89 +82,56 @@ msgid ""
 ":doc:`which Docker image <using/selecting>` you want to use, and want to "
 "launch a single Jupyter Notebook server in a container."
 msgstr ""
-"You can try a `recent build of the jupyter/base-notebook image on "
-"mybinder.org <https://mybinder.org/v2/gh/jupyter/docker-"
-"stacks/master?filepath=README.ipynb>`_ by simply clicking the preceding "
-"link. Otherwise, the two examples below may help you get started if you "
-"`have Docker installed <https://docs.docker.com/install/>`_, know "
-":doc:`which Docker image <using/selecting>` you want to use, and want to "
-"launch a single Jupyter Notebook server in a container."
 
-# 9e4094e8de264e20bca0af8f6cf888b7
+# 051ed23ef62e41058a7c889604f96035
 #: ../../index.rst:15
 msgid ""
-"The other pages in this documentation describe additional uses and features "
-"in detail."
+"The other pages in this documentation describe additional uses and "
+"features in detail."
 msgstr ""
-"The other pages in this documentation describe additional uses and features "
-"in detail."
 
-# 8b75310f2eaa4aac95d9387e0a4db9e8
+# e91f3b62a1b54166b966be6d7a4f061e
 #: ../../index.rst:17
 msgid ""
 "**Example 1:** This command pulls the ``jupyter/scipy-notebook`` image "
-"tagged ``17aba6048f44`` from Docker Hub if it is not already present on the "
-"local host. It then starts a container running a Jupyter Notebook server and"
-" exposes the server on host port 8888. The server logs appear in the "
-"terminal. Visiting ``http://<hostname>:8888/?token=<token>`` in a browser "
-"loads the Jupyter Notebook dashboard page, where ``hostname`` is the name of"
-" the computer running docker and ``token`` is the secret token printed in "
-"the console. The container remains intact for restart after the notebook "
-"server exits.::"
+"tagged ``17aba6048f44`` from Docker Hub if it is not already present on "
+"the local host. It then starts a container running a Jupyter Notebook "
+"server and exposes the server on host port 8888. The server logs appear "
+"in the terminal. Visiting ``http://<hostname>:8888/?token=<token>`` in a "
+"browser loads the Jupyter Notebook dashboard page, where ``hostname`` is "
+"the name of the computer running docker and ``token`` is the secret token"
+" printed in the console. The container remains intact for restart after "
+"the notebook server exits.::"
 msgstr ""
-"**Example 1:** This command pulls the ``jupyter/scipy-notebook`` image "
-"tagged ``17aba6048f44`` from Docker Hub if it is not already present on the "
-"local host. It then starts a container running a Jupyter Notebook server and"
-" exposes the server on host port 8888. The server logs appear in the "
-"terminal. Visiting ``http://<hostname>:8888/?token=<token>`` in a browser "
-"loads the Jupyter Notebook dashboard page, where ``hostname`` is the name of"
-" the computer running docker and ``token`` is the secret token printed in "
-"the console. The container remains intact for restart after the notebook "
-"server exits.::"
 
-# 9e0229c99f404aceb7e517387ae88365
+# e04140e6cd8442f7a6f347d88224f591
 #: ../../index.rst:21
 msgid ""
-"**Example 2:** This command performs the same operations as **Example 1**, "
-"but it exposes the server on host port 10000 instead of port 8888. Visiting "
-"``http://<hostname>:10000/?token=<token>`` in a browser loads JupyterLab, "
-"where ``hostname`` is the name of the computer running docker and ``token`` "
-"is the secret token printed in the console.::"
+"**Example 2:** This command performs the same operations as **Example "
+"1**, but it exposes the server on host port 10000 instead of port 8888. "
+"Visiting ``http://<hostname>:10000/?token=<token>`` in a browser loads "
+"JupyterLab, where ``hostname`` is the name of the computer running docker"
+" and ``token`` is the secret token printed in the console.::"
 msgstr ""
-"**Example 2:** This command performs the same operations as **Example 1**, "
-"but it exposes the server on host port 10000 instead of port 8888. Visiting "
-"``http://<hostname>:10000/?token=<token>`` in a browser loads JupyterLab, "
-"where ``hostname`` is the name of the computer running docker and ``token`` "
-"is the secret token printed in the console.::"
 
-# 02c25d3f0abe48348100dd878c243a75
+# 1c3229680cf44a5bb2d8450602bfcf7d
 #: ../../index.rst:25
 msgid ""
-"**Example 3:** This command pulls the ``jupyter/datascience-notebook`` image"
-" tagged ``9b06df75e445`` from Docker Hub if it is not already present on the"
-" local host. It then starts an *ephemeral* container running a Jupyter "
-"Notebook server and exposes the server on host port 10000. The command "
-"mounts the current working directory on the host as ``/home/jovyan/work`` in"
-" the container. The server logs appear in the terminal. Visiting "
-"``http://<hostname>:10000/?token=<token>`` in a browser loads JupyterLab, "
-"where ``hostname`` is the name of the computer running docker and ``token`` "
-"is the secret token printed in the console. Docker destroys the container "
-"after notebook server exit, but any files written to ``~/work`` in the "
-"container remain intact on the host.::"
+"**Example 3:** This command pulls the ``jupyter/datascience-notebook`` "
+"image tagged ``9b06df75e445`` from Docker Hub if it is not already "
+"present on the local host. It then starts an *ephemeral* container "
+"running a Jupyter Notebook server and exposes the server on host port "
+"10000. The command mounts the current working directory on the host as "
+"``/home/jovyan/work`` in the container. The server logs appear in the "
+"terminal. Visiting ``http://<hostname>:10000/?token=<token>`` in a "
+"browser loads JupyterLab, where ``hostname`` is the name of the computer "
+"running docker and ``token`` is the secret token printed in the console. "
+"Docker destroys the container after notebook server exit, but any files "
+"written to ``~/work`` in the container remain intact on the host.::"
 msgstr ""
-"**Example 3:** This command pulls the ``jupyter/datascience-notebook`` image"
-" tagged ``9b06df75e445`` from Docker Hub if it is not already present on the"
-" local host. It then starts an *ephemeral* container running a Jupyter "
-"Notebook server and exposes the server on host port 10000. The command "
-"mounts the current working directory on the host as ``/home/jovyan/work`` in"
-" the container. The server logs appear in the terminal. Visiting "
-"``http://<hostname>:10000/?token=<token>`` in a browser loads JupyterLab, "
-"where ``hostname`` is the name of the computer running docker and ``token`` "
-"is the secret token printed in the console. Docker destroys the container "
-"after notebook server exit, but any files written to ``~/work`` in the "
-"container remain intact on the host.::"
 
-# 1bc0c7d54cd343d689362047c0b00122
+# 3ac1a41d185844b1b43315a4cc74efc8
 #: ../../index.rst:30
 msgid "Table of Contents"
-msgstr "Table of Contents"
+msgstr ""
+

--- a/docs/locale/en/LC_MESSAGES/maintaining.po
+++ b/docs/locale/en/LC_MESSAGES/maintaining.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docker-stacks latest\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-05-05 23:06+0000\n"
+"POT-Creation-Date: 2019-05-05 19:53-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,56 +18,49 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.6.0\n"
 
-# b6a590f1e4ab4bc0a9c14860d5cbdc4d
+# 99bff7d6e014436daac99d7d6c9bccf0
 #: ../../maintaining/tasks.md:1
 msgid "Maintainer Playbook"
-msgstr "Maintainer Playbook"
+msgstr ""
 
-# 7677f4cfb9814af4a32104cb255a86b6
+# 2adfeb6f61a94194b4f2cac30ebd3215
 #: ../../maintaining/tasks.md:3
 msgid "Merging Pull Requests"
-msgstr "Merging Pull Requests"
+msgstr ""
 
-# b1ec12692f4f4db6941f5c54674f26b2
+# 0a04eb6c0525428984f07f3c249f5d73
 #: ../../maintaining/tasks.md:5
 msgid ""
 "To build new images on Docker Cloud and publish them to the Docker Hub "
 "registry, do the following:"
 msgstr ""
-"To build new images on Docker Cloud and publish them to the Docker Hub "
-"registry, do the following:"
 
-# 2937ff0f3cb24b5586c8f07c6d0ee56a
+# f2710754a41e4354b51f4acd6f1f9545
 #: ../../maintaining/tasks.md:7
 msgid "Make sure Travis is green for a PR."
-msgstr "Make sure Travis is green for a PR."
+msgstr ""
 
-# e7216bde438c43daa9d1aa4ed82c4952
+# db74ca47dfde4e558a20aff52176347a
 #: ../../maintaining/tasks.md:8
 msgid "Merge the PR."
-msgstr "Merge the PR."
+msgstr ""
 
-# 4f51667b27284252bf327570b60931c7
+# 87b2e059678349b38d0badc5404484ec
 #: ../../maintaining/tasks.md:9
 msgid ""
 "Monitor the Docker Cloud build status for each of the stacks, starting "
 "with jupyter/base-notebook and ending with jupyter/all-spark-notebook. "
 "See the stack hierarchy diagram for the current, complete build order."
 msgstr ""
-"Monitor the Docker Cloud build status for each of the stacks, starting "
-"with jupyter/base-notebook and ending with jupyter/all-spark-notebook. "
-"See the stack hierarchy diagram for the current, complete build order."
 
-# 2db614a1387647eb9fb81bcf855561ac
+# 9149cb3c2bdc48ffa9109b3b6ddcf446
 #: ../../maintaining/tasks.md:10
 msgid ""
 "Manually click the retry button next to any build that fails to resume "
 "that build and any dependent builds."
 msgstr ""
-"Manually click the retry button next to any build that fails to resume "
-"that build and any dependent builds."
 
-# dee0cb20af1a4490a6236bc197f46622
+# d204ada7a14b46338be9b7afb0bc95b0
 #: ../../maintaining/tasks.md:11
 msgid ""
 "Try to avoid merging another PR to master until all outstanding builds "
@@ -75,17 +68,13 @@ msgid ""
 "through the Docker Cloud build trigger API. Every build trigger works off"
 " of master HEAD."
 msgstr ""
-"Try to avoid merging another PR to master until all outstanding builds "
-"complete. There's no way at present to propagate the git SHA to build "
-"through the Docker Cloud build trigger API. Every build trigger works off"
-" of master HEAD."
 
-# 7aa41d8da11e434d87b1700d5ba3cdc9
+# 9626663d7dc145979f6f75e7aaf7689f
 #: ../../maintaining/tasks.md:13
 msgid "Updating the Ubuntu Base Image"
-msgstr "Updating the Ubuntu Base Image"
+msgstr ""
 
-# f9cc91cb8c7648ef9bd948930e44c875
+# 6951ec7a2be24782bc2f814c5c02978a
 #: ../../maintaining/tasks.md:15
 msgid ""
 "When there's a security fix in the Ubuntu base image or after some time "
@@ -94,323 +83,290 @@ msgid ""
 "process. Expect the build to take a while to complete: every image layer "
 "will rebuild."
 msgstr ""
-"When there's a security fix in the Ubuntu base image or after some time "
-"passes, it's a good idea to update the pinned SHA in the jupyter/base-"
-"notebook Dockerfile. Submit it as a regular PR and go through the build "
-"process. Expect the build to take a while to complete: every image layer "
-"will rebuild."
 
-# 757afe44cefd4ea0b537c3453f278f6a
+# 37576597a1524fabb0ef175abe29ee8a
 #: ../../maintaining/tasks.md:17
 msgid "Adding a New Core Image to Docker Cloud"
-msgstr "Adding a New Core Image to Docker Cloud"
+msgstr ""
 
-# 6f006959be2049efb71407c403acf3a5
+# 201f0506bbb24b47b79a5db01db86557
 #: ../../maintaining/tasks.md:19
 msgid ""
 "When there's a new stack definition, do the following before merging the "
 "PR with the new stack:"
 msgstr ""
-"When there's a new stack definition, do the following before merging the "
-"PR with the new stack:"
 
-# 90a1ed140bd84cf3837a06943f93dbf9
+# 5460275aca4848e297e80aa2d9d4f3ee
 #: ../../maintaining/tasks.md:21
 msgid ""
 "Ensure the PR includes an update to the stack overview diagram in the "
 "documentation. The image links to the blockdiag source used to create it."
 msgstr ""
-"Ensure the PR includes an update to the stack overview diagram in the "
-"documentation. The image links to the blockdiag source used to create it."
 
-# 78e4a812ee79456cb01b2d71369125af
+# 0e3d12dcfb4b42b8a3d24b9401caa757
 #: ../../maintaining/tasks.md:22
 msgid ""
 "Ensure the PR updates the Makefile which is used to build the stacks in "
 "order on Travis CI."
 msgstr ""
-"Ensure the PR updates the Makefile which is used to build the stacks in "
-"order on Travis CI."
 
-# 9ee006db043c4c4b86bc0f7e4f756970
+# 4175414ec7e94aab8ae15d02afff0580
 #: ../../maintaining/tasks.md:23
 msgid ""
 "Create a new repository in the jupyter org on Docker Cloud named after "
 "the stack folder in the git repo."
 msgstr ""
-"Create a new repository in the jupyter org on Docker Cloud named after "
-"the stack folder in the git repo."
 
-# 50957c7a281b49749865a7f55d28e1be
+# eb598362707c44adadac8890755936ef
 #: ../../maintaining/tasks.md:24
 msgid "Grant the stacks team permission to write to the repo."
-msgstr "Grant the stacks team permission to write to the repo."
+msgstr ""
 
-# b73d949ce8394bd18656e3681fa7b944
+# 25076c59e0ec4dc28ee2c977d5977216
 #: ../../maintaining/tasks.md:25
 msgid "Click Builds and then Configure Automated Builds for the repository."
-msgstr "Click Builds and then Configure Automated Builds for the repository."
+msgstr ""
 
-# f208a0adc2c04ddcaf99b7e17a8b70ef
+# 1e5483f6ca3542ea9d43923d8eacf53d
 #: ../../maintaining/tasks.md:26
 msgid "Select jupyter/docker-stacks as the source repository."
-msgstr "Select jupyter/docker-stacks as the source repository."
+msgstr ""
 
-# 6515054e89bc4ad2a1b55a86d48f9ff2
+# 157cc21e4a1a4bda80d6e3f8a37c29d7
 #: ../../maintaining/tasks.md:27
 msgid ""
 "Choose Build on Docker Cloud's infrastructure using a Small node unless "
 "you have reason to believe a bigger host is required."
 msgstr ""
-"Choose Build on Docker Cloud's infrastructure using a Small node unless "
-"you have reason to believe a bigger host is required."
 
-# 5f57084b8d96479886b3738d22c283c7
+# 36c9c49d610a4e32b024413ce1924f04
 #: ../../maintaining/tasks.md:28
 msgid ""
 "Update the Build Context in the default build rule to be /<name-of-the-"
 "stack>."
 msgstr ""
-"Update the Build Context in the default build rule to be /<name-of-the-"
-"stack>."
 
-# 5f831501060e446abbee65190ed40b79
+# b98a150760924b36ad034180f6703f71
 #: ../../maintaining/tasks.md:29
 msgid ""
 "Toggle Autobuild to disabled unless the stack is a new root stack (e.g., "
 "like jupyter/base-notebook)."
 msgstr ""
-"Toggle Autobuild to disabled unless the stack is a new root stack (e.g., "
-"like jupyter/base-notebook)."
 
-# e8018e42d7414a0d8a2734796198d21b
+# dd8eb743edb8447ca525286d44c47b11
 #: ../../maintaining/tasks.md:30
 msgid "If the new stack depends on the build of another stack in the hierarchy:"
-msgstr "If the new stack depends on the build of another stack in the hierarchy:"
+msgstr ""
 
-# 9a6f9bcddb574fe78d5951034dfdaa26
+# a7dad3d094a242adadfa852c1437ec9f
 #: ../../maintaining/tasks.md:31
 msgid "Hit Save and then click Configure Automated Builds."
-msgstr "Hit Save and then click Configure Automated Builds."
+msgstr ""
 
-# d3630e11c8814d118e35f7900bf543ac
+# bd94bcfffbc449ee85ffec18d13ba909
 #: ../../maintaining/tasks.md:32
 msgid "At the very bottom, add a build trigger named Stack hierarchy trigger."
-msgstr "At the very bottom, add a build trigger named Stack hierarchy trigger."
+msgstr ""
 
-# 704b5495a93845608b35bda3341232ae
+# c1dc766b9b9f45e59510580c3e29017e
 #: ../../maintaining/tasks.md:33
 msgid "Copy the build trigger URL."
-msgstr "Copy the build trigger URL."
+msgstr ""
 
-# e96a57c3030143bfa4e72c192d5ac91c
+# c47dc2c8c04f4af9bbb059692074d979
 #: ../../maintaining/tasks.md:34
 msgid ""
 "Visit the parent repository Builds page and click Configure Automated "
 "Builds."
 msgstr ""
-"Visit the parent repository Builds page and click Configure Automated "
-"Builds."
 
-# 2f11389555c54c43bcd613e0a17ec6fe
+# 53ad6138cba343c4a2314cbdfefaa3de
 #: ../../maintaining/tasks.md:35
 msgid ""
 "Add the URL you copied to the NEXT_BUILD_TRIGGERS environment variable "
 "comma separated list of URLs, creating that environment variable if it "
 "does not already exist."
 msgstr ""
-"Add the URL you copied to the NEXT_BUILD_TRIGGERS environment variable "
-"comma separated list of URLs, creating that environment variable if it "
-"does not already exist."
 
-# f7f4c9918418475eba1dabdb0d824a0f
-# 0ff29b7ccd4e43d5ac81e85cbba06fbd
+# c1b65a945fb84b57929a970c00fe60e7
+# f235402e08104dcbac10aee2415b5aba
 #: ../../maintaining/tasks.md:36 ../../maintaining/tasks.md:40
 msgid "Hit Save."
-msgstr "Hit Save."
+msgstr ""
 
-# 0e70414ce74846499b88e0507b59f47f
+# c915beb1daef4cab989b00b571d30cbb
 #: ../../maintaining/tasks.md:37
 msgid "If the new stack should trigger other dependent builds:"
-msgstr "If the new stack should trigger other dependent builds:"
+msgstr ""
 
-# f407038a85e84f3fa9bc4175f54598f7
+# b19b3d4243a648ec9aaa46f038e29636
 #: ../../maintaining/tasks.md:38
 msgid "Add an environment variable named NEXT_BUILD_TRIGGERS."
-msgstr "Add an environment variable named NEXT_BUILD_TRIGGERS."
+msgstr ""
 
-# d8b96bb7c7cc4cccb7fa7fe12f96ab42
+# 74dbcd642b774e46aa2d472161fe228f
 #: ../../maintaining/tasks.md:39
 msgid ""
 "Copy the build trigger URLs from the dependent builds into the "
 "NEXT_BUILD_TRIGGERS comma separated list of URLs."
 msgstr ""
-"Copy the build trigger URLs from the dependent builds into the "
-"NEXT_BUILD_TRIGGERS comma separated list of URLs."
 
-# 360600c28ae247109a65b0f0b3b06e0b
+# 3d39e5c5b33641d8ba202c4cedc33849
 #: ../../maintaining/tasks.md:41
 msgid ""
 "Adjust other NEXT_BUILD_TRIGGERS values as needed so that the build order"
 " matches that in the stack hierarchy diagram."
 msgstr ""
-"Adjust other NEXT_BUILD_TRIGGERS values as needed so that the build order"
-" matches that in the stack hierarchy diagram."
 
-# e150e5c2361c457296005d1d4bcdcbf2
+# c15b6f77f0784056aa45c456e49673ff
 #: ../../maintaining/tasks.md:43
 msgid "Adding a New Maintainer Account"
-msgstr "Adding a New Maintainer Account"
+msgstr ""
 
-# abf39aef5a9c44539528c39f6c8ad983
+# e3bd3ced73994d9fad596784e1469cfc
 #: ../../maintaining/tasks.md:45
 msgid "Visit https://cloud.docker.com/app/jupyter/team/stacks/users"
-msgstr "Visit https://cloud.docker.com/app/jupyter/team/stacks/users"
+msgstr ""
 
-# 7b35523258a541fd8cd2a1c85609d46a
+# 51b166c70ba743e0b4d335b3471da69a
 #: ../../maintaining/tasks.md:46
 msgid "Add the maintainer's Docker Cloud username."
-msgstr "Add the maintainer's Docker Cloud username."
+msgstr ""
 
-# 144e77f0adae48f59acec26b63717a67
+# 300f5dbd933f4ee6b5a550efd35f1c52
 #: ../../maintaining/tasks.md:47
 msgid ""
 "Visit https://github.com/orgs/jupyter/teams/docker-image-"
 "maintainers/members"
 msgstr ""
-"Visit https://github.com/orgs/jupyter/teams/docker-image-"
-"maintainers/members"
 
-# 51df15ffb089464ab4bbc01d6b9bb240
+# e26ad8ffb6de489988e076e64b6a1415
 #: ../../maintaining/tasks.md:48
 msgid "Add the maintainer's GitHub username."
-msgstr "Add the maintainer's GitHub username."
+msgstr ""
 
-# 612a368f44994dd49c1e60ace5ab5e00
+# 97362d55b4f340e6af93e7150d357906
 #: ../../maintaining/tasks.md:50
 msgid "Pushing a Build Manually"
-msgstr "Pushing a Build Manually"
+msgstr ""
 
-# 0da877c32c1c4f6ca271d990db263ec3
+# 050b5c7a3d9d46bcbe26d54e8585ddd8
 #: ../../maintaining/tasks.md:52
 msgid ""
 "If automated builds on Docker Cloud have got you down, do the following "
 "to push a build manually:"
 msgstr ""
-"If automated builds on Docker Cloud have got you down, do the following "
-"to push a build manually:"
 
-# a31798d9c0fb4b50894dbc62fbe41469
+# ead6a3a714ae4a8a9df5585c18260c16
 #: ../../maintaining/tasks.md:54
 msgid "Clone this repository."
-msgstr "Clone this repository."
+msgstr ""
 
-# 3ec0e41666d54236bcf5fefd6d3dcd63
+# 48e1d6954f414fe080d7b4afd9e0c391
 #: ../../maintaining/tasks.md:55
 msgid "Check out the git SHA you want to build and publish."
-msgstr "Check out the git SHA you want to build and publish."
+msgstr ""
 
-# 9d4ae50163104bdf9e045722f937dcee
+# 98f385aba16144acb355a7f8ceccbf65
 #: ../../maintaining/tasks.md:56
 msgid "docker login with your Docker Hub/Cloud credentials."
-msgstr "docker login with your Docker Hub/Cloud credentials."
+msgstr ""
 
-# 8361c96028714cfc90f0c056e3c9a667
+# 580040491fc14cef9ecf16b58128093e
 #: ../../maintaining/tasks.md:57
 msgid "Run make retry/release-all."
-msgstr "Run make retry/release-all."
+msgstr ""
 
-# 8d6d2bec49254b19abd9ec65963c2d1b
+# bd3a5cebd1254827a53b9dba986e69fa
 #: ../../maintaining/tasks.md:59
 msgid "Enabling a New Doc Language Translation"
 msgstr ""
 
-# e21802d27ecc41b7a14bba3a5be7edf5
+# 5aafef10dc75417785a79aba203175e5
 #: ../../maintaining/tasks.md:61
 msgid "First enable translation on Transifex:"
 msgstr ""
 
-# 35647680591f4687b8127d74b33932aa
+# c1a249c0d0cd4e9192ed7814dfde6e34
 #: ../../maintaining/tasks.md:63
 msgid ""
 "Visit https://www.transifex.com/project-jupyter/jupyter-docker-"
 "stacks-1/languages/"
 msgstr ""
 
-# 5ec4d0534f874acfb10aa84f98ea023d
+# 3675bff3644a4d928586f884e3bf2636
 #: ../../maintaining/tasks.md:64
 msgid "Click Edit Languages in the top right."
 msgstr ""
 
-# cd9f57630a704841b967e4e1c9bd66e0
+# 7efe7d98a98b47bd82d697673d277cbd
 #: ../../maintaining/tasks.md:65
 msgid "Select the language from the dropdown."
 msgstr ""
 
-# 7120834d7d104cb5b8b852d20e9b2ac6
+# 174f04a821b843dcace04f708cbf3c78
 #: ../../maintaining/tasks.md:66
 msgid "Click Apply."
 msgstr ""
 
-# f7e1cac01eec4d0db0c530affc350476
+# 1e3868ee7dae469f9921516dd7973766
 #: ../../maintaining/tasks.md:68
 msgid "Then setup a subproject on ReadTheDocs for the language:"
 msgstr ""
 
-# c88e7509775a46978d52a83a3cae2ed2
+# fffa155a75674f0dbe746a15eb3be492
 #: ../../maintaining/tasks.md:70
 msgid "Visit https://readthedocs.org/dashboard/import/manual/"
 msgstr ""
 
-# 6daaeb112ffe4d7b935b97821bdd9c15
+# a798b8e31be7408d9301187ff3e3ef69
 #: ../../maintaining/tasks.md:71
-#, fuzzy
 msgid "Enter jupyter-docker-stacks-<lang> for the project name."
-msgstr "Select jupyter/docker-stacks as the source repository."
+msgstr ""
 
-# aec21541948f4acfaee4473da0992c89
+# 2869b2f7a89c428f903e3695dd511e9a
 #: ../../maintaining/tasks.md:72
 msgid "Enter https://github.com/jupyter/docker-stacks for the URL."
 msgstr ""
 
-# 2c6205ea95c34d859515c8179495be97
+# 4a964f7a3ec242b2bf03a8478f53b5d9
 #: ../../maintaining/tasks.md:73
 msgid "Check Edit advanced project options."
 msgstr ""
 
-# cb89e56ab1b0441aa17d7030b164f3f1
+# baf5be1aea37451dbdb266b5aa221453
 #: ../../maintaining/tasks.md:74
 msgid "Click Next."
 msgstr ""
 
-# fcbd0ae59cb941278c6947cd3562b7a9
+# 1f6b09025ce34dc1bef51a8ac114080a
 #: ../../maintaining/tasks.md:75
 msgid "Select the Language from the dropdown on the next screen."
 msgstr ""
 
-# 9b4abd50989744048ac6b51cb5347039
+# 50c15b61ac8e4d1bbdd36681a25aa6ed
 #: ../../maintaining/tasks.md:76
 msgid "Click Finish."
 msgstr ""
 
-# 3b3f801f2275489cbf6b8c95c8dbb602
+# 529f3729d2474287adec0ff895100248
 #: ../../maintaining/tasks.md:78
 msgid "Finally link the new language subproject to the top level doc project:"
 msgstr ""
 
-# 6c5e1d49b76c4a8fa02aecba2b9d5300
+# 024aaf54695141839eaa5537b4087a81
 #: ../../maintaining/tasks.md:80
 msgid ""
 "Visit https://readthedocs.org/dashboard/jupyter-docker-"
 "stacks/translations/"
 msgstr ""
 
-# 8db0013a233e4005aeaa9232ec69c969
+# 6e5a75790d784cdaaa2cda5fac32b67e
 #: ../../maintaining/tasks.md:81
 msgid "Select the subproject you created from the Project dropdown."
 msgstr ""
 
-# 0d42f7009add4d76bb464d83e6cad9d6
+# 9367330f235441869d649687e97a1796
 #: ../../maintaining/tasks.md:82
 msgid "Click Add."
 msgstr ""

--- a/docs/locale/en/LC_MESSAGES/using.po
+++ b/docs/locale/en/LC_MESSAGES/using.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docker-stacks latest\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-05-05 23:06+0000\n"
+"POT-Creation-Date: 2019-05-05 19:53-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,12 +18,12 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.6.0\n"
 
-# 13a6de8b769f46139d620a19f29ae5a3
+# e41cd9909fcf4bfe9df2b20f447770f7
 #: ../../using/common.md:1
 msgid "Common Features"
-msgstr "Common Features"
+msgstr ""
 
-# 0239e3ecf37741df97059ddbe7c468c1
+# 611e344f2bb64ed89fa2005d030e5479
 #: ../../using/common.md:3
 msgid ""
 "A container launched from any Jupyter Docker Stacks image runs a Jupyter "
@@ -32,27 +32,20 @@ msgid ""
 "environment and then runs jupyter notebook, passing it any command line "
 "arguments received."
 msgstr ""
-"A container launched from any Jupyter Docker Stacks image runs a Jupyter "
-"Notebook server by default. The container does so by executing a start-"
-"notebook.sh script. This script configures the internal container "
-"environment and then runs jupyter notebook, passing it any command line "
-"arguments received."
 
-# 900f46a5f45947c0a5fa73e561f6ecc6
+# 608ce0de07a84d5dab8e53b4e1480cc1
 #: ../../using/common.md:5
 msgid ""
 "This page describes the options supported by the startup script as well "
 "as how to bypass it to run alternative commands."
 msgstr ""
-"This page describes the options supported by the startup script as well "
-"as how to bypass it to run alternative commands."
 
-# 7940abbd331c486db06eda850941b413
+# a4d5d5ad78f14210a50d59ac9a7dd8ac
 #: ../../using/common.md:7
 msgid "Notebook Options"
-msgstr "Notebook Options"
+msgstr ""
 
-# 639ca41dacd049ad829349343e56802c
+# d1dfc4449caa4df688bf649bb1ffc782
 #: ../../using/common.md:9
 msgid ""
 "You can pass Jupyter command line options to the start-notebook.sh script"
@@ -60,37 +53,28 @@ msgid ""
 " with a custom password hashed using IPython.lib.passwd() instead of the "
 "default token, you can run the following:"
 msgstr ""
-"You can pass Jupyter command line options to the start-notebook.sh script"
-" when launching the container. For example, to secure the Notebook server"
-" with a custom password hashed using IPython.lib.passwd() instead of the "
-"default token, you can run the following:"
 
-# 759c229dfd524c588cedffce2e832bd5
+# d1444171de834a15aa9a98eeb0c5ecf4
 #: ../../using/common.md:15
 msgid ""
 "For example, to set the base URL of the notebook server, you can run the "
 "following:"
 msgstr ""
-"For example, to set the base URL of the notebook server, you can run the "
-"following:"
 
-# a40981b568f9407f9bd1fdb8bb0c1bf4
+# 007861f656fc4ec083b2f046ce7bce61
 #: ../../using/common.md:21
 msgid "Docker Options"
-msgstr "Docker Options"
+msgstr ""
 
-# ffa49b5e83e241f2a5cb39359587c727
+# 94984b8745f4497b8f146c8cdc503c0c
 #: ../../using/common.md:23
 msgid ""
 "You may instruct the start-notebook.sh script to customize the container "
 "environment before launching the notebook server. You do so by passing "
 "arguments to the docker run command."
 msgstr ""
-"You may instruct the start-notebook.sh script to customize the container "
-"environment before launching the notebook server. You do so by passing "
-"arguments to the docker run command."
 
-# 4c646f36960d49888b51c24536a93f46
+# 569ce4a080664344915f3efe69effc72
 #: ../../using/common.md:26
 msgid ""
 "-e NB_USER=jovyan - Instructs the startup script to change the default "
@@ -100,14 +84,8 @@ msgid ""
 " -w /home/$NB_USER. This feature is useful when mounting host volumes "
 "with specific home folder."
 msgstr ""
-"-e NB_USER=jovyan - Instructs the startup script to change the default "
-"container username from jovyan to the provided value. Causes the script "
-"to rename the jovyan user home folder. For this option to take effect, "
-"you must run the container with --user root and set the working directory"
-" -w /home/$NB_USER. This feature is useful when mounting host volumes "
-"with specific home folder."
 
-# 189d26a96fb140268d9fb662597f2a44
+# 0d0ff97c80094025adee1a345eb85735
 #: ../../using/common.md:27
 msgid ""
 "-e NB_UID=1000 - Instructs the startup script to switch the numeric user "
@@ -118,15 +96,8 @@ msgid ""
 "modern Docker options --user and --group-add instead. See the last bullet"
 " below for details."
 msgstr ""
-"-e NB_UID=1000 - Instructs the startup script to switch the numeric user "
-"ID of $NB_USER to the given value. This feature is useful when mounting "
-"host volumes with specific owner permissions. For this option to take "
-"effect, you must run the container with --user root. (The startup script "
-"will su $NB_USER after adjusting the user ID.) You might consider using "
-"modern Docker options --user and --group-add instead. See the last bullet"
-" below for details."
 
-# 34088db5e6344f039286ac930648354c
+# 9acc25ea16124e35bba9528f734f3475
 #: ../../using/common.md:28
 msgid ""
 "-e NB_GID=100 - Instructs the startup script to change the primary group "
@@ -142,31 +113,16 @@ msgid ""
 "ensure the user stays in group users if you want them to be able to "
 "modify files in the image."
 msgstr ""
-"-e NB_GID=100 - Instructs the startup script to change the primary group "
-"of$NB_USER to $NB_GID (the new group is added with a name of $NB_GROUP if"
-" it is defined, otherwise the group is named $NB_USER).  This feature is "
-"useful when mounting host volumes with specific group permissions. For "
-"this option to take effect, you must run the container with --user root. "
-"(The startup script will su $NB_USER after adjusting the group ID.) You "
-"might consider using modern Docker options --user and --group-add "
-"instead. See the last bullet below for details.  The user is added to "
-"supplemental group users (gid 100) in order to allow write access to the "
-"home directory and /opt/conda.  If you override the user/group logic, "
-"ensure the user stays in group users if you want them to be able to "
-"modify files in the image."
 
-# db20531d09cb4144a4daba8ef61dfb1f
+# 9607821e245e452d896ec1b30f7053a5
 #: ../../using/common.md:29
 msgid ""
 "-e NB_GROUP=<name> - The name used for $NB_GID, which defaults to "
 "$NB_USER.  This is only used if $NB_GID is specified and completely "
 "optional: there is only cosmetic effect."
 msgstr ""
-"-e NB_GROUP=<name> - The name used for $NB_GID, which defaults to "
-"$NB_USER.  This is only used if $NB_GID is specified and completely "
-"optional: there is only cosmetic effect."
 
-# aaf02fcc8636448ba3c5bdf2ee50b586
+# 1c73d7064e21443eb3cbee69968f726e
 #: ../../using/common.md:30
 msgid ""
 "-e NB_UMASK=<umask> - Configures Jupyter to use a different umask value "
@@ -179,17 +135,8 @@ msgid ""
 "for additional files created during run-hooks e.g. via pip or conda - if "
 "you need to set a umask for these you must set umask for each command."
 msgstr ""
-"-e NB_UMASK=<umask> - Configures Jupyter to use a different umask value "
-"from default, i.e. 022. For example, if setting umask to 002, new files "
-"will be readable and writable by group members instead of just writable "
-"by the owner. Wikipedia has a good article about umask. Feel free to read"
-" it in order to choose the value that better fits your needs. Default "
-"value should fit most situations. Note that NB_UMASK when set only "
-"applies to the Jupyter process itself - you cannot use it to set a umask "
-"for additional files created during run-hooks e.g. via pip or conda - if "
-"you need to set a umask for these you must set umask for each command."
 
-# 3cd168c261bd43d6a11fc31e688e066e
+# 5a54345a51fa4c1b9b03d34a3de8ca74
 #: ../../using/common.md:31
 msgid ""
 "-e CHOWN_HOME=yes - Instructs the startup script to change the $NB_USER "
@@ -199,14 +146,8 @@ msgid ""
 "applied recursively by default. You can change modify the chown behavior "
 "by setting CHOWN_HOME_OPTS (e.g., -e CHOWN_HOME_OPTS='-R')."
 msgstr ""
-"-e CHOWN_HOME=yes - Instructs the startup script to change the $NB_USER "
-"home directory owner and group to the current value of $NB_UID and "
-"$NB_GID. This change will take effect even if the user home directory is "
-"mounted from the host using -v as described below. The change is not "
-"applied recursively by default. You can change modify the chown behavior "
-"by setting CHOWN_HOME_OPTS (e.g., -e CHOWN_HOME_OPTS='-R')."
 
-# 6f0589e671c342f18b1eb162e0299622
+# dbd06371a36547c9aa22b8da35120c89
 #: ../../using/common.md:32
 msgid ""
 "-e CHOWN_EXTRA=\"<some dir>,<some other dir>\" - Instructs the startup "
@@ -215,13 +156,8 @@ msgid ""
 "applied recursively by default. You can change modify the chown behavior "
 "by setting CHOWN_EXTRA_OPTS (e.g., -e CHOWN_EXTRA_OPTS='-R')."
 msgstr ""
-"-e CHOWN_EXTRA=\"<some dir>,<some other dir>\" - Instructs the startup "
-"script to change the owner and group of each comma-separated container "
-"directory to the current value of $NB_UID and $NB_GID. The change is not "
-"applied recursively by default. You can change modify the chown behavior "
-"by setting CHOWN_EXTRA_OPTS (e.g., -e CHOWN_EXTRA_OPTS='-R')."
 
-# 2028353295994b629a03a98f6b56301e
+# a4a085a9571a441bb8d084df104e0593
 #: ../../using/common.md:33
 msgid ""
 "-e GRANT_SUDO=yes - Instructs the startup script to grant the NB_USER "
@@ -234,28 +170,16 @@ msgid ""
 "sudoers.) You should only enable sudo if you trust the user or if the "
 "container is running on an isolated host."
 msgstr ""
-"-e GRANT_SUDO=yes - Instructs the startup script to grant the NB_USER "
-"user passwordless sudo capability. You do not need this option to allow "
-"the user to conda or pip install additional packages. This option is "
-"useful, however, when you wish to give $NB_USER the ability to install OS"
-" packages with apt or modify other root-owned files in the container. For"
-" this option to take effect, you must run the container with --user root."
-" (The start-notebook.sh script will su $NB_USER after adding $NB_USER to "
-"sudoers.) You should only enable sudo if you trust the user or if the "
-"container is running on an isolated host."
 
-# 01ddb1eb7a034833ad330efa7b3dee2c
+# d22e4525015d40e8b45df68936c7650f
 #: ../../using/common.md:34
 msgid ""
 "-e GEN_CERT=yes - Instructs the startup script to generates a self-signed"
 " SSL certificate and configure Jupyter Notebook to use it to accept "
 "encrypted HTTPS connections."
 msgstr ""
-"-e GEN_CERT=yes - Instructs the startup script to generates a self-signed"
-" SSL certificate and configure Jupyter Notebook to use it to accept "
-"encrypted HTTPS connections."
 
-# 893f7d5d93414c2b9dc38cbe7696e1fb
+# ab3e246dc22849b9abd24370da63dc55
 #: ../../using/common.md:35
 msgid ""
 "-e JUPYTER_ENABLE_LAB=yes - Instructs the startup script to run jupyter "
@@ -263,12 +187,8 @@ msgid ""
 "orchestration environments where setting environment variables is easier "
 "than change command line parameters."
 msgstr ""
-"-e JUPYTER_ENABLE_LAB=yes - Instructs the startup script to run jupyter "
-"lab instead of the default jupyter notebook command. Useful in container "
-"orchestration environments where setting environment variables is easier "
-"than change command line parameters."
 
-# b23ee8c50e244a359e688ca90d5fb3b8
+# 8a84035eba7f46c393eed97d7b240afe
 #: ../../using/common.md:36
 msgid ""
 "-v /some/host/folder/for/work:/home/jovyan/work - Mounts a host machine "
@@ -278,14 +198,8 @@ msgid ""
 "write access to the host directory (e.g., sudo chown 1000 "
 "/some/host/folder/for/work)."
 msgstr ""
-"-v /some/host/folder/for/work:/home/jovyan/work - Mounts a host machine "
-"directory as folder in the container. Useful when you want to preserve "
-"notebooks and other work even after the container is destroyed. You must "
-"grant the within-container notebook user or group (NB_UID or NB_GID) "
-"write access to the host directory (e.g., sudo chown 1000 "
-"/some/host/folder/for/work)."
 
-# eb9985eed92f45568ff1bac70ab6634d
+# 362e3aa9c0c2469b9dd5777db3646c5e
 #: ../../using/common.md:37
 msgid ""
 "--user 5000 --group-add users - Launches the container with a specific "
@@ -293,62 +207,48 @@ msgid ""
 " in the default home directory and /opt/conda. You can use these "
 "arguments as alternatives to setting $NB_UID and $NB_GID."
 msgstr ""
-"--user 5000 --group-add users - Launches the container with a specific "
-"user ID and adds that user to the users group so that it can modify files"
-" in the default home directory and /opt/conda. You can use these "
-"arguments as alternatives to setting $NB_UID and $NB_GID."
 
-# adf0db04da7542cfa5e071bb96ab5bd0
+# 1e7fa5e0e4f0456789e8e5f3692a33e0
 #: ../../using/common.md:39
 msgid "Startup Hooks"
-msgstr "Startup Hooks"
+msgstr ""
 
-# 44f9c3d105e34b44a87029dfed52f977
+# cdcdb2229de64e54b89f86c8bed5ed30
 #: ../../using/common.md:41
 msgid ""
 "You can further customize the container environment by adding shell "
 "scripts (*.sh) to be sourced or executables (chmod +x) to be run to the "
 "paths below:"
 msgstr ""
-"You can further customize the container environment by adding shell "
-"scripts (*.sh) to be sourced or executables (chmod +x) to be run to the "
-"paths below:"
 
-# 50088080a2954352aab47d74ea47ea2e
+# 9674ca5b624a4c1482caf1725ab3d01b
 #: ../../using/common.md:44
 msgid ""
 "/usr/local/bin/start-notebook.d/ - handled before any of the standard "
 "options noted above are applied"
 msgstr ""
-"/usr/local/bin/start-notebook.d/ - handled before any of the standard "
-"options noted above are applied"
 
-# 5642e7d9104d4cdbb0ae115b93343e2e
+# 5f11a62b1c414894af157d23ce8893ae
 #: ../../using/common.md:46
 msgid ""
 "/usr/local/bin/before-notebook.d/ - handled after all of the standard "
 "options noted above are applied and just before the notebook server "
 "launches"
 msgstr ""
-"/usr/local/bin/before-notebook.d/ - handled after all of the standard "
-"options noted above are applied and just before the notebook server "
-"launches"
 
-# 3efb822d7dc64e56a93eabe694aa270c
+# 3f97359a0aa34755b18ff1bf51d9bc47
 #: ../../using/common.md:49
 msgid ""
 "See the run-hooks function in the jupyter/base-notebook start.sh script "
 "for execution details."
 msgstr ""
-"See the run-hooks function in the jupyter/base-notebook start.sh script "
-"for execution details."
 
-# 8233518943ad497fa60ed9ea7a0f2d66
+# 75046865f61c4df3977920e74156bfe0
 #: ../../using/common.md:52
 msgid "SSL Certificates"
-msgstr "SSL Certificates"
+msgstr ""
 
-# d10e269c81b742078a92241bd1b3b6aa
+# 7d8e48b6d3c448f1a3a4779deee18192
 #: ../../using/common.md:54
 msgid ""
 "You may mount SSL key and certificate files into a container and "
@@ -356,74 +256,59 @@ msgid ""
 "example, to mount a host folder containing a notebook.key and "
 "notebook.crt and use them, you might run the following:"
 msgstr ""
-"You may mount SSL key and certificate files into a container and "
-"configure Jupyter Notebook to use them to accept HTTPS connections. For "
-"example, to mount a host folder containing a notebook.key and "
-"notebook.crt and use them, you might run the following:"
 
-# 8c500bdbee2949abbd392e6c1f02a27e
+# 502ad4a251fe4c648c45205a3e4d75bc
 #: ../../using/common.md:64
 msgid ""
 "Alternatively, you may mount a single PEM file containing both the key "
 "and certificate. For example:"
 msgstr ""
-"Alternatively, you may mount a single PEM file containing both the key "
-"and certificate. For example:"
 
-# ba055500c2194bbc87ec0f1a953571ec
+# 619a68775c0f4bde851da52dd2fcf4d0
 #: ../../using/common.md:73
 msgid ""
 "In either case, Jupyter Notebook expects the key and certificate to be a "
 "base64 encoded text file. The certificate file or PEM may contain one or "
 "more certificates (e.g., server, intermediate, and root)."
 msgstr ""
-"In either case, Jupyter Notebook expects the key and certificate to be a "
-"base64 encoded text file. The certificate file or PEM may contain one or "
-"more certificates (e.g., server, intermediate, and root)."
 
-# a121ba41f11b45efae9adb97481aacb4
+# d080e400a62044a7a488e7fceb7c87fd
 #: ../../using/common.md:75
 msgid "For additional information about using SSL, see the following:"
-msgstr "For additional information about using SSL, see the following:"
+msgstr ""
 
-# 90e2df492b8d4cbca8928cc366b8eb3a
+# 127678fd894945b488ff9073a69c8cbe
 #: ../../using/common.md:77
 msgid ""
 "The docker-stacks/examples for information about how to use Let's Encrypt"
 " certificates when you run these stacks on a publicly visible domain."
 msgstr ""
-"The docker-stacks/examples for information about how to use Let's Encrypt"
-" certificates when you run these stacks on a publicly visible domain."
 
-# ec8f514ad89e4ec9820d019279ab7677
+# 0ccecbceea074b8f898837adc6fba3fe
 #: ../../using/common.md:78
 msgid ""
 "The jupyter_notebook_config.py file for how this Docker image generates a"
 " self-signed certificate."
 msgstr ""
-"The jupyter_notebook_config.py file for how this Docker image generates a"
-" self-signed certificate."
 
-# 7eb58c8b4e9a4be39a5b3bab02592fd7
+# a2cd4739b7ab48558eff205a4c0c0d79
 #: ../../using/common.md:79
 msgid ""
 "The Jupyter Notebook documentation for best practices about securing a "
 "public notebook server in general."
 msgstr ""
-"The Jupyter Notebook documentation for best practices about securing a "
-"public notebook server in general."
 
-# 20b18bf780474c3ab5e4fe7b4419f276
+# 02cf3f994bc0435bab175aa7ba3bca23
 #: ../../using/common.md:81
 msgid "Alternative Commands"
-msgstr "Alternative Commands"
+msgstr ""
 
-# 5227cbe5574b4e0188a3e68ae664acb3
+# dec6483e89a24ea19227e9596ad1ef76
 #: ../../using/common.md:83
 msgid "start.sh"
-msgstr "start.sh"
+msgstr ""
 
-# 6441c65a343546cb8dd886f36cc47fa5
+# 1e497e8452b447af833630319560e351
 #: ../../using/common.md:85
 msgid ""
 "The start-notebook.sh script actually inherits most of its option "
@@ -432,51 +317,39 @@ msgid ""
 "specify an arbitrary command to execute. For example, to run the text-"
 "based ipython console in a container, do the following:"
 msgstr ""
-"The start-notebook.sh script actually inherits most of its option "
-"handling capability from a more generic start.sh script. The start.sh "
-"script supports all of the features described above, but allows you to "
-"specify an arbitrary command to execute. For example, to run the text-"
-"based ipython console in a container, do the following:"
 
-# 729935e209ec4bdb9ca2256b842faf25
+# abb5f8d7161143e693fde71df9496362
 #: ../../using/common.md:91
 msgid "Or, to run JupyterLab instead of the classic notebook, run the following:"
-msgstr "Or, to run JupyterLab instead of the classic notebook, run the following:"
+msgstr ""
 
-# b191ae5e54764748ba119058c72d8a8e
+# 2a8ff717ba22400a8a5f5e02fc87c03d
 #: ../../using/common.md:97
 msgid ""
 "This script is particularly useful when you derive a new Dockerfile from "
 "this image and install additional Jupyter applications with subcommands "
 "like jupyter console, jupyter kernelgateway, etc."
 msgstr ""
-"This script is particularly useful when you derive a new Dockerfile from "
-"this image and install additional Jupyter applications with subcommands "
-"like jupyter console, jupyter kernelgateway, etc."
 
-# 558998a5647045148d2ab054decb5b18
+# 577ae6d953784517826ce5b20a4297ee
 #: ../../using/common.md:99
 msgid "Others"
-msgstr "Others"
+msgstr ""
 
-# 483e84532a754a989299a638521b72cc
+# 8cbff9cc00f44eb1831079f170b1f701
 #: ../../using/common.md:101
-#, fuzzy
 msgid ""
 "You can bypass the provided scripts and specify an arbitrary start "
 "command. If you do, keep in mind that features supported by the start.sh "
 "script and its kin will not function (e.g., GRANT_SUDO)."
 msgstr ""
-"You can bypass the provided scripts and specify your an arbitrary start "
-"command. If you do, keep in mind that features supported by the start.sh "
-"script and its kin will not function (e.g., GRANT_SUDO)."
 
-# a11f620c68d34fa8b61c5c46ec986027
+# aaa3c260d46844d8b04d7e951fd928a1
 #: ../../using/common.md:103
 msgid "Conda Environments"
-msgstr "Conda Environments"
+msgstr ""
 
-# f1b03110464747a3ade4cc386f9a8a9d
+# 58f06c1abb5845abaa5ab414610ce616
 #: ../../using/common.md:105
 msgid ""
 "The default Python 3.x Conda environment resides in /opt/conda. The "
@@ -484,28 +357,21 @@ msgid ""
 " directory is also whitelisted for use in sudo commands by the start.sh "
 "script."
 msgstr ""
-"The default Python 3.x Conda environment resides in /opt/conda. The "
-"/opt/conda/bin directory is part of the default jovyan user's $PATH. That"
-" directory is also whitelisted for use in sudo commands by the start.sh "
-"script."
 
-# 617e94429a5d4945ac842954e6f5379f
+# 121c9ede94f849ca8cac9ea98d2321dd
 #: ../../using/common.md:107
 msgid ""
 "The jovyan user has full read/write access to the /opt/conda directory. "
 "You can use either conda or pip to install new packages without any "
 "additional permissions."
 msgstr ""
-"The jovyan user has full read/write access to the /opt/conda directory. "
-"You can use either conda or pip to install new packages without any "
-"additional permissions."
 
-# 016180b1ee6047febe03e0edd8c661ce
+# 96df5e77c43d40babb98a14b987d1435
 #: ../../using/recipes.md:1
 msgid "Contributed Recipes"
-msgstr "Contributed Recipes"
+msgstr ""
 
-# a7b0001c7e60442b938384186346ae9f
+# 3a4dd4c9503a4a2ea62cda4f55bcf6d0
 #: ../../using/recipes.md:3
 msgid ""
 "Users sometimes share interesting ways of using the Jupyter Docker "
@@ -514,183 +380,153 @@ msgid ""
 " by submitting a pull request to docs/using/recipes.md. The sections "
 "below capture this knowledge."
 msgstr ""
-"Users sometimes share interesting ways of using the Jupyter Docker "
-"Stacks. We encourage users to contribute these recipes to the "
-"documentation in case they prove useful to other members of the community"
-" by submitting a pull request to docs/using/recipes.md. The sections "
-"below capture this knowledge."
 
-# b7afd37be39d4d44b8718e95fefd45f2
+# bea8241927a54c75a0ded413dec82e3a
 #: ../../using/recipes.md:5
 msgid "Using pip install or conda install in a Child Docker image"
-msgstr "Using pip install or conda install in a Child Docker image"
+msgstr ""
 
-# 536b8eac4cd24332a451c4fe87588c2e
+# 4d213737d62c45eaa3852726297b7c28
 #: ../../using/recipes.md:7
 msgid "Create a new Dockerfile like the one shown below."
-msgstr "Create a new Dockerfile like the one shown below."
+msgstr ""
 
-# 1e44ae49c58d4c43bd20ab58fd594192
+# ca36eb48cc5f452a96f9440811f45cb5
 #: ../../using/recipes.md:16
 msgid "Then build a new image."
-msgstr "Then build a new image."
+msgstr ""
 
-# 0a1225c3c5d847db98d448d71e4af224
+# bc376e79b2884fad991018aa30023146
 #: ../../using/recipes.md:22
 msgid ""
 "To use a requirements.txt file, first create your requirements.txt file "
 "with the listing of packages desired.  Next, create a new Dockerfile like"
 " the one shown below."
 msgstr ""
-"To use a requirements.txt file, first create your requirements.txt file "
-"with the listing of packages desired.  Next, create a new Dockerfile like"
-" the one shown below."
 
-# 6b9519a4316f414ba062e44140b5de5b
+# 5d6ce581929447a0af7958c47ed1769c
 #: ../../using/recipes.md:35
 msgid "For conda, the Dockerfile is similar:"
-msgstr "For conda, the Dockerfile is similar:"
+msgstr ""
 
-# 38c4eaf4ab82407ca71eec4af1ed5ed1
+# 398d875ac92e46b9bf522f17db73075e
 #: ../../using/recipes.md:47
 msgid "Ref: docker-stacks/commit/79169618d571506304934a7b29039085e77db78c"
-msgstr "Ref: docker-stacks/commit/79169618d571506304934a7b29039085e77db78c"
+msgstr ""
 
-# 6ca8a7bf8158482b97b053421b08d4d4
+# 3c654dec03f74a6f9b64da850de3f4e8
 #: ../../using/recipes.md:49
 msgid "Add a Python 2.x environment"
-msgstr "Add a Python 2.x environment"
+msgstr ""
 
-# eeb55520b87d402dac931f902f64eaf8
+# 60f73f66c81f495d85d971a5838f6cc3
 #: ../../using/recipes.md:51
 msgid ""
 "Python 2.x was removed from all images on August 10th, 2017, starting in "
 "tag cc9feab481f7. You can add a Python 2.x environment by defining your "
 "own Dockerfile inheriting from one of the images like so:"
 msgstr ""
-"Python 2.x was removed from all images on August 10th, 2017, starting in "
-"tag cc9feab481f7. You can add a Python 2.x environment by defining your "
-"own Dockerfile inheriting from one of the images like so:"
 
-# 4bdd5dcc73b8436ba1891ce3d23eaae8
+# 47c5a8d4de7b4bf18180580b07c01fa2
 #: ../../using/recipes.md:73
 msgid "Ref: https://github.com/jupyter/docker-stacks/issues/440"
-msgstr "Ref: https://github.com/jupyter/docker-stacks/issues/440"
+msgstr ""
 
-# 2b59968e04d24ca5a7e7f51d14e8addf
+# 2de5eb85f4c7475ab3499f88bd20f8d9
 #: ../../using/recipes.md:75
 msgid "Run JupyterLab"
-msgstr "Run JupyterLab"
+msgstr ""
 
-# 2ca97b3ff1894619abed28a5b49d4416
+# e0e2db6436024c1a9f3827362046f21c
 #: ../../using/recipes.md:77
 msgid ""
 "JupyterLab is preinstalled as a notebook extension starting in tag "
 "c33a7dc0eece."
 msgstr ""
-"JupyterLab is preinstalled as a notebook extension starting in tag "
-"c33a7dc0eece."
 
-# 0a5f7f67e89b4d4b97521b0bc8f2cc24
+# 29d86244710246d3a99adbe727d41fbe
 #: ../../using/recipes.md:79
 msgid ""
 "Run jupyterlab using a command such as docker run -it --rm -p 8888:8888 "
 "jupyter/datascience-notebook start.sh jupyter lab"
 msgstr ""
-"Run jupyterlab using a command such as docker run -it --rm -p 8888:8888 "
-"jupyter/datascience-notebook start.sh jupyter lab"
 
-# 2e8693ac9b674ae89053146ad2fdede3
+# 359d14a5fbcc4bf5838c3cef102bd7d2
 #: ../../using/recipes.md:81
 msgid "Let's Encrypt a Notebook server"
-msgstr "Let's Encrypt a Notebook server"
+msgstr ""
 
-# ed3d7f27be2d454da69a88b10f97f17b
+# f03dce66cd314ce48b6f63f9f8b3f839
 #: ../../using/recipes.md:83
 msgid ""
 "See the README for the simple automation here https://github.com/jupyter"
 "/docker-stacks/tree/master/examples/make-deploy which includes steps for "
 "requesting and renewing a Let's Encrypt certificate."
 msgstr ""
-"See the README for the simple automation here https://github.com/jupyter"
-"/docker-stacks/tree/master/examples/make-deploy which includes steps for "
-"requesting and renewing a Let's Encrypt certificate."
 
-# 42d03a239d114a96a9e29bccabef5dc8
+# ae272bea82974525ab5b17104de09344
 #: ../../using/recipes.md:85
 msgid "Ref: https://github.com/jupyter/docker-stacks/issues/78"
-msgstr "Ref: https://github.com/jupyter/docker-stacks/issues/78"
+msgstr ""
 
-# cd0f9fdbad1f49b78f5839abfbf7e029
+# 69440a80a8dd40c093a11e052c5ffb7d
 #: ../../using/recipes.md:87
 msgid "Slideshows with Jupyter and RISE"
-msgstr "Slideshows with Jupyter and RISE"
+msgstr ""
 
-# 019add4a0836493581e5f1b9334ac4a1
+# eecba36e666b4725a9696a571fddf3a4
 #: ../../using/recipes.md:89
 msgid ""
 "RISE allows via extension to create live slideshows of your notebooks, "
 "with no conversion, adding javascript Reveal.js:"
 msgstr ""
-"RISE allows via extension to create live slideshows of your notebooks, "
-"with no conversion, adding javascript Reveal.js:"
 
-# fbd9203b84a14656b863535b22ff42d3
+# 2204bca916034fd68769987aaa1c9e9a
 #: ../../using/recipes.md:95
 msgid "Credit: Paolo D. based on docker-stacks/issues/43"
-msgstr "Credit: Paolo D. based on docker-stacks/issues/43"
+msgstr ""
 
-# 4e90758ee5894299aaed6ce951154909
+# d1b8d0688d7c457d9512ce73a8c323be
 #: ../../using/recipes.md:97
 msgid "xgboost"
-msgstr "xgboost"
+msgstr ""
 
-# ef909867a7594853945d7d4226609a41
+# 4a41168ccdce41ab92f12673be4145ba
 #: ../../using/recipes.md:99
 msgid ""
 "You need to install conda's gcc for Python xgboost to work properly. "
 "Otherwise, you'll get an exception about libgomp.so.1 missing GOMP_4.0."
 msgstr ""
-"You need to install conda's gcc for Python xgboost to work properly. "
-"Otherwise, you'll get an exception about libgomp.so.1 missing GOMP_4.0."
 
-# 7cf990860bec48889d90be72c02a36b8
+# 8056222583324c679fcf24166b7539dc
 #: ../../using/recipes.md:109
 msgid "Running behind a nginx proxy"
-msgstr "Running behind a nginx proxy"
+msgstr ""
 
-# 580a0749dbd14b0b9a4a38e631cadfd3
+# 24d5e546f0da44448c5b64643481388c
 #: ../../using/recipes.md:111
 msgid ""
 "Sometimes it is useful to run the Jupyter instance behind a nginx proxy, "
 "for instance:"
 msgstr ""
-"Sometimes it is useful to run the Jupyter instance behind a nginx proxy, "
-"for instance:"
 
-# 75e04e9b57d246c9a4fd8f73ea9a257e
+# 057c2dbd67be44b8bdf158217757829d
 #: ../../using/recipes.md:113
 msgid ""
 "you would prefer to access the notebook at a server URL with a path "
 "(https://example.com/jupyter) rather than a port "
 "(https://example.com:8888)"
 msgstr ""
-"you would prefer to access the notebook at a server URL with a path "
-"(https://example.com/jupyter) rather than a port "
-"(https://example.com:8888)"
 
-# 4e421fae756a4f50b63d2533eb86e7ed
+# 520fd309518e445aba1117b2dcde5b71
 #: ../../using/recipes.md:114
 msgid ""
 "you may have many different services in addition to Jupyter running on "
 "the same server, and want to nginx to help improve server performance in "
 "manage the connections"
 msgstr ""
-"you may have many different services in addition to Jupyter running on "
-"the same server, and want to nginx to help improve server performance in "
-"manage the connections"
 
-# 3cc1571d9dcb44eb97c2ca17ff10c331
+# f4f57a6b4e6c468490102274877fecd7
 #: ../../using/recipes.md:116
 msgid ""
 "Here is a quick example NGINX configuration to get started.  You'll need "
@@ -699,18 +535,13 @@ msgid ""
 "docker-compose up -d to test it out.  Customize the nginx.conf file to "
 "set the desired paths and add other services."
 msgstr ""
-"Here is a quick example NGINX configuration to get started.  You'll need "
-"a server, a .crt and .key file for your server, and docker & docker-"
-"compose installed.  Then just download the files at that gist and run "
-"docker-compose up -d to test it out.  Customize the nginx.conf file to "
-"set the desired paths and add other services."
 
-# fa7529c9b4b0450cb64a50792be07a12
+# a1b6da6433a243a1b5e5f36aa024fe62
 #: ../../using/recipes.md:118
 msgid "Host volume mounts and notebook errors"
-msgstr "Host volume mounts and notebook errors"
+msgstr ""
 
-# 7df011d4acb94457adc7c364c5f6b67a
+# 9f9cd5a20a64430e81675cedd5495031
 #: ../../using/recipes.md:120
 msgid ""
 "If you are mounting a host directory as /home/jovyan/work in your "
@@ -720,35 +551,26 @@ msgid ""
 "specify the UID of the jovyan user on container startup using the -e "
 "NB_UID option described in the Common Features, Docker Options section"
 msgstr ""
-"If you are mounting a host directory as /home/jovyan/work in your "
-"container and you receive permission errors or connection errors when you"
-" create a notebook, be sure that the jovyan user (UID=1000 by default) "
-"has read/write access to the directory on the host. Alternatively, "
-"specify the UID of the jovyan user on container startup using the -e "
-"NB_UID option described in the Common Features, Docker Options section"
 
-# 080988a20c254295b3e51d22e38078e8
+# bfe9c4ce5c664b1d9e71694acccc72a5
 #: ../../using/recipes.md:122
 msgid "Ref: https://github.com/jupyter/docker-stacks/issues/199"
-msgstr "Ref: https://github.com/jupyter/docker-stacks/issues/199"
+msgstr ""
 
-# 9088317f3cb44afe8c00511b68e84f7f
+# d34a4721b88942b18507ae53189ad1ad
 #: ../../using/recipes.md:124
 msgid "Manpage installation"
-msgstr "Manpage installation"
+msgstr ""
 
-# 9b2b1201befd45d094c4d518eb39a7fd
+# aa0a4cd167fe49809dfc513cf965470d
 #: ../../using/recipes.md:126
 msgid ""
 "Most containers, including our Ubuntu base image, ship without manpages "
 "installed to save space. You can use the following dockerfile to inherit "
 "from one of our images to enable manpages:"
 msgstr ""
-"Most containers, including our Ubuntu base image, ship without manpages "
-"installed to save space. You can use the following dockerfile to inherit "
-"from one of our images to enable manpages:"
 
-# 4f3da23eee0040799af9beab9f02b552
+# 6c443960b61c4b83bc348bbba654957c
 #: ../../using/recipes.md:151
 msgid ""
 "Adding the documentation on top of an existing singleuser image wastes a "
@@ -757,139 +579,126 @@ msgid ""
 "been shown to grow by almost 3GB when adding manapages in this way. "
 "Enabling manpages in the base Ubuntu layer prevents this container bloat:"
 msgstr ""
-"Adding the documentation on top of an existing singleuser image wastes a "
-"lot of space and requires reinstalling every system package, which can "
-"take additional time and bandwidth; the datascience-notebook image has "
-"been shown to grow by almost 3GB when adding manapages in this way. "
-"Enabling manpages in the base Ubuntu layer prevents this container bloat:"
 
-# fc2c9f0b078040829ea15242c6c3ef75
+# 6f7d3db232f14979ac6e11214b089d2b
 #: ../../using/recipes.md:173
 msgid "Be sure to check the current base image in base-notebook before building."
-msgstr "Be sure to check the current base image in base-notebook before building."
+msgstr ""
 
-# d457dbd0edeb4a598a59de35826566b7
+# 67ffff4f1bee4b1eb570c52cc23a259d
 #: ../../using/recipes.md:175
 msgid "JupyterHub"
-msgstr "JupyterHub"
+msgstr ""
 
-# dc6f81c4c9c048f1af173b91ba576be5
+# f082ad5f120b4d779a09e8e08f1dda79
 #: ../../using/recipes.md:177
 msgid "We also have contributed recipes for using JupyterHub."
-msgstr "We also have contributed recipes for using JupyterHub."
+msgstr ""
 
-# 0330df9324a9459382c462e253fca8b2
+# 021f9c498d87459ab8b7eec9902a1ff5
 #: ../../using/recipes.md:179
 msgid "Use JupyterHub's dockerspawner"
-msgstr "Use JupyterHub's dockerspawner"
+msgstr ""
 
-# 084af0247fcd489a88b116d4e1711f20
+# 07655cc3f3fc4445a27cb4b1500ded88
 #: ../../using/recipes.md:181
 msgid ""
 "In most cases for use with DockerSpawner, given any image that already "
 "has a notebook stack set up, you would only need to add:"
 msgstr ""
-"In most cases for use with DockerSpawner, given any image that already "
-"has a notebook stack set up, you would only need to add:"
 
-# dc6cd4938e104c4d89a87264ed8f262b
+# 13af5ca0e82a4b50a8043f5c1a97099b
 #: ../../using/recipes.md:183
 msgid "install the jupyterhub-singleuser script (for the right Python)"
-msgstr "install the jupyterhub-singleuser script (for the right Python)"
+msgstr ""
 
-# 0b17c1e891d1437a9b061464065577fc
+# ea56e8bbbe8d4a9db5f95d33cd178c03
 #: ../../using/recipes.md:184
 msgid "change the command to launch the single-user server"
-msgstr "change the command to launch the single-user server"
+msgstr ""
 
-# b80012852cd849759e8e8a285ec78dfa
+# 97b283b80f1543c8a673644fde46971d
 #: ../../using/recipes.md:186
 msgid ""
 "Swapping out the FROM line in the jupyterhub/singleuser Dockerfile should"
 " be enough for most cases."
 msgstr ""
-"Swapping out the FROM line in the jupyterhub/singleuser Dockerfile should"
-" be enough for most cases."
 
-# 57b3210da06440c8a1c63a022d2f54dc
+# a002a7462b6c43909fe730a6866a9c2a
 #: ../../using/recipes.md:188
 msgid ""
 "Credit: Justin Tyberg, quanghoc, and Min RK based on docker-"
 "stacks/issues/124 and docker-stacks/pull/185"
 msgstr ""
-"Credit: Justin Tyberg, quanghoc, and Min RK based on docker-"
-"stacks/issues/124 and docker-stacks/pull/185"
 
-# 0be846adb5084e1f8eae90ef78aa2221
+# a0e591ed0e2c49b4801ba78294e04e51
 #: ../../using/recipes.md:190
 msgid "Containers with a specific version of JupyterHub"
-msgstr "Containers with a specific version of JupyterHub"
+msgstr ""
 
-# 51d84fa1f13b4b6d9ececdb1ec37c0c7
+# c4c3647187f946daa180b968be35b38a
 #: ../../using/recipes.md:192
 msgid ""
 "To use a specific version of JupyterHub, the version of jupyterhub in "
 "your image should match the version in the Hub itself."
 msgstr ""
-"To use a specific version of JupyterHub, the version of jupyterhub in "
-"your image should match the version in the Hub itself."
 
-# 3c333b2e9e344aa0a82280f41a000274
+# 5b520a1539e0481abd8bb6468ff848d7
 #: ../../using/recipes.md:199
 msgid "Credit: MinRK"
-msgstr "Credit: MinRK"
+msgstr ""
 
-# b799da3c37ed4603bdbb0a36b3fbeddf
+# 627a7b8ac6e5493da03459e5a05fec93
 #: ../../using/recipes.md:202
 msgid "Ref: https://github.com/jupyter/docker-stacks/issues/177"
-msgstr "Ref: https://github.com/jupyter/docker-stacks/issues/177"
+msgstr ""
 
-# 004860a9067f4216ab19c03547f440c7
+# fe647ec58496481d9a7751bde440fa0c
 #: ../../using/recipes.md:204
 msgid "Spark"
-msgstr "Spark"
+msgstr ""
 
-# 005cc1686dd64fe5af20b0c2be9e6851
+# d0fc3715abab4a76812a2e7015f2be55
 #: ../../using/recipes.md:206
 msgid "A few suggestions have been made regarding using Docker Stacks with spark."
-msgstr "A few suggestions have been made regarding using Docker Stacks with spark."
+msgstr ""
 
-# 234750b4a0b64f59982acb5ffe1af082
+# 6182f433983649208b691dc4ad39b3b1
 #: ../../using/recipes.md:208
 msgid "Using PySpark with AWS S3"
-msgstr "Using PySpark with AWS S3"
+msgstr ""
 
-# 53b5b6c8f80f4b0392d91cc24f392840
+# 536fd7b869df4ab3837b510fdaab4f83
 #: ../../using/recipes.md:210
 msgid "Using Spark session for hadoop 2.7.3"
-msgstr "Using Spark session for hadoop 2.7.3"
+msgstr ""
 
-# 54deb7ee376945c1b8872e890bffd942
+# 4cba8e4c12704f51aae9a8d73f3fc54f
 #: ../../using/recipes.md:230
 msgid "Using Spark context for hadoop 2.6.0"
-msgstr "Using Spark context for hadoop 2.6.0"
+msgstr ""
 
-# 7d5ce7e60c3b4ad3933e0cc501ba92be
+# 340a026384be4c5791dd1e1ceadb68bb
 #: ../../using/recipes.md:252
 msgid "Ref: https://github.com/jupyter/docker-stacks/issues/127"
-msgstr "Ref: https://github.com/jupyter/docker-stacks/issues/127"
+msgstr ""
 
-# f35b663a2499465f9e4d061e2225ab13
+# a4e41f560b674eed8235533202d4a3e2
 #: ../../using/recipes.md:254
 msgid "Using Local Spark JARs"
-msgstr "Using Local Spark JARs"
+msgstr ""
 
-# 6824e98cf3644f41818835141e01ec86
+# 98497d18d63c47d8a1c0b881567af6b2
 #: ../../using/recipes.md:270
 msgid "Ref: https://github.com/jupyter/docker-stacks/issues/154"
-msgstr "Ref: https://github.com/jupyter/docker-stacks/issues/154"
+msgstr ""
 
-# cbd3f11321504951af41e0853308eaef
+# 721488b8395241a9a28ed073d5922d66
 #: ../../using/recipes.md:272
 msgid "Using spark-packages.org"
-msgstr "Using spark-packages.org"
+msgstr ""
 
-# f2bc7706283b4826bd035db283e37579
+# c631f17a0b484bf0ab4db1db6c250b63
 #: ../../using/recipes.md:274
 msgid ""
 "If you'd like to use packages from spark-packages.org, see "
@@ -897,41 +706,35 @@ msgid ""
 "how to specify the package identifier in the environment before creating "
 "a SparkContext."
 msgstr ""
-"If you'd like to use packages from spark-packages.org, see "
-"https://gist.github.com/parente/c95fdaba5a9a066efaab for an example of "
-"how to specify the package identifier in the environment before creating "
-"a SparkContext."
 
-# ac4acb880a10426482bc9f3e2361aa2e
+# 54aad266bbe04b2c832113f8c6de961d
 #: ../../using/recipes.md:276
 msgid "Ref: https://github.com/jupyter/docker-stacks/issues/43"
-msgstr "Ref: https://github.com/jupyter/docker-stacks/issues/43"
+msgstr ""
 
-# 92d045ae4c42413c84dfb5bdc5ee2608
+# 1b12c39b6e9e48c9b53a56dcbb3c687b
 #: ../../using/recipes.md:278
 msgid "Use jupyter/all-spark-notebooks with an existing Spark/YARN cluster"
-msgstr "Use jupyter/all-spark-notebooks with an existing Spark/YARN cluster"
+msgstr ""
 
-# 14ba57ec7228490ebe2acf784b33d1e9
+# 0088c44217b4442ea1bc0776c085647e
 #: ../../using/recipes.md:342
 msgid "Credit: britishbadger from docker-stacks/issues/369"
-msgstr "Credit: britishbadger from docker-stacks/issues/369"
+msgstr ""
 
-# 0d891419d8934e09ab4e0e3c449cff96
+# 05e2f7930b2146b3b6dc2160e7b2938f
 #: ../../using/recipes.md:344
 msgid ""
 "Run Jupyter Notebook/Lab inside an already secured environment (i.e., "
 "with no token)"
 msgstr ""
-"Run Jupyter Notebook/Lab inside an already secured environment (i.e., "
-"with no token)"
 
-# 045e3bade4a54568b1806a4daba9ebfa
+# 96661b40222d42d7beb6ea4a4e27ed2a
 #: ../../using/recipes.md:346
 msgid "(Adapted from issue 728)"
-msgstr "(Adapted from issue 728)"
+msgstr ""
 
-# b07846ae169b4238a3543715cef9d42c
+# 968a4d9ee2ce4da3b15836cb19fe73c6
 #: ../../using/recipes.md:348
 msgid ""
 "The default security is very good. There are use cases, encouraged by "
@@ -940,71 +743,66 @@ msgid ""
 "launch the server without a password or token. In this case, you should "
 "use the start.sh script to launch the server with no token:"
 msgstr ""
-"The default security is very good. There are use cases, encouraged by "
-"containers, where the jupyter container and the system it runs within, "
-"lie inside the security boundary. In these use cases it is convenient to "
-"launch the server without a password or token. In this case, you should "
-"use the start.sh script to launch the server with no token:"
 
-# b44ed7a45e5e4826909013848e8d5591
+# 577b175adea2465682a27ca6b5dbe047
 #: ../../using/recipes.md:354
 msgid "For jupyterlab:"
-msgstr "For jupyterlab:"
+msgstr ""
 
-# 59077422c6c04c17a0bf1f0b413634ff
+# 68eca3d8da8a4e4a9582eae5db03a2f7
 #: ../../using/recipes.md:360
 msgid "For jupyter classic:"
-msgstr "For jupyter classic:"
+msgstr ""
 
-# 1937ca0d3bce4efe96a8df213864412a
+# 749d1d070d084422912681681b95de7c
 #: ../../using/recipes.md:365
 msgid "Enable nbextension spellchecker for markdown (or any other nbextension)"
-msgstr "Enable nbextension spellchecker for markdown (or any other nbextension)"
+msgstr ""
 
-# 39b0def7263842fcbf907aff02a34c96
+# eafb01c0017241f7b0d63c9efe3bf471
 #: ../../using/recipes.md:367
 msgid "NB: this works for classic notebooks only"
-msgstr "NB: this works for classic notebooks only"
+msgstr ""
 
-# e434ac80072b4a0085a59aa244a92f71
+# fd2b07901b0644b3851371881aaec0d3
 #: ../../using/recipes.md:380
 msgid "Ref: https://github.com/jupyter/docker-stacks/issues/675"
-msgstr "Ref: https://github.com/jupyter/docker-stacks/issues/675"
+msgstr ""
 
-# 490d2e765b364be2a6299dd43614dcf9
+# bd95c67863cf43f7968ba7ec8ec6ed77
 #: ../../using/running.md:1
 msgid "Running a Container"
-msgstr "Running a Container"
+msgstr ""
 
-# 2adc4aa861104f02a8230f86d2a75a3b
-# 6f5ff436b55b4556b568b5f3511da4ad
+# 05cc15a914e342de851163b9c977b78e
+# 035dba075a364e20ba77adb31704057f
 #: ../../using/running.md:3 ../../using/selecting.md:7
 msgid "Using one of the Jupyter Docker Stacks requires two choices:"
-msgstr "Using one of the Jupyter Docker Stacks requires two choices:"
+msgstr ""
 
-# ee12d1961869443f8a5e9d586558c18d
-# b556bb570d44483e83ac3c4d272da1b1
+# a5bd470d20664a7abb0d7a4fc5a26ab6
+# 24ff2826e55444bbaf9c7852ad84a862
 #: ../../using/running.md:5 ../../using/selecting.md:9
 msgid "Which Docker image you wish to use"
-msgstr "Which Docker image you wish to use"
+msgstr ""
 
-# 74d2d8066624448fa4bd18311193953b
-# b0c91634100d409383da7f0f897157e8
+# cad851a7c7bf4b58bd5c740bbd51370f
+# fc4a1d9d40fc4531819c7e3268d42477
 #: ../../using/running.md:6 ../../using/selecting.md:10
 msgid "How you wish to start Docker containers from that image"
-msgstr "How you wish to start Docker containers from that image"
+msgstr ""
 
-# 2d161d9c5d074499bf89795bc1f9ee71
+# 2a3f883d3edc4d02b67a9bc857bbf9d2
 #: ../../using/running.md:8
 msgid "This section provides details about the second."
-msgstr "This section provides details about the second."
+msgstr ""
 
-# 9dd416c6f6ef497f86b6b2f1b1449ee4
+# efdebebd730f4d34b3776e1768b4edc5
 #: ../../using/running.md:10
 msgid "Using the Docker CLI"
-msgstr "Using the Docker CLI"
+msgstr ""
 
-# 60a326dcab6d4264b5765a8bb4d763fc
+# 47eaf61cf553485db1e7a1554eebfd1b
 #: ../../using/running.md:12
 msgid ""
 "You can launch a local Docker container from the Jupyter Docker Stacks "
@@ -1012,12 +810,8 @@ msgid ""
 "configure containers using the CLI. The following are some common "
 "patterns."
 msgstr ""
-"You can launch a local Docker container from the Jupyter Docker Stacks "
-"using the Docker command line interface. There are numerous ways to "
-"configure containers using the CLI. The following are some common "
-"patterns."
 
-# a5b279914e3045188e52967cd3305550
+# 102b2f16273f4cdda45099ccf6430e39
 #: ../../using/running.md:14
 msgid ""
 "Example 1 This command pulls the jupyter/scipy-notebook image tagged "
@@ -1026,24 +820,16 @@ msgid ""
 "exposes the server on host port 8888. The server logs appear in the "
 "terminal and include a URL to the notebook server."
 msgstr ""
-"Example 1 This command pulls the jupyter/scipy-notebook image tagged "
-"2c80cf3537ca from Docker Hub if it is not already present on the local "
-"host. It then starts a container running a Jupyter Notebook server and "
-"exposes the server on host port 8888. The server logs appear in the "
-"terminal and include a URL to the notebook server."
 
-# 2208746e8c354ff9ad12e6876164fb83
+# 3866e5dbc6bb4f12826cc9d5c6389cd0
 #: ../../using/running.md:36
 msgid ""
 "Pressing Ctrl-C shuts down the notebook server but leaves the container "
 "intact on disk for later restart or permanent deletion using commands "
 "like the following:"
 msgstr ""
-"Pressing Ctrl-C shuts down the notebook server but leaves the container "
-"intact on disk for later restart or permanent deletion using commands "
-"like the following:"
 
-# 7ce1418608914601a5b39372951b1913
+# 777e803f312d46cf9f20feedc7d88fe0
 #: ../../using/running.md:55
 msgid ""
 "Example 2 This command pulls the jupyter/r-notebook image tagged "
@@ -1053,25 +839,16 @@ msgid ""
 "terminal and include a URL to the notebook server, but with the internal "
 "container port (8888) instead of the the correct host port (10000)."
 msgstr ""
-"Example 2 This command pulls the jupyter/r-notebook image tagged "
-"e5c5a7d3e52d from Docker Hub if it is not already present on the local "
-"host. It then starts a container running a Jupyter Notebook server and "
-"exposes the server on host port 10000. The server logs appear in the "
-"terminal and include a URL to the notebook server, but with the internal "
-"container port (8888) instead of the the correct host port (10000)."
 
-# c7dede95229d476faaeb3b4002732c63
+# 377c4f764c4942c8806f93e74ced124e
 #: ../../using/running.md:77
 msgid ""
 "Pressing Ctrl-C shuts down the notebook server and immediately destroys "
 "the Docker container. Files written to ~/work in the container remain "
 "touched. Any other changes made in the container are lost."
 msgstr ""
-"Pressing Ctrl-C shuts down the notebook server and immediately destroys "
-"the Docker container. Files written to ~/work in the container remain "
-"touched. Any other changes made in the container are lost."
 
-# 29a0707a214c4a469f742dc2538403d1
+# e2fecfe0aa8f486db14e7ea53c6e1c39
 #: ../../using/running.md:79
 msgid ""
 "Example 3 This command pulls the jupyter/all-spark-notebook image "
@@ -1080,47 +857,35 @@ msgid ""
 "notebook running a JupyterLab server and exposes the server on a randomly"
 " selected port."
 msgstr ""
-"Example 3 This command pulls the jupyter/all-spark-notebook image "
-"currently tagged latest from Docker Hub if an image tagged latest is not "
-"already present on the local host. It then starts a container named "
-"notebook running a JupyterLab server and exposes the server on a randomly"
-" selected port."
 
-# ec26e19216d841d89d3f25061bd1802a
+# 22c531b06ab14a07b6c05571d20093d6
 #: ../../using/running.md:85
 msgid ""
 "The assigned port and notebook server token are visible using other "
 "Docker commands."
 msgstr ""
-"The assigned port and notebook server token are visible using other "
-"Docker commands."
 
-# 26c7577d7e334e7caf588ce9dd0ec4df
+# 1a0c5a5c2c234271932e76999ef582ec
 #: ../../using/running.md:99
 msgid ""
 "Together, the URL to visit on the host machine to access the server in "
 "this case is "
 "http://localhost:32769?token=15914ca95f495075c0aa7d0e060f1a78b6d94f70ea373b00."
 msgstr ""
-"Together, the URL to visit on the host machine to access the server in "
-"this case is "
-"http://localhost:32769?token=15914ca95f495075c0aa7d0e060f1a78b6d94f70ea373b00."
 
-# 8214ce49fdfd460db95940fd8e2d5647
+# 2ebdbe40ca2844e8b9e72b7842f662bc
 #: ../../using/running.md:101
 msgid ""
 "The container runs in the background until stopped and/or removed by "
 "additional Docker commands."
 msgstr ""
-"The container runs in the background until stopped and/or removed by "
-"additional Docker commands."
 
-# 234eb69601a9448691b21c8e96b87e60
+# 5b052f4a27a54535af5ab5b7464dbe89
 #: ../../using/running.md:113
 msgid "Using Binder"
-msgstr "Using Binder"
+msgstr ""
 
-# c099a92eb85542e1854a017fa79a7b13
+# da98399210274ccdaad3dae3627b1184
 #: ../../using/running.md:115
 msgid ""
 "Binder is a service that allows you to create and share custom computing "
@@ -1129,18 +894,13 @@ msgid ""
 "Dockerfile. See the docker-stacks example and Using a Dockerfile sections"
 " in the Binder documentation for instructions."
 msgstr ""
-"Binder is a service that allows you to create and share custom computing "
-"environments for projects in version control. You can use any of the "
-"Jupyter Docker Stacks images as a basis for a Binder-compatible "
-"Dockerfile. See the docker-stacks example and Using a Dockerfile sections"
-" in the Binder documentation for instructions."
 
-# a1bf87c991b8488a91067c8849d65fcf
+# 55ac73b7088d4c8daee182dfa7da273f
 #: ../../using/running.md:117
 msgid "Using JupyterHub"
-msgstr "Using JupyterHub"
+msgstr ""
 
-# c599fd57e7ab4c328aaceee219c0ea9f
+# 927dc077eea741c2bfc0c65d20cedfe3
 #: ../../using/running.md:119
 msgid ""
 "You can configure JupyterHub to launcher Docker containers from the "
@@ -1150,19 +910,13 @@ msgid ""
 "Picking or building a Docker image instructions for the dockerspawner "
 "instead."
 msgstr ""
-"You can configure JupyterHub to launcher Docker containers from the "
-"Jupyter Docker Stacks images. If you've been following the Zero to "
-"JupyterHub with Kubernetes guide, see the Use an existing Docker image "
-"section for details. If you have a custom JupyterHub deployment, see the "
-"Picking or building a Docker image instructions for the dockerspawner "
-"instead."
 
-# baae8f8a8fbc4482868309033cf5cd1c
+# 633e412af0a446b0b97a27b51a86532b
 #: ../../using/running.md:121
 msgid "Using Other Tools and Services"
-msgstr "Using Other Tools and Services"
+msgstr ""
 
-# 7c7d5324b0224c3abefa55ac3cdffec9
+# f184b5fe87ea4101995177d78b4b2f17
 #: ../../using/running.md:123
 msgid ""
 "You can use the Jupyter Docker Stacks with any Docker-compatible "
@@ -1171,41 +925,36 @@ msgid ""
 "service for details about how to reference, configure, and launch "
 "containers from these images."
 msgstr ""
-"You can use the Jupyter Docker Stacks with any Docker-compatible "
-"technology (e.g., Docker Compose, docker-py, your favorite cloud "
-"container service). See the documentation of the tool, library, or "
-"service for details about how to reference, configure, and launch "
-"containers from these images."
 
-# 243e8b2630b64f749d3784805f6f4113
+# c98fdeb172fb4ec3a8a8087c48429f04
 #: ../../using/selecting.md:1
 msgid "Selecting an Image"
-msgstr "Selecting an Image"
+msgstr ""
 
-# 421d67febd47493586983498ae450830
-# 13321c6a6cea48c49d0d91e30f65b3f0
+# 3c714629ef574f34a2a3a38085fb9c8d
+# 85328d14a09a4f8d83a92d7550bf0690
 #: ../../using/selecting.md:3 ../../using/selecting.md:14
 msgid "Core Stacks"
-msgstr "Core Stacks"
+msgstr ""
 
-# 526f3519e0c64fa38f903ac0cf48bdea
-# 25c533bce01546c6885f32e274f9f00c
+# c95a54d4c1fe45229ce45ebbb1ee249f
+# 52f10b204ebd42dfa5f51748f680fb38
 #: ../../using/selecting.md:4 ../../using/selecting.md:123
 msgid "Image Relationships"
-msgstr "Image Relationships"
+msgstr ""
 
-# 37abdbe678eb4b618cf6d04e8fe5e282
-# 1c365037cd764aa2a463483eb58d4440
+# 541ac85034034eaab56f331ee972b242
+# 20eed0a822964e89bf3cad70fb0afefb
 #: ../../using/selecting.md:5 ../../using/selecting.md:141
 msgid "Community Stacks"
-msgstr "Community Stacks"
+msgstr ""
 
-# 5091b2436a524dc8b3869043329df2ad
+# 9bf531372259449da32ea02ec63840c9
 #: ../../using/selecting.md:12
 msgid "This section provides details about the first."
-msgstr "This section provides details about the first."
+msgstr ""
 
-# 46d1b9c6be034219914b7adbc6198e72
+# ff7679af5a5b41b79bfab5312a8dead7
 #: ../../using/selecting.md:16
 msgid ""
 "The Jupyter team maintains a set of Docker image definitions in the "
@@ -1213,338 +962,300 @@ msgid ""
 " sections describe these images including their contents, relationships, "
 "and versioning strategy."
 msgstr ""
-"The Jupyter team maintains a set of Docker image definitions in the "
-"https://github.com/jupyter/docker-stacks GitHub repository. The following"
-" sections describe these images including their contents, relationships, "
-"and versioning strategy."
 
-# 71a4044edba64940921ce4b475e58f98
+# ad78f1eac13349fb9c5e1f2d29898915
 #: ../../using/selecting.md:18
 msgid "jupyter/base-notebook"
-msgstr "jupyter/base-notebook"
+msgstr ""
 
-# c1025f8e3e094293bc84c5a0a7cdce55
-# 1bfd6e62249e493d87a70f142203c73e
-# 131c9f7015764d41b5264b55b8dbd264
-# 1d8ce0253d7c407ba2047fa0a8670bf1
-# 602bffd2e75f44fd87604613e65a0034
-# 5addc2c813bf43ee82459920007d65d8
-# 4926865437ed47f5afcb6d808591c691
-# 67f4eb891de7451da969d6731c9d736b
+# 7eb0e89ad7444281a4b571f8b8ae0e89
+# 838bb6c7b9e044ab8c92b1ccdec2bb11
+# f378336c6e4e4a46a4001cae350d6199
+# 530ae4daf0fe4fec95b195912d46f61d
+# 533bf0d50c5a4455854d251c0af1fc2d
+# 8887645ecbec4f43857537709e20f4e2
+# 9a6a5802dfc243f8b4746d7b0f6f35b3
+# ec4654635f8c4d79ae4f46b5b7d9824b
 #: ../../using/selecting.md:20 ../../using/selecting.md:37
 #: ../../using/selecting.md:49 ../../using/selecting.md:63
 #: ../../using/selecting.md:76 ../../using/selecting.md:87
 #: ../../using/selecting.md:100 ../../using/selecting.md:112
 msgid "Source on GitHub | Dockerfile commit history | Docker Hub image tags"
-msgstr "Source on GitHub | Dockerfile commit history | Docker Hub image tags"
+msgstr ""
 
-# ce1a1661140d4cf6bf4e3264bf5f2ad8
+# 19e8cc4d204d4fcd853e5e98b088f1c5
 #: ../../using/selecting.md:24
 msgid ""
 "jupyter/base-notebook is a small image supporting the options common "
 "across all core stacks. It is the basis for all other stacks."
 msgstr ""
-"jupyter/base-notebook is a small image supporting the options common "
-"across all core stacks. It is the basis for all other stacks."
 
-# e5a00787f52c45a99c7e94add1b4ffd3
+# abe2bd4773244867b879cfcd19febba1
 #: ../../using/selecting.md:26
 msgid ""
 "Minimally-functional Jupyter Notebook server (e.g., no pandoc for saving "
 "notebooks as PDFs)"
 msgstr ""
-"Minimally-functional Jupyter Notebook server (e.g., no pandoc for saving "
-"notebooks as PDFs)"
 
-# 0776cc5afe4f4894bf96b16c3aa5d757
+# a42389a1eb89450da6aca8acd393ca39
 #: ../../using/selecting.md:27
 msgid "Miniconda Python 3.x in /opt/conda"
-msgstr "Miniconda Python 3.x in /opt/conda"
+msgstr ""
 
-# 707f22d737ae4024acb0033f4895938d
+# 25f397007c0f4db5a1ea1de455b638d0
 #: ../../using/selecting.md:28
 msgid "No preinstalled scientific computing packages"
-msgstr "No preinstalled scientific computing packages"
+msgstr ""
 
-# 77a2cea92bdb46aaab4f9e6c5cbb9cd5
+# f9119a342ec34931abcd73eed074a7b0
 #: ../../using/selecting.md:29
 msgid ""
 "Unprivileged user jovyan (uid=1000, configurable, see options) in group "
 "users (gid=100) with ownership over the /home/jovyan and /opt/conda paths"
 msgstr ""
-"Unprivileged user jovyan (uid=1000, configurable, see options) in group "
-"users (gid=100) with ownership over the /home/jovyan and /opt/conda paths"
 
-# e254c9a34e5c4823a941c8b29dcc9a8b
+# ccaf8853148e4d06b7fb86cf5788e053
 #: ../../using/selecting.md:30
 msgid ""
 "tini as the container entrypoint and a start-notebook.sh script as the "
 "default command"
 msgstr ""
-"tini as the container entrypoint and a start-notebook.sh script as the "
-"default command"
 
-# 2c9f49a55e8e454eb99a9ade77a4d0f3
+# 5df136e2752645579d66021ed3bce9d9
 #: ../../using/selecting.md:31
 msgid "A start-singleuser.sh script useful for launching containers in JupyterHub"
-msgstr "A start-singleuser.sh script useful for launching containers in JupyterHub"
+msgstr ""
 
-# d53f7c3ba0e94a8ab294d3cfaa2141a5
+# 54cb2007aaba4dbf86693d23f065f9e1
 #: ../../using/selecting.md:32
 msgid ""
 "A start.sh script useful for running alternative commands in the "
 "container (e.g. ipython, jupyter kernelgateway, jupyter lab)"
 msgstr ""
-"A start.sh script useful for running alternative commands in the "
-"container (e.g. ipython, jupyter kernelgateway, jupyter lab)"
 
-# 50a710c15c2043389812e51d9c89b586
+# 6276758896934d1a95e201188ca88581
 #: ../../using/selecting.md:33
 msgid "Options for a self-signed HTTPS certificate and passwordless sudo"
-msgstr "Options for a self-signed HTTPS certificate and passwordless sudo"
+msgstr ""
 
-# 689ea9ca3909487fbdb3e6ac4e2602ee
+# 79f980cbfd974e008ded2250b54f8883
 #: ../../using/selecting.md:35
 msgid "jupyter/minimal-notebook"
-msgstr "jupyter/minimal-notebook"
+msgstr ""
 
-# 6e1e0efbe2f54b3bafa8932eb166571e
+# 9b4d477117294b2bb5b43d8652a91411
 #: ../../using/selecting.md:41
 msgid ""
 "jupyter/minimal-notebook adds command line tools useful when working in "
 "Jupyter applications."
 msgstr ""
-"jupyter/minimal-notebook adds command line tools useful when working in "
-"Jupyter applications."
 
-# d4e803bc76f74c2e9ce5c4a25fdff3e0
+# 5e4b7b7c197d42269cea410998165328
 #: ../../using/selecting.md:43
 msgid "Everything in jupyter/base-notebook"
-msgstr "Everything in jupyter/base-notebook"
+msgstr ""
 
-# 8eeaad6148ef47e287a5caaf5406a486
+# 8ffa13035bc94e8094923da873afffc0
 #: ../../using/selecting.md:44
 msgid "Pandoc and TeX Live for notebook document conversion"
-msgstr "Pandoc and TeX Live for notebook document conversion"
+msgstr ""
 
-# cc3b4b72425b4035a4fce571d7c61117
+# 6a8674b3982d418588c44c51c5333332
 #: ../../using/selecting.md:45
 msgid "git, emacs, jed, nano, tzdata, and unzip"
-msgstr "git, emacs, jed, nano, tzdata, and unzip"
+msgstr ""
 
-# 7331cc8849de475b86ee80794ed896b2
+# 1d7b56913ee14365bf3e6c151cfeed30
 #: ../../using/selecting.md:47
 msgid "jupyter/r-notebook"
-msgstr "jupyter/r-notebook"
+msgstr ""
 
-# db9575cf8547463daa831d25c98e01fd
+# 4e739543ae274c89a73b86a2e2dbfaf3
 #: ../../using/selecting.md:53
 msgid "jupyter/r-notebook includes popular packages from the R ecosystem."
-msgstr "jupyter/r-notebook includes popular packages from the R ecosystem."
+msgstr ""
 
-# 2b6fb981ef5e40539d1395a117495960
-# a8528c5c397b4464b0babd70446239ad
+# 3fb4f35b1ea94491a43ffa8ffeb964a3
+# 7be6194575844080a173a1d4af5a46da
 #: ../../using/selecting.md:55 ../../using/selecting.md:69
 msgid "Everything in jupyter/minimal-notebook and its ancestor images"
-msgstr "Everything in jupyter/minimal-notebook and its ancestor images"
+msgstr ""
 
-# aa15aa48ed304870be02cc9e5c1e66ea
+# 5630c81956d6488881eed4aa4f788096
 #: ../../using/selecting.md:56
 msgid "The R interpreter and base environment"
-msgstr "The R interpreter and base environment"
+msgstr ""
 
-# 454174da68f740c483d7662facdbe40e
-# e25a254bcfd24f9a8cc30747c68ce2d2
+# b64173b2d08a485ea32a05f12622fdc1
+# 4f8609f03211436eb3c1d63133982858
 #: ../../using/selecting.md:57 ../../using/selecting.md:119
 msgid "IRKernel to support R code in Jupyter notebooks"
-msgstr "IRKernel to support R code in Jupyter notebooks"
+msgstr ""
 
-# e91675b46b494a1b9db901b179ef57ec
+# 86a316eba14944cba3dc611949d0fab8
 #: ../../using/selecting.md:58
 msgid ""
 "tidyverse packages, including ggplot2, dplyr, tidyr, readr, purrr, "
 "tibble, stringr, lubridate, and broom from conda-forge"
 msgstr ""
-"tidyverse packages, including ggplot2, dplyr, tidyr, readr, purrr, "
-"tibble, stringr, lubridate, and broom from conda-forge"
 
-# 5c6ae83d7db943b590c9036a047e7659
+# bc3f6ff1c7dd4b8ca53e3814a83dfd35
 #: ../../using/selecting.md:59
 msgid ""
 "plyr, devtools, shiny, rmarkdown, forecast, rsqlite, reshape2, "
 "nycflights13, caret, rcurl, and randomforest packages from conda-forge"
 msgstr ""
-"plyr, devtools, shiny, rmarkdown, forecast, rsqlite, reshape2, "
-"nycflights13, caret, rcurl, and randomforest packages from conda-forge"
 
-# 79af591505fc4c8689f562f11cf479cc
+# 5222f4d373c84249a4ba0480fb8db3a8
 #: ../../using/selecting.md:61
 msgid "jupyter/scipy-notebook"
-msgstr "jupyter/scipy-notebook"
+msgstr ""
 
-# 18b0bc0aa7a44544b666cedf2ee8c4c2
+# 700f5e415b1d41d8b378e09624094d74
 #: ../../using/selecting.md:67
 msgid ""
 "jupyter/scipy-notebook includes popular packages from the scientific "
 "Python ecosystem."
 msgstr ""
-"jupyter/scipy-notebook includes popular packages from the scientific "
-"Python ecosystem."
 
-# 3c34f0c6f3f94038b7aec5bdc348d505
+# 0e9b3eff7379426489b766e66a8d45b8
 #: ../../using/selecting.md:70
 msgid ""
 "pandas, numexpr, matplotlib, scipy, seaborn, scikit-learn, scikit-image, "
 "sympy, cython, patsy, statsmodel, cloudpickle, dill, numba, bokeh, "
 "sqlalchemy, hdf5, vincent, beautifulsoup, protobuf, and xlrd packages"
 msgstr ""
-"pandas, numexpr, matplotlib, scipy, seaborn, scikit-learn, scikit-image, "
-"sympy, cython, patsy, statsmodel, cloudpickle, dill, numba, bokeh, "
-"sqlalchemy, hdf5, vincent, beautifulsoup, protobuf, and xlrd packages"
 
-# 0fa5dbbb205c4d15b1fe19997b4d2fc8
+# bf633775d17141bd9d4308406b0fab85
 #: ../../using/selecting.md:71
 msgid "ipywidgets for interactive visualizations in Python notebooks"
-msgstr "ipywidgets for interactive visualizations in Python notebooks"
+msgstr ""
 
-# 3373de5aef5d4fbf926a479a20d37f37
+# a380ec62a87649509a3c0192a6b001f5
 #: ../../using/selecting.md:72
 msgid "Facets for visualizing machine learning datasets"
-msgstr "Facets for visualizing machine learning datasets"
+msgstr ""
 
-# bc5ff0ccc8a644a0aa91864a6abc1535
+# ab5fb5a329c34d648eec5edb3da42bb5
 #: ../../using/selecting.md:74
 msgid "jupyter/tensorflow-notebook"
-msgstr "jupyter/tensorflow-notebook"
+msgstr ""
 
-# 3a472f27e15f45b3811aaabf890b5e7b
+# 47dce5b8eeb849a9a56f93a4570b6f09
 #: ../../using/selecting.md:80
 msgid ""
 "jupyter/tensorflow-notebook includes popular Python deep learning "
 "libraries."
 msgstr ""
-"jupyter/tensorflow-notebook includes popular Python deep learning "
-"libraries."
 
-# 36c757eb11fb4bda8ee09dc640fba193
-# 2e4d562af4964c578e69a178feb9fe9b
+# b141cf514f5d4effa57ebb81cb6bd1ed
+# 8b1be211fcc940ef9e20c661df60d2ad
 #: ../../using/selecting.md:82 ../../using/selecting.md:106
 msgid "Everything in jupyter/scipy-notebook and its ancestor images"
-msgstr "Everything in jupyter/scipy-notebook and its ancestor images"
+msgstr ""
 
-# f228a9c8c5d44e44ba4dab8775f3dacf
+# 1bfc470730d6484984c1f365bb056de1
 #: ../../using/selecting.md:83
 msgid "tensorflow and keras machine learning libraries"
-msgstr "tensorflow and keras machine learning libraries"
+msgstr ""
 
-# 2096212f410b44b48c48b1e2945f211b
+# 505a7e4bf3614f919bca04234179ee09
 #: ../../using/selecting.md:85
 msgid "jupyter/datascience-notebook"
-msgstr "jupyter/datascience-notebook"
+msgstr ""
 
-# 41a8274669c64236a1f22f9d42bdf473
+# cef11c0bcecc4b80832e78d2b1d1330a
 #: ../../using/selecting.md:91
 msgid ""
 "jupyter/datascience-notebook includes libraries for data analysis from "
 "the Julia, Python, and R communities."
 msgstr ""
-"jupyter/datascience-notebook includes libraries for data analysis from "
-"the Julia, Python, and R communities."
 
-# abffe15879c442f89e6d13369262026c
+# 19bd5d1f94cb49f383d759bfa3f9dce6
 #: ../../using/selecting.md:93
 msgid ""
 "Everything in the jupyter/scipy-notebook and jupyter/r-notebook images, "
 "and their ancestor images"
 msgstr ""
-"Everything in the jupyter/scipy-notebook and jupyter/r-notebook images, "
-"and their ancestor images"
 
-# 7108b05722a542daa8891eabea8e8353
+# 839a27e685d544788f93350789fc4c69
 #: ../../using/selecting.md:94
 msgid "The Julia compiler and base environment"
-msgstr "The Julia compiler and base environment"
+msgstr ""
 
-# 9303aeb6cb1b401f8b75dad9f0f6bd8f
+# 389dacb00a264c899cad2518c1203fe4
 #: ../../using/selecting.md:95
 msgid "IJulia to support Julia code in Jupyter notebooks"
-msgstr "IJulia to support Julia code in Jupyter notebooks"
+msgstr ""
 
-# aebe107836d94fa2ad7d233680286880
+# 9d560201cf654dc1b14153793258e3a3
 #: ../../using/selecting.md:96
 msgid "HDF5, Gadfly, and RDatasets packages"
-msgstr "HDF5, Gadfly, and RDatasets packages"
+msgstr ""
 
-# d0f83aa408dd4fc78403707a2e077da9
+# 93a7dcfdca074fdb87e92efbadc5fa73
 #: ../../using/selecting.md:98
 msgid "jupyter/pyspark-notebook"
-msgstr "jupyter/pyspark-notebook"
+msgstr ""
 
-# d09cdee474a648d2bc9c659456e8dedb
+# 576bec9122ce405a9a162ef1f21413ca
 #: ../../using/selecting.md:104
 msgid ""
 "jupyter/pyspark-notebook includes Python support for Apache Spark, "
 "optionally on Mesos."
 msgstr ""
-"jupyter/pyspark-notebook includes Python support for Apache Spark, "
-"optionally on Mesos."
 
-# 289550a01d7a4f038141441495ea5c46
+# 3e64994adabf403ebd4111e7fe4e8c66
 #: ../../using/selecting.md:107
 msgid "Apache Spark with Hadoop binaries"
-msgstr "Apache Spark with Hadoop binaries"
+msgstr ""
 
-# df04fed1dfb44b40a114d30b96e5eec1
+# 94aa3a29350441079731fda40ba4c0ab
 #: ../../using/selecting.md:108
 msgid "Mesos client libraries"
-msgstr "Mesos client libraries"
+msgstr ""
 
-# ee06a7ee85a6463b98bf2cde2f14e3ea
+# 1cdbad177653419e86d26e56bdf71a47
 #: ../../using/selecting.md:110
 msgid "jupyter/all-spark-notebook"
-msgstr "jupyter/all-spark-notebook"
+msgstr ""
 
-# 9bea2957a3c4463facfcee645d0f5714
+# a122e974fa11467b814b190d24e29a7c
 #: ../../using/selecting.md:116
 msgid ""
 "jupyter/all-spark-notebook includes Python, R, and Scala support for "
 "Apache Spark, optionally on Mesos."
 msgstr ""
-"jupyter/all-spark-notebook includes Python, R, and Scala support for "
-"Apache Spark, optionally on Mesos."
 
-# 9ecf7ee9d785458fa6b99b96191825fe
+# 10ec575fffcd4a9f9d0d8c95250ee316
 #: ../../using/selecting.md:118
 msgid "Everything in jupyter/pyspark-notebook and its ancestor images"
-msgstr "Everything in jupyter/pyspark-notebook and its ancestor images"
+msgstr ""
 
-# efb0601cdbb34381b1720d0a345b6a8a
+# 8f59798f190f4a87b7e4855922db31e0
 #: ../../using/selecting.md:120
 msgid "Apache Toree and spylon-kernel to support Scala code in Jupyter notebooks"
-msgstr "Apache Toree and spylon-kernel to support Scala code in Jupyter notebooks"
+msgstr ""
 
-# bcb4f4720d1a45889b38c7659aaa6c31
+# 44a5a2bef65b41ba8dc432fecc6203b7
 #: ../../using/selecting.md:121
 msgid "ggplot2, sparklyr, and rcurl packages"
-msgstr "ggplot2, sparklyr, and rcurl packages"
+msgstr ""
 
-# 0c85f58e68d0447bba2b47dcb72e0edd
+# a8c71c9f788a42de87a58dee32b34139
 #: ../../using/selecting.md:125
 msgid ""
 "The following diagram depicts the build dependency tree of the core "
 "images. (i.e., the FROM statements in their Dockerfiles). Any given image"
 " inherits the complete content of all ancestor images pointing to it."
 msgstr ""
-"The following diagram depicts the build dependency tree of the core "
-"images. (i.e., the FROM statements in their Dockerfiles). Any given image"
-" inherits the complete content of all ancestor images pointing to it."
 
-# d9fce203a65c4b5da91aea327d7afc96
+# 6c01def83d214a4b92fd6c229c4f50a0
 #: ../../using/selecting.md:129
 msgid "Builds"
-msgstr "Builds"
+msgstr ""
 
-# f5b078b3b6e447adbfb3c4ff4fd375f4
+# d6b5e32382164e2a8efa7a0cc414914a
 #: ../../using/selecting.md:131
 msgid ""
 "Pull requests to the jupyter/docker-stacks repository trigger builds of "
@@ -1553,29 +1264,21 @@ msgid ""
 "rebuild on Docker Cloud and become available to docker pull from Docker "
 "Hub."
 msgstr ""
-"Pull requests to the jupyter/docker-stacks repository trigger builds of "
-"all images on Travis CI. These images are for testing purposes only and "
-"are not saved for use. When pull requests merge to master, all images "
-"rebuild on Docker Cloud and become available to docker pull from Docker "
-"Hub."
 
-# 5acafb62cac64815be900450da4c7bf0
+# 1991e435563c4c5b990aed6763504bea
 #: ../../using/selecting.md:133
 msgid "Versioning"
-msgstr "Versioning"
+msgstr ""
 
-# 9154d913b93f4fe897c8ca454de49e35
+# 3c74950bf43d45ce93e873da75a8fa7c
 #: ../../using/selecting.md:135
 msgid ""
 "The latest tag in each Docker Hub repository tracks the master branch "
 "HEAD reference on GitHub. latest is a moving target, by definition, and "
 "will have backward-incompatible changes regularly."
 msgstr ""
-"The latest tag in each Docker Hub repository tracks the master branch "
-"HEAD reference on GitHub. latest is a moving target, by definition, and "
-"will have backward-incompatible changes regularly."
 
-# a1d1ae3922034f6fa6fda050f55b529f
+# 83cd6274afe847dcbe95a453f6fee2e1
 #: ../../using/selecting.md:137
 msgid ""
 "Every image on Docker Hub also receives a 12-character tag which "
@@ -1585,14 +1288,8 @@ msgid ""
 "7c45ec67c8e7 were built from https://github.com/jupyter/docker-"
 "stacks/tree/7c45ec67c8e7)."
 msgstr ""
-"Every image on Docker Hub also receives a 12-character tag which "
-"corresponds with the git commit SHA that triggered the image build. You "
-"can inspect the state of the jupyter/docker-stacks repository for that "
-"commit to review the definition of the image (e.g., images with tag "
-"7c45ec67c8e7 were built from https://github.com/jupyter/docker-"
-"stacks/tree/7c45ec67c8e7)."
 
-# 2c9a704e8c5b415cb64fdea76e36448b
+# 9de32dc00e7c45138197eecca9018dd5
 #: ../../using/selecting.md:139
 msgid ""
 "You must refer to git-SHA image tags when stability and reproducibility "
@@ -1602,14 +1299,8 @@ msgid ""
 "container instance is acceptable (e.g., you want to briefly try a new "
 "library in a notebook)."
 msgstr ""
-"You must refer to git-SHA image tags when stability and reproducibility "
-"are important in your work. (e.g. FROM jupyter/scipy-"
-"notebook:7c45ec67c8e7, docker run -it --rm jupyter/scipy-"
-"notebook:7c45ec67c8e7). You should only use latest when a one-off "
-"container instance is acceptable (e.g., you want to briefly try a new "
-"library in a notebook)."
 
-# 2493f9c1b27e48bd9dd67f2a55c365b3
+# a3c6faf51ba6492499382b8c31a2d76f
 #: ../../using/selecting.md:143
 msgid ""
 "The core stacks are just a tiny sample of what's possible when combining "
@@ -1617,17 +1308,13 @@ msgid ""
 "community to create their own stacks based on the core images and link "
 "them below."
 msgstr ""
-"The core stacks are just a tiny sample of what's possible when combining "
-"Jupyter with other technologies. We encourage members of the Jupyter "
-"community to create their own stacks based on the core images and link "
-"them below."
 
-# b24d1c182204450ea831493384d052c7
+# 5e06096348924f51881d05f984e91381
 #: ../../using/selecting.md:145
 msgid "This list only has 2 examples. You can be the next!"
-msgstr "This list only has 2 examples. You can be the next!"
+msgstr ""
 
-# 13d75d7a9187411cb3cc1ef8c3d80fad
+# 978ce64398404c889fb00f07b5a0c6c8
 #: ../../using/selecting.md:147
 msgid ""
 "csharp-notebook is a community Jupyter Docker Stack image. Try C# in "
@@ -1635,47 +1322,38 @@ msgid ""
 "with example C# code and can readily be tried online via mybinder.org. "
 "Click here to launch ."
 msgstr ""
-"csharp-notebook is a community Jupyter Docker Stack image. Try C# in "
-"Jupyter Notebooks. The image includes more than 200 Jupyter Notebooks "
-"with example C# code and can readily be tried online via mybinder.org. "
-"Click here to launch ."
 
-# bb753856fb2543b3b2d2bd6056e49299
+# 76eb0a1648324472a6555850b70ca3bc
 #: ../../using/selecting.md:149
 msgid ""
 "education-notebook is a community Jupyter Docker Stack image. The image "
 "includes nbgrader and RISE on top of the datascience-notebook image. "
 "Click here to launch it on ."
 msgstr ""
-"education-notebook is a community Jupyter Docker Stack image. The image "
-"includes nbgrader and RISE on top of the datascience-notebook image. "
-"Click here to launch it on ."
 
-# a9e60ab1d2fa480fa86ba24f44e87f54
+# b1892840b7b24962bdd9485e0f6d1ead
 #: ../../using/selecting.md:151
 msgid ""
 "See the contributing guide for information about how to create your own "
 "Jupyter Docker Stack."
 msgstr ""
-"See the contributing guide for information about how to create your own "
-"Jupyter Docker Stack."
 
-# a62a60bdf34744c2b8c2de5602d077be
+# e8bd6dfe48a44bd09804fa04b72e1471
 #: ../../using/specifics.md:1
 msgid "Image Specifics"
-msgstr "Image Specifics"
+msgstr ""
 
-# 2945c0231ade459ebfed93e1dcb7d0c0
+# c1ab9b1a320a4f28ae49e578627595ef
 #: ../../using/specifics.md:3
 msgid "This page provides details about features specific to one or more images."
-msgstr "This page provides details about features specific to one or more images."
+msgstr ""
 
-# bc26125b63e848688be5c2572d353a0a
+# 4d189fd621134ee58b72055d032387ca
 #: ../../using/specifics.md:5
 msgid "Apache Spark"
-msgstr "Apache Spark"
+msgstr ""
 
-# ba31771aad70421fab406b8c051e0dc2
+# 1ebe3699513d44bc99f6d3eb8a9fe5b8
 #: ../../using/specifics.md:7
 msgid ""
 "The jupyter/pyspark-notebook and jupyter/all-spark-notebook images "
@@ -1683,122 +1361,104 @@ msgid ""
 "following sections provide some examples of how to get started using "
 "them."
 msgstr ""
-"The jupyter/pyspark-notebook and jupyter/all-spark-notebook images "
-"support the use of Apache Spark in Python, R, and Scala notebooks. The "
-"following sections provide some examples of how to get started using "
-"them."
 
-# 596763d999254f77864c0d2df7a88af2
+# 02762daed83646c3bb92b8a2952f237a
 #: ../../using/specifics.md:9
 msgid "Using Spark Local Mode"
-msgstr "Using Spark Local Mode"
+msgstr ""
 
-# 31cb4f9136a14355adf1a9ef805b0afb
+# 17b34b37b2514f7f8a03d3e7bbb5b609
 #: ../../using/specifics.md:11
 msgid ""
 "Spark local mode is useful for experimentation on small data when you do "
 "not have a Spark cluster available."
 msgstr ""
-"Spark local mode is useful for experimentation on small data when you do "
-"not have a Spark cluster available."
 
-# 9d9f99b639e44ff3a29801d4e9568a39
-# 33955d4c770f49a68d223bc60e56b0fd
+# 13d15d820e4a481eaefbe6bd53728a7c
+# 3bfab29528ae44029716add6192b627c
 #: ../../using/specifics.md:13 ../../using/specifics.md:69
 msgid "In a Python Notebook"
-msgstr "In a Python Notebook"
+msgstr ""
 
-# 194bb65319fd4c658b5ab97d02ee8064
-# 14653ab7b5084644a711eb876a772044
+# 3dc8937d38fe423c91bce4a44bbec105
+# 015f2179b4cb497889a8bd64f8816377
 #: ../../using/specifics.md:22 ../../using/specifics.md:96
 msgid "In a R Notebook"
-msgstr "In a R Notebook"
+msgstr ""
 
-# c7d2984ebbaa4cd3a2fe127c3b7013f9
-# 58fc8beb8c744a229380f18f61b265ef
+# ba52f62ac0e04181a5ab3cd51ef3480a
+# 569dd56bba454440a3ee598683a0f822
 #: ../../using/specifics.md:34 ../../using/specifics.md:117
 msgid "In a Spylon Kernel Scala Notebook"
-msgstr "In a Spylon Kernel Scala Notebook"
+msgstr ""
 
-# d9a4d849fa50441292cd058e9b4d595f
+# f6f29ad5fbe843f79496da70a040a345
 #: ../../using/specifics.md:36
 #, python-format
 msgid ""
 "Spylon kernel instantiates a SparkContext for you in variable sc after "
 "you configure Spark options in a %%init_spark magic cell."
 msgstr ""
-"Spylon kernel instantiates a SparkContext for you in variable sc after "
-"you configure Spark options in a %%init_spark magic cell."
 
-# 8b842fee795f438ba0aabc9eb35ad233
-# eff0b20e8787456ca1ebcbe5b93457b4
+# 931c98145855457d916b7b89d9dc718a
+# 00a1f40cf41b4896a3fde7251feb0809
 #: ../../using/specifics.md:50 ../../using/specifics.md:132
 msgid "In an Apache Toree Scala Notebook"
-msgstr "In an Apache Toree Scala Notebook"
+msgstr ""
 
-# 96f5c1de8c744fbe89f58b1165b159b5
+# 03ef9966ede74a97b04e1854b1c79cda
 #: ../../using/specifics.md:52
 msgid ""
 "Apache Toree instantiates a local SparkContext for you in variable sc "
 "when the kernel starts."
 msgstr ""
-"Apache Toree instantiates a local SparkContext for you in variable sc "
-"when the kernel starts."
 
-# 4c09e6dc0e3f46ef8cfeed20efd294c7
+# baac8bfd2f0e49b0bce9b645a735c02a
 #: ../../using/specifics.md:59
 msgid "Connecting to a Spark Cluster on Mesos"
-msgstr "Connecting to a Spark Cluster on Mesos"
+msgstr ""
 
-# d08dd34b2d254b1f99429dfa8f0177bc
+# 32218f10947a486888a1429452f21e5e
 #: ../../using/specifics.md:61
 msgid "This configuration allows your compute cluster to scale with your data."
-msgstr "This configuration allows your compute cluster to scale with your data."
+msgstr ""
 
-# 2c881937c74947649c999bdac4b1e885
+# 6f13341afbce4709ab138670ad666fcc
 #: ../../using/specifics.md:63
 msgid "Deploy Spark on Mesos."
-msgstr "Deploy Spark on Mesos."
+msgstr ""
 
-# 39c5f28fa1064ccca4997e3b1d3d508b
+# d1865378f23942afb087c79b8be9ef76
 #: ../../using/specifics.md:64
 msgid ""
 "Configure each slave with the --no-switch_user flag or create the "
 "$NB_USER account on every slave node."
 msgstr ""
-"Configure each slave with the --no-switch_user flag or create the "
-"$NB_USER account on every slave node."
 
-# 906afb72b9de431fabb4c8103b80f5d0
-# d3b3e73b1d5b4840b7786f741e5b9f53
+# 574e9a6c755e441386d96ec5bd5db6cf
+# ea2a7da5b48240b78ffb98f4dd3c6fa8
 #: ../../using/specifics.md:65 ../../using/specifics.md:161
 msgid ""
 "Run the Docker container with --net=host in a location that is network "
 "addressable by all of your Spark workers. (This is a Spark networking "
 "requirement.)"
 msgstr ""
-"Run the Docker container with --net=host in a location that is network "
-"addressable by all of your Spark workers. (This is a Spark networking "
-"requirement.)"
 
-# d20c2752acfe43ab83425fd23fbe7d4f
-# daf5232d113147d782a57bd15c8315f6
+# 219499497367418bbb05718852cf1463
+# 4daffa53b58d4576aec1181c8a4d5947
 #: ../../using/specifics.md:66 ../../using/specifics.md:162
 msgid ""
 "NOTE: When using --net=host, you must also use the flags --pid=host -e "
 "TINI_SUBREAPER=true. See https://github.com/jupyter/docker-"
 "stacks/issues/64 for details."
 msgstr ""
-"NOTE: When using --net=host, you must also use the flags --pid=host -e "
-"TINI_SUBREAPER=true. See https://github.com/jupyter/docker-"
-"stacks/issues/64 for details."
 
-# 9ea8136f4bf640949bf2a070966a3090
+# dc09dc0efca6464aa9ac1dd6a6a7ab0b
 #: ../../using/specifics.md:67
 msgid "Follow the language specific instructions below."
-msgstr "Follow the language specific instructions below."
+msgstr ""
 
-# d7e9945553a04bc0b94a2c6b382c83e2
+# 4a61e4180b0c4a569f6bc0757ab09a69
 #: ../../using/specifics.md:134
 msgid ""
 "The Apache Toree kernel automatically creates a SparkContext when it "
@@ -1807,94 +1467,74 @@ msgid ""
 "cluster via the SPARK_OPTS environment variable when you spawn a "
 "container."
 msgstr ""
-"The Apache Toree kernel automatically creates a SparkContext when it "
-"starts based on configuration information from its command line arguments"
-" and environment variables. You can pass information about your Mesos "
-"cluster via the SPARK_OPTS environment variable when you spawn a "
-"container."
 
-# 1bec6c70217941098145f78682d22403
+# 7647d636b1f444eab30838ba3a8ff889
 #: ../../using/specifics.md:136
 msgid ""
 "For instance, to pass information about a Mesos master, Spark binary "
 "location in HDFS, and an executor options, you could start the container "
 "like so:"
 msgstr ""
-"For instance, to pass information about a Mesos master, Spark binary "
-"location in HDFS, and an executor options, you could start the container "
-"like so:"
 
-# f0e143fe6d294ac2837e7450ad8d1f09
+# fc231a361033452498d26ddc435a2d48
 #: ../../using/specifics.md:144
 msgid ""
 "Note that this is the same information expressed in a notebook in the "
 "Python case above. Once the kernel spec has your cluster information, you"
 " can test your cluster in an Apache Toree notebook like so:"
 msgstr ""
-"Note that this is the same information expressed in a notebook in the "
-"Python case above. Once the kernel spec has your cluster information, you"
-" can test your cluster in an Apache Toree notebook like so:"
 
-# 1729661c37854d1ba33f20ce742fd7aa
+# d20fe02617394234a8c2d400162a88d3
 #: ../../using/specifics.md:155
 msgid "Connecting to a Spark Cluster in Standalone Mode"
-msgstr "Connecting to a Spark Cluster in Standalone Mode"
+msgstr ""
 
-# e84af2d74c924786b26884a0ff974f1a
+# 3ca478a816eb4cc996e656df0c4738d8
 #: ../../using/specifics.md:157
 msgid ""
 "Connection to Spark Cluster on Standalone Mode requires the following set"
 " of steps:"
 msgstr ""
-"Connection to Spark Cluster on Standalone Mode requires the following set"
-" of steps:"
 
-# 6c36d0d7f3fb4adf94693d143092c97c
+# f93abc3c1c004ec2871acfb9a233952b
 #: ../../using/specifics.md:159
 msgid ""
 "Verify that the docker image (check the Dockerfile) and the Spark Cluster"
 " which is being deployed, run the same version of Spark."
 msgstr ""
-"Verify that the docker image (check the Dockerfile) and the Spark Cluster"
-" which is being deployed, run the same version of Spark."
 
-# ae2cd1278ff140c58350e878af555fa8
+# cb5a7b58234c42fbb75ccfedab7dd607
 #: ../../using/specifics.md:160
 msgid "Deploy Spark in Standalone Mode."
-msgstr "Deploy Spark in Standalone Mode."
+msgstr ""
 
-# 3de224baf8c04be6999cfec48bcd8d81
+# 84ac8ee338244480ae2363ace97f39bb
 #: ../../using/specifics.md:163
 msgid ""
 "The language specific instructions are almost same as mentioned above for"
 " Mesos, only the master url would now be something like "
 "spark://10.10.10.10:7077"
 msgstr ""
-"The language specific instructions are almost same as mentioned above for"
-" Mesos, only the master url would now be something like "
-"spark://10.10.10.10:7077"
 
-# d91bea2342b1414792d7615658d7f991
+# 5e2d68073fa34580ab031a31f91f7f31
 #: ../../using/specifics.md:165
 msgid "Tensorflow"
-msgstr "Tensorflow"
+msgstr ""
 
-# 55fefbc1d65a400f99db58667b6117ca
+# 3b854359945548279e7addfecaef9492
 #: ../../using/specifics.md:167
 msgid ""
 "The jupyter/tensorflow-notebook image supports the use of Tensorflow in "
 "single machine or distributed mode."
 msgstr ""
-"The jupyter/tensorflow-notebook image supports the use of Tensorflow in "
-"single machine or distributed mode."
 
-# ff1c47c05e9d46a994e6ed02e0be2e1d
+# 0d42c934f9024f58bf2fd0e978f1e750
 #: ../../using/specifics.md:169
 msgid "Single Machine Mode"
-msgstr "Single Machine Mode"
+msgstr ""
 
-# 5c0f3406beb2496db1bcad5a6771f5b1
+# 62b50887e594424dbd129e2326931ff2
 #: ../../using/specifics.md:183
 msgid "Distributed Mode"
-msgstr "Distributed Mode"
+msgstr ""
 


### PR DESCRIPTION
* Remove `msgstr` values. They were accidentally pulled from Transifex and committed during initial setup. `make gettext` properly regenerates them with `msgid`s only.
* Add `[ci skip]` to the commit messages when Travis pushes English template files to master to avoid a no-op rebuild.
* Add a hook to try to skip Docker Hub builds when `ci skip` is present in the message.