### PR TITLE
Changed `conda clean` flags to `--all -f -y`

### DIFF
--- a/all-spark-notebook/Dockerfile
+++ b/all-spark-notebook/Dockerfile
@@ -28,7 +28,7 @@ RUN conda install --quiet --yes \
     'r-ggplot2=3.1*' \
     'r-sparklyr=0.9*' \
     'r-rcurl=1.95*' && \
-    conda clean --all -y && \
+    conda clean --all -f -y && \
     fix-permissions $CONDA_DIR && \
     fix-permissions /home/$NB_USER
 
@@ -43,7 +43,7 @@ RUN pip install --no-cache-dir \
 
 # Spylon-kernel
 RUN conda install --quiet --yes 'spylon-kernel=0.4*' && \
-    conda clean --all -y && \
+    conda clean --all -f -y && \
     python -m spylon_kernel install --sys-prefix && \
     rm -rf /home/$NB_USER/.local && \
     fix-permissions $CONDA_DIR && \

--- a/all-spark-notebook/Dockerfile
+++ b/all-spark-notebook/Dockerfile
@@ -28,7 +28,7 @@ RUN conda install --quiet --yes \
     'r-ggplot2=3.1*' \
     'r-sparklyr=0.9*' \
     'r-rcurl=1.95*' && \
-    conda clean -tipsy && \
+    conda clean --all -y && \
     fix-permissions $CONDA_DIR && \
     fix-permissions /home/$NB_USER
 
@@ -43,7 +43,7 @@ RUN pip install --no-cache-dir \
 
 # Spylon-kernel
 RUN conda install --quiet --yes 'spylon-kernel=0.4*' && \
-    conda clean -tipsy && \
+    conda clean --all -y && \
     python -m spylon_kernel install --sys-prefix && \
     rm -rf /home/$NB_USER/.local && \
     fix-permissions $CONDA_DIR && \

--- a/base-notebook/Dockerfile
+++ b/base-notebook/Dockerfile
@@ -79,7 +79,7 @@ RUN cd /tmp && \
     $CONDA_DIR/bin/conda config --system --set show_channel_urls true && \
     $CONDA_DIR/bin/conda install --quiet --yes conda="${CONDA_VERSION%.*}.*" && \
     $CONDA_DIR/bin/conda update --all --quiet --yes && \
-    conda clean --all -y && \
+    conda clean --all -f -y && \
     rm -rf /home/$NB_USER/.cache/yarn && \
     fix-permissions $CONDA_DIR && \
     fix-permissions /home/$NB_USER
@@ -87,7 +87,7 @@ RUN cd /tmp && \
 # Install Tini
 RUN conda install --quiet --yes 'tini=0.18.0' && \
     conda list tini | grep tini | tr -s ' ' | cut -d ' ' -f 1,2 >> $CONDA_DIR/conda-meta/pinned && \
-    conda clean --all -y && \
+    conda clean --all -f -y && \
     fix-permissions $CONDA_DIR && \
     fix-permissions /home/$NB_USER
 
@@ -101,7 +101,7 @@ RUN conda install --quiet --yes \
     'notebook=5.7.8' \
     'jupyterhub=0.9.6' \
     'jupyterlab=0.35.4' && \
-    conda clean --all -y && \
+    conda clean --all -f -y && \
     jupyter labextension install @jupyterlab/hub-extension@^0.12.0 && \
     npm cache clean --force && \
     jupyter notebook --generate-config && \

--- a/base-notebook/Dockerfile
+++ b/base-notebook/Dockerfile
@@ -79,7 +79,7 @@ RUN cd /tmp && \
     $CONDA_DIR/bin/conda config --system --set show_channel_urls true && \
     $CONDA_DIR/bin/conda install --quiet --yes conda="${CONDA_VERSION%.*}.*" && \
     $CONDA_DIR/bin/conda update --all --quiet --yes && \
-    conda clean -tipsy && \
+    conda clean --all -y && \
     rm -rf /home/$NB_USER/.cache/yarn && \
     fix-permissions $CONDA_DIR && \
     fix-permissions /home/$NB_USER
@@ -87,7 +87,7 @@ RUN cd /tmp && \
 # Install Tini
 RUN conda install --quiet --yes 'tini=0.18.0' && \
     conda list tini | grep tini | tr -s ' ' | cut -d ' ' -f 1,2 >> $CONDA_DIR/conda-meta/pinned && \
-    conda clean -tipsy && \
+    conda clean --all -y && \
     fix-permissions $CONDA_DIR && \
     fix-permissions /home/$NB_USER
 
@@ -101,7 +101,7 @@ RUN conda install --quiet --yes \
     'notebook=5.7.8' \
     'jupyterhub=0.9.6' \
     'jupyterlab=0.35.4' && \
-    conda clean -tipsy && \
+    conda clean --all -y && \
     jupyter labextension install @jupyterlab/hub-extension@^0.12.0 && \
     npm cache clean --force && \
     jupyter notebook --generate-config && \

--- a/base-notebook/Dockerfile.ppc64le
+++ b/base-notebook/Dockerfile.ppc64le
@@ -71,7 +71,7 @@ RUN cd /tmp && \
     $CONDA_DIR/bin/conda install --quiet --yes conda=4.2.12  && \
     $CONDA_DIR/bin/conda config --system --add channels conda-forge && \
     $CONDA_DIR/bin/conda config --system --set auto_update_conda false && \
-    conda clean --all -y
+    conda clean --all -f -y
 
 # Install Jupyter notebook and Hub
 RUN yes | pip install --upgrade pip

--- a/base-notebook/Dockerfile.ppc64le
+++ b/base-notebook/Dockerfile.ppc64le
@@ -71,7 +71,7 @@ RUN cd /tmp && \
     $CONDA_DIR/bin/conda install --quiet --yes conda=4.2.12  && \
     $CONDA_DIR/bin/conda config --system --add channels conda-forge && \
     $CONDA_DIR/bin/conda config --system --set auto_update_conda false && \
-    conda clean -tipsy
+    conda clean --all -y
 
 # Install Jupyter notebook and Hub
 RUN yes | pip install --upgrade pip

--- a/base-notebook/Dockerfile.ppc64le.patch
+++ b/base-notebook/Dockerfile.ppc64le.patch
@@ -77,14 +77,14 @@
 +    $CONDA_DIR/bin/conda install --quiet --yes conda=4.2.12  && \
      $CONDA_DIR/bin/conda config --system --add channels conda-forge && \
      $CONDA_DIR/bin/conda config --system --set auto_update_conda false && \
-     conda clean --all -y
+     conda clean --all -f -y
  
 -# Install Jupyter Notebook and Hub
 -RUN conda install --quiet --yes \
 -    'notebook=5.2.*' \
 -    'jupyterhub=0.7.*' \
 -    'jupyterlab=0.18.*' \
--    && conda clean --all -y
+-    && conda clean --all -f -y
 +# Install Jupyter notebook and Hub
 +RUN yes | pip install --upgrade pip
 +RUN yes | pip install --quiet --no-cache-dir \

--- a/base-notebook/Dockerfile.ppc64le.patch
+++ b/base-notebook/Dockerfile.ppc64le.patch
@@ -77,14 +77,14 @@
 +    $CONDA_DIR/bin/conda install --quiet --yes conda=4.2.12  && \
      $CONDA_DIR/bin/conda config --system --add channels conda-forge && \
      $CONDA_DIR/bin/conda config --system --set auto_update_conda false && \
-     conda clean -tipsy
+     conda clean --all -y
  
 -# Install Jupyter Notebook and Hub
 -RUN conda install --quiet --yes \
 -    'notebook=5.2.*' \
 -    'jupyterhub=0.7.*' \
 -    'jupyterlab=0.18.*' \
--    && conda clean -tipsy
+-    && conda clean --all -y
 +# Install Jupyter notebook and Hub
 +RUN yes | pip install --upgrade pip
 +RUN yes | pip install --quiet --no-cache-dir \

--- a/datascience-notebook/Dockerfile
+++ b/datascience-notebook/Dockerfile
@@ -65,7 +65,7 @@ RUN conda install --quiet --yes \
     'r-sparklyr=0.9*' \
     'r-htmlwidgets=1.2*' \
     'r-hexbin=1.27*' && \
-    conda clean --all -y && \
+    conda clean --all -f -y && \
     fix-permissions $CONDA_DIR && \
     fix-permissions /home/$NB_USER
 

--- a/datascience-notebook/Dockerfile
+++ b/datascience-notebook/Dockerfile
@@ -65,7 +65,7 @@ RUN conda install --quiet --yes \
     'r-sparklyr=0.9*' \
     'r-htmlwidgets=1.2*' \
     'r-hexbin=1.27*' && \
-    conda clean -tipsy && \
+    conda clean --all -y && \
     fix-permissions $CONDA_DIR && \
     fix-permissions /home/$NB_USER
 

--- a/docs/using/recipes.md
+++ b/docs/using/recipes.md
@@ -58,7 +58,7 @@ FROM jupyter/scipy-notebook:latest
 # and the kernda utility. Add any additional packages you want available for use
 # in a Python 2 notebook to the first line here (e.g., pandas, matplotlib, etc.)
 RUN conda create --quiet --yes -p $CONDA_DIR/envs/python2 python=2.7 ipython ipykernel kernda && \
-    conda clean --all -y
+    conda clean --all -f -y
 
 USER root
 

--- a/docs/using/recipes.md
+++ b/docs/using/recipes.md
@@ -58,7 +58,7 @@ FROM jupyter/scipy-notebook:latest
 # and the kernda utility. Add any additional packages you want available for use
 # in a Python 2 notebook to the first line here (e.g., pandas, matplotlib, etc.)
 RUN conda create --quiet --yes -p $CONDA_DIR/envs/python2 python=2.7 ipython ipykernel kernda && \
-    conda clean -tipsy
+    conda clean --all -y
 
 USER root
 

--- a/examples/source-to-image/README.md
+++ b/examples/source-to-image/README.md
@@ -87,7 +87,7 @@ The next steps are:
 ```
 if [ -f /home/$NB_USER/environment.yml ]; then
     conda env update --name root --file /home/$NB_USER/environment.yml
-    conda clean -tipsy
+    conda clean --all -y
 else
     if [ -f /home/$NB_USER/requirements.txt ]; then
         pip --no-cache-dir install -r /home/$NB_USER/requirements.txt

--- a/examples/source-to-image/README.md
+++ b/examples/source-to-image/README.md
@@ -87,7 +87,7 @@ The next steps are:
 ```
 if [ -f /home/$NB_USER/environment.yml ]; then
     conda env update --name root --file /home/$NB_USER/environment.yml
-    conda clean --all -y
+    conda clean --all -f -y
 else
     if [ -f /home/$NB_USER/requirements.txt ]; then
         pip --no-cache-dir install -r /home/$NB_USER/requirements.txt

--- a/examples/source-to-image/assemble
+++ b/examples/source-to-image/assemble
@@ -26,7 +26,7 @@ rm -rf /tmp/src
 
 if [ -f /home/$NB_USER/environment.yml ]; then
     conda env update --name root --file /home/$NB_USER/environment.yml
-    conda clean --all -y
+    conda clean --all -f -y
 else
     if [ -f /home/$NB_USER/requirements.txt ]; then
         pip --no-cache-dir install -r /home/$NB_USER/requirements.txt

--- a/examples/source-to-image/assemble
+++ b/examples/source-to-image/assemble
@@ -26,7 +26,7 @@ rm -rf /tmp/src
 
 if [ -f /home/$NB_USER/environment.yml ]; then
     conda env update --name root --file /home/$NB_USER/environment.yml
-    conda clean -tipsy
+    conda clean --all -y
 else
     if [ -f /home/$NB_USER/requirements.txt ]; then
         pip --no-cache-dir install -r /home/$NB_USER/requirements.txt

--- a/pyspark-notebook/Dockerfile
+++ b/pyspark-notebook/Dockerfile
@@ -45,6 +45,6 @@ USER $NB_UID
 
 # Install pyarrow
 RUN conda install --quiet -y 'pyarrow' && \
-    conda clean -tipsy && \
+    conda clean --all -y && \
     fix-permissions $CONDA_DIR && \
     fix-permissions /home/$NB_USER

--- a/pyspark-notebook/Dockerfile
+++ b/pyspark-notebook/Dockerfile
@@ -45,6 +45,6 @@ USER $NB_UID
 
 # Install pyarrow
 RUN conda install --quiet -y 'pyarrow' && \
-    conda clean --all -y && \
+    conda clean --all -f -y && \
     fix-permissions $CONDA_DIR && \
     fix-permissions /home/$NB_USER

--- a/r-notebook/Dockerfile
+++ b/r-notebook/Dockerfile
@@ -46,5 +46,5 @@ RUN conda install --quiet --yes \
     'r-sparklyr=0.9*' \
     'r-htmlwidgets=1.2*' \
     'r-hexbin=1.27*' && \
-    conda clean --all -y && \
+    conda clean --all -f -y && \
     fix-permissions $CONDA_DIR

--- a/r-notebook/Dockerfile
+++ b/r-notebook/Dockerfile
@@ -46,5 +46,5 @@ RUN conda install --quiet --yes \
     'r-sparklyr=0.9*' \
     'r-htmlwidgets=1.2*' \
     'r-hexbin=1.27*' && \
-    conda clean -tipsy && \
+    conda clean --all -y && \
     fix-permissions $CONDA_DIR

--- a/scipy-notebook/Dockerfile
+++ b/scipy-notebook/Dockerfile
@@ -44,7 +44,7 @@ RUN conda install --quiet --yes \
     'protobuf=3.7.*' \
     'xlrd'  && \
     conda remove --quiet --yes --force qt pyqt && \
-    conda clean --all -y && \
+    conda clean --all -f -y && \
     # Activate ipywidgets extension in the environment that runs the notebook server
     jupyter nbextension enable --py widgetsnbextension --sys-prefix && \
     # Also activate ipywidgets extension for JupyterLab

--- a/scipy-notebook/Dockerfile
+++ b/scipy-notebook/Dockerfile
@@ -44,7 +44,7 @@ RUN conda install --quiet --yes \
     'protobuf=3.7.*' \
     'xlrd'  && \
     conda remove --quiet --yes --force qt pyqt && \
-    conda clean -tipsy && \
+    conda clean --all -y && \
     # Activate ipywidgets extension in the environment that runs the notebook server
     jupyter nbextension enable --py widgetsnbextension --sys-prefix && \
     # Also activate ipywidgets extension for JupyterLab

--- a/tensorflow-notebook/Dockerfile
+++ b/tensorflow-notebook/Dockerfile
@@ -9,6 +9,6 @@ LABEL maintainer="Jupyter Project <jupyter@googlegroups.com>"
 RUN conda install --quiet --yes \
     'tensorflow=1.12*' \
     'keras=2.2*' && \
-    conda clean -tipsy && \
+    conda clean --all -y && \
     fix-permissions $CONDA_DIR && \
     fix-permissions /home/$NB_USER

--- a/tensorflow-notebook/Dockerfile
+++ b/tensorflow-notebook/Dockerfile
@@ -9,6 +9,6 @@ LABEL maintainer="Jupyter Project <jupyter@googlegroups.com>"
 RUN conda install --quiet --yes \
     'tensorflow=1.12*' \
     'keras=2.2*' && \
-    conda clean --all -y && \
+    conda clean --all -f -y && \
     fix-permissions $CONDA_DIR && \
     fix-permissions /home/$NB_USER


### PR DESCRIPTION
This PR has all of the instances I could find grepping through the files of the `-tipsy` flag on `conda clean` changed to `--all -f -y` per the discussion in issue #861.