### PR TITLE
Make fix-permissions executable by all

### DIFF
--- a/base-notebook/Dockerfile
+++ b/base-notebook/Dockerfile
@@ -44,6 +44,7 @@ ENV PATH=$CONDA_DIR/bin:$PATH \
 
 # Add a script that we will use to correct permissions after running certain commands
 ADD fix-permissions /usr/local/bin/fix-permissions
+RUN chmod a+rx /usr/local/bin/fix-permissions
 
 # Enable prompt color in the skeleton .bashrc before creating the default NB_USER
 RUN sed -i 's/^#force_color_prompt=yes/force_color_prompt=yes/' /etc/skel/.bashrc


### PR DESCRIPTION
Make the `fix-permissions` script executable by everyone, avoiding permission denied error when `NG_UID` isn't root and doesn't match the file's owner or group id.