### PR TITLE
Added install of e1071 R package

### DIFF
--- a/r-notebook/Dockerfile
+++ b/r-notebook/Dockerfile
@@ -48,3 +48,6 @@ RUN conda install --quiet --yes \
     'r-hexbin=1.27*' && \
     conda clean --all -f -y && \
     fix-permissions $CONDA_DIR
+
+# Install e1071 R package (dependency of the caret R package)
+RUN conda install --quiet --yes r-e1071


### PR DESCRIPTION
The e1071 R package is a dependency of functions within the caret package. Without it, `caret::train` (for example) cannot be run. This pull request addresses issue #889 (https://github.com/jupyter/docker-stacks/issues/889). 

note - I first tried installing e1071 in the RUN command started on line 27 but that resulted in e1071 not installing (don't know why) but adding an additional RUN command led to succesful installation... So I just went with it.