### PR TITLE
Community Stacks documentation ihaskell-notebook

### DIFF
--- a/docs/using/selecting.md
+++ b/docs/using/selecting.md
@@ -142,8 +142,6 @@ You must refer to git-SHA image tags when stability and reproducibility are impo
 
 The core stacks are just a tiny sample of what's possible when combining Jupyter with other technologies. We encourage members of the Jupyter community to create their own stacks based on the core images and link them below.
 
-*This list only has 2 examples. You can be the next!*
-
 * [csharp-notebook is a community Jupyter Docker Stack image. Try C# in Jupyter Notebooks](https://github.com/tlinnet/csharp-notebook). The image includes more than 200 Jupyter Notebooks with example C# code and can readily be tried online via mybinder.org. Click here to launch [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/tlinnet/csharp-notebook/master).
 
 * [education-notebook is a community Jupyter Docker Stack image](https://github.com/umsi-mads/education-notebook). The image includes nbgrader and RISE on top of the datascience-notebook image. Click here to launch it on [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/umsi-mads/education-notebook/master).

--- a/docs/using/selecting.md
+++ b/docs/using/selecting.md
@@ -148,4 +148,12 @@ The core stacks are just a tiny sample of what's possible when combining Jupyter
 
 * [education-notebook is a community Jupyter Docker Stack image](https://github.com/umsi-mads/education-notebook). The image includes nbgrader and RISE on top of the datascience-notebook image. Click here to launch it on [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/umsi-mads/education-notebook/master).
 
+* __crosscompass/ihaskell-notebook__
+
+  [Source on GitHub](https://github.com/jamesdbrock/ihaskell-notebook)
+  | [Dockerfile commit history](https://github.com/jamesdbrock/ihaskell-notebook/commits/master/Dockerfile)
+  | [Docker Hub image tags](https://hub.docker.com/r/crosscompass/ihaskell-notebook/tags)
+
+  `crosscompass/ihaskell-notebook` is based on [IHaskell](https://github.com/gibiansky/IHaskell). Includes popular packages and example notebooks.
+
 See the [contributing guide](../contributing/stacks.md) for information about how to create your own Jupyter Docker Stack.


### PR DESCRIPTION
I'd like to add Haskell to the list of Community Stacks, please.

this `ihaskell-notebook` Docker Stack was created using the [Community Stack contributing guide](https://jupyter-docker-stacks.readthedocs.io/en/latest/contributing/stacks.html).

<https://github.com/jamesdbrock/ihaskell-notebook>