### PR TITLE
With JupyterLab 1.1, --dev-build=False is no longer necessary.

### DIFF
--- a/scipy-notebook/Dockerfile
+++ b/scipy-notebook/Dockerfile
@@ -50,7 +50,7 @@ RUN conda install --quiet --yes \
     # https://github.com/jupyter-widgets/ipywidgets/tree/master/packages/jupyterlab-manager
     jupyter labextension install @jupyter-widgets/jupyterlab-manager@^1.0.1 --no-build && \
     jupyter labextension install jupyterlab_bokeh@1.0.0 --no-build && \
-    jupyter lab build --dev-build=False && \
+    jupyter lab build && \
     npm cache clean --force && \
     rm -rf $CONDA_DIR/share/jupyter/lab/staging && \
     rm -rf /home/$NB_USER/.cache/yarn && \


### PR DESCRIPTION
Reverts a temporary workaround included in [this commit](https://github.com/jupyter/docker-stacks/commit/eb5c77ee43c8ee193f34c8e23ac3568f1f3f2578#diff-90dd1590ae70de58d60090b55b7ee318), which addressed [this issue](https://github.com/jupyterlab/jupyterlab/issues/6869) which has subsequently been fixed.