### PR TITLE
upgrade to tensoflow2

### DIFF
--- a/tensorflow-notebook/Dockerfile
+++ b/tensorflow-notebook/Dockerfile
@@ -6,9 +6,7 @@ FROM $BASE_CONTAINER
 LABEL maintainer="Jupyter Project <jupyter@googlegroups.com>"
 
 # Install Tensorflow
-RUN conda install --quiet --yes \
-    'tensorflow=1.13*' \
-    'keras=2.2*' && \
-    conda clean --all -f -y && \
+RUN pip install --quiet \
+    'tensorflow==2.0.0' && \
     fix-permissions $CONDA_DIR && \
     fix-permissions /home/$NB_USER


### PR DESCRIPTION
Conda currently does not have tf2 as can be seen in [url](https://anaconda.org/conda-forge/tensorflow/files) 

I used pip installation
