### PR TITLE
Switch to matplotlib-base to avoid qt dependency

### DIFF
--- a/scipy-notebook/Dockerfile
+++ b/scipy-notebook/Dockerfile
@@ -20,7 +20,7 @@ RUN conda install --quiet --yes \
     'ipywidgets=7.5*' \
     'pandas=0.24*' \
     'numexpr=2.6*' \
-    'matplotlib=3.0*' \
+    'matplotlib-base=3.1.*' \
     'scipy=1.2*' \
     'seaborn=0.9*' \
     'scikit-learn=0.20*' \


### PR DESCRIPTION
Based on [this discussion](https://github.com/jupyter/docker-stacks/pull/896#issuecomment-515792038).  It seems to work, but I have not tested it thoroughly.