### PR TITLE
Don't upgrade base image

### DIFF
--- a/base-notebook/Dockerfile
+++ b/base-notebook/Dockerfile
@@ -16,7 +16,7 @@ USER root
 # Install all OS dependencies for notebook server that starts but lacks all
 # features (e.g., download as all possible file formats)
 ENV DEBIAN_FRONTEND noninteractive
-RUN apt-get update && apt-get -yq dist-upgrade \
+RUN apt-get update \
  && apt-get install -yq --no-install-recommends \
     wget \
     bzip2 \
@@ -25,7 +25,7 @@ RUN apt-get update && apt-get -yq dist-upgrade \
     locales \
     fonts-liberation \
     run-one \
- && rm -rf /var/lib/apt/lists/*
+ && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 RUN echo "en_US.UTF-8 UTF-8" > /etc/locale.gen && \
     locale-gen

--- a/base-notebook/Dockerfile.ppc64le
+++ b/base-notebook/Dockerfile.ppc64le
@@ -11,7 +11,7 @@ USER root
 # Install all OS dependencies for notebook server that starts but lacks all
 # features (e.g., download as all possible file formats)
 ENV DEBIAN_FRONTEND noninteractive
-RUN apt-get update && apt-get -yq dist-upgrade \
+RUN apt-get update \
  && apt-get install -yq --no-install-recommends \
     build-essential \
     bzip2 \
@@ -21,8 +21,7 @@ RUN apt-get update && apt-get -yq dist-upgrade \
     locales \
     sudo \
     wget \
-    && \
-    rm -rf /var/lib/apt/lists/*
+ && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 RUN echo "LANGUAGE=en_US.UTF-8" >> /etc/default/locale
 RUN echo "LC_ALL=en_US.UTF-8" >> /etc/default/locale

--- a/minimal-notebook/Dockerfile
+++ b/minimal-notebook/Dockerfile
@@ -30,7 +30,7 @@ RUN apt-get update && apt-get install -yq --no-install-recommends \
     tzdata \
     unzip \
     nano \
-    && rm -rf /var/lib/apt/lists/*
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Switch back to jovyan to avoid accidental container runs as root
 USER $NB_UID


### PR DESCRIPTION
This PR removes the `apt-get dist-upgrade` from the build  process of the base-notebook image, as per the [dockerfile best practices](https://docs.docker.com/develop/develop-images/dockerfile_best-practices).

Upgrading the base image, especially without being able to specify package versions, can break dependencies, reproducibility of builds, and can significantly enlarge the final image.

I also added a call to `apt-get clean` after package installations: this command will remove any debs files left in apt-get's cache.