### PR TITLE
Sort package installation lines alphabetically for easier comparison

### DIFF
--- a/all-spark-notebook/Dockerfile
+++ b/all-spark-notebook/Dockerfile
@@ -24,10 +24,11 @@ USER $NB_UID
 # R packages
 RUN conda install --quiet --yes \
     'r-base=3.6.1' \
-    'r-irkernel=1.0*' \
     'r-ggplot2=3.2*' \
+    'r-irkernel=1.0*' \
+    'r-rcurl=1.95*' \
     'r-sparklyr=1.0*' \
-    'r-rcurl=1.95*' && \
+    && \
     conda clean --all -f -y && \
     fix-permissions $CONDA_DIR && \
     fix-permissions /home/$NB_USER

--- a/datascience-notebook/Dockerfile
+++ b/datascience-notebook/Dockerfile
@@ -45,26 +45,27 @@ USER $NB_UID
 
 # R packages including IRKernel which gets installed globally.
 RUN conda install --quiet --yes \
-    'rpy2=2.9*' \
     'r-base=3.6.1' \
-    'r-irkernel=1.0*' \
-    'r-plyr=1.8*' \
-    'r-devtools=2.1*' \
-    'r-tidyverse=1.2*' \
-    'r-shiny=1.3*' \
-    'r-rmarkdown=1.14*' \
-    'r-forecast=8.7*' \
-    'r-rsqlite=2.1*' \
-    'r-reshape2=1.4*' \
-    'r-nycflights13=1.0*' \
     'r-caret=6.0*' \
-    'r-rcurl=1.95*' \
     'r-crayon=1.3*' \
-    'r-randomforest=4.6*' \
+    'r-devtools=2.1*' \
+    'r-forecast=8.7*' \
+    'r-hexbin=1.27*' \
     'r-htmltools=0.3*' \
-    'r-sparklyr=1.0*' \
     'r-htmlwidgets=1.3*' \
-    'r-hexbin=1.27*' && \
+    'r-irkernel=1.0*' \
+    'r-nycflights13=1.0*' \
+    'r-plyr=1.8*' \
+    'r-randomforest=4.6*' \
+    'r-rcurl=1.95*' \
+    'r-reshape2=1.4*' \
+    'r-rmarkdown=1.14*' \
+    'r-rsqlite=2.1*' \
+    'r-shiny=1.3*' \
+    'r-sparklyr=1.0*' \
+    'r-tidyverse=1.2*' \
+    'rpy2=2.9*' \
+    && \
     conda clean --all -f -y && \
     fix-permissions $CONDA_DIR && \
     fix-permissions /home/$NB_USER

--- a/r-notebook/Dockerfile
+++ b/r-notebook/Dockerfile
@@ -26,26 +26,27 @@ USER $NB_UID
 # R packages
 RUN conda install --quiet --yes \
     'r-base=3.6.1' \
-    'r-rodbc=1.3*' \
-    'unixodbc=2.3.*' \
-    'r-irkernel=1.0*' \
-    'r-plyr=1.8*' \
-    'r-devtools=2.0*' \
-    'r-tidyverse=1.2*' \
-    'r-shiny=1.3*' \
-    'r-rmarkdown=1.14*' \
-    'r-forecast=8.7*' \
-    'r-rsqlite=2.1*' \
-    'r-reshape2=1.4*' \
-    'r-nycflights13=1.0*' \
     'r-caret=6.0*' \
-    'r-rcurl=1.95*' \
     'r-crayon=1.3*' \
-    'r-randomforest=4.6*' \
+    'r-devtools=2.0*' \
+    'r-forecast=8.7*' \
+    'r-hexbin=1.27*' \
     'r-htmltools=0.3*' \
-    'r-sparklyr=1.0*' \
     'r-htmlwidgets=1.3*' \
-    'r-hexbin=1.27*' && \
+    'r-irkernel=1.0*' \
+    'r-nycflights13=1.0*' \
+    'r-plyr=1.8*' \
+    'r-randomforest=4.6*' \
+    'r-rcurl=1.95*' \
+    'r-reshape2=1.4*' \
+    'r-rmarkdown=1.14*' \
+    'r-rodbc=1.3*' \
+    'r-rsqlite=2.1*' \
+    'r-shiny=1.3*' \
+    'r-sparklyr=1.0*' \
+    'r-tidyverse=1.2*' \
+    'unixodbc=2.3.*' \
+    && \
     conda clean --all -f -y && \
     fix-permissions $CONDA_DIR
 

--- a/scipy-notebook/Dockerfile
+++ b/scipy-notebook/Dockerfile
@@ -16,31 +16,32 @@ USER $NB_UID
 
 # Install Python 3 packages
 RUN conda install --quiet --yes \
+    'beautifulsoup4=4.8.*' \
     'conda-forge::blas=*=openblas' \
+    'bokeh=1.3*' \
+    'cloudpickle=1.2*' \
+    'cython=0.29*' \
+    'dask=2.2.*' \
+    'dill=0.3*' \
+    'h5py=2.9*' \
+    'hdf5=1.10*' \
     'ipywidgets=7.5*' \
-    'pandas=0.25*' \
-    'numexpr=2.6*' \
     'matplotlib-base=3.1.*' \
+    'numba=0.45*' \
+    'numexpr=2.6*' \
+    'pandas=0.25*' \
+    'patsy=0.5*' \
+    'protobuf=3.9.*' \
+    'scikit-image=0.15*' \
+    'scikit-learn=0.21*' \
     'scipy=1.3*' \
     'seaborn=0.9*' \
-    'scikit-learn=0.21*' \
-    'scikit-image=0.15*' \
-    'sympy=1.4*' \
-    'cython=0.29*' \
-    'patsy=0.5*' \
-    'statsmodels=0.10*' \
-    'cloudpickle=1.2*' \
-    'dill=0.3*' \
-    'dask=2.2.*' \
-    'numba=0.45*' \
-    'bokeh=1.3*' \
     'sqlalchemy=1.3*' \
-    'hdf5=1.10*' \
-    'h5py=2.9*' \
+    'statsmodels=0.10*' \
+    'sympy=1.4*' \
     'vincent=0.4.*' \
-    'beautifulsoup4=4.8.*' \
-    'protobuf=3.9.*' \
-    'xlrd'  && \
+    'xlrd' \
+    && \
     conda clean --all -f -y && \
     # Activate ipywidgets extension in the environment that runs the notebook server
     jupyter nbextension enable --py widgetsnbextension --sys-prefix && \


### PR DESCRIPTION
- This would have made updating all package versions easier, so doing it now.
- Differences I noticed:
  - r-notebook and datascience-notebook are almost identical
  - r-notebook has r-odbc and unixodbc, datascience-notebook doesn't
  - all-spark-notebook has r-ggplot2 explicitely added and version
    pinned.  The others pull it in but isn't version pinned.
- I'm conflicted as to if I should skip the CI on this, but since it's
  not pure text changes I won't.