### PR TITLE
Add sparkmagic-notebook Image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,8 @@ ALL_STACKS:=base-notebook \
 	tensorflow-notebook \
 	datascience-notebook \
 	pyspark-notebook \
-	all-spark-notebook
+	all-spark-notebook \
+	sparkmagic-notebook
 endif
 
 ALL_IMAGES:=$(ALL_STACKS)

--- a/docs/using/selecting.md
+++ b/docs/using/selecting.md
@@ -120,6 +120,17 @@ The Jupyter team maintains a set of Docker image definitions in the [https://git
 * [Apache Toree](https://toree.apache.org/) and [spylon-kernel](https://github.com/maxpoint/spylon-kernel) to support Scala code in Jupyter notebooks
 * [ggplot2](http://ggplot2.org/), [sparklyr](http://spark.rstudio.com/), and [rcurl](https://cran.r-project.org/web/packages/RCurl/index.html) packages
 
+### jupyter/sparkmagic-notebook
+
+[Source on GitHub](https://github.com/jupyter/docker-stacks/tree/master/sparkmagic-notebook)
+| [Dockerfile commit history](https://github.com/jupyter/docker-stacks/commits/master/sparkmagic-notebook/Dockerfile)
+| [Docker Hub image tags](https://hub.docker.com/r/jupyter/sparkmagic-notebook/tags/)
+
+`jupyter/sparkmagic-notebook` includes sparkmagic with support for R, pyspark and Scala using apache livy.
+
+* Everything in `jupyter/base-notebook`
+* [sparkmagic](https://github.com/jupyter-incubator/sparkmagic) to support Jupyter magics and kernels for working with remote Spark clusters
+
 ### Image Relationships
 
 The following diagram depicts the build dependency tree of the core images. (i.e., the `FROM` statements in their Dockerfiles). Any given image inherits the complete content of all ancestor images pointing to it.

--- a/sparkmagic-notebook/.dockerignore
+++ b/sparkmagic-notebook/.dockerignore
@@ -1,0 +1,2 @@
+# Documentation
+README.md

--- a/sparkmagic-notebook/Dockerfile
+++ b/sparkmagic-notebook/Dockerfile
@@ -1,0 +1,41 @@
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+ARG BASE_CONTAINER=jupyter/base-notebook
+FROM $BASE_CONTAINER
+
+LABEL maintainer="Jupyter Project <jupyter@googlegroups.com>"
+
+USER root
+# This is needed because requests-kerberos fails to install on debian due to missing linux headers
+RUN conda install --quiet --yes 'requests-kerberos==0.12.*' && \
+    conda clean --all -f -y && \
+    fix-permissions $CONDA_DIR && \
+    fix-permissions /home/$NB_USER
+# Switch back to jovyan to avoid accidental container runs as root
+USER $NB_UID
+
+# Install sparkmagic
+RUN conda install --quiet --yes 'sparkmagic==0.14.*' && \
+    conda clean --all -f -y && \
+    # Activate ipywidgets extension in the environment that runs the notebook server
+    jupyter nbextension enable --py widgetsnbextension --sys-prefix && \
+    # Also activate ipywidgets extension for JupyterLab
+    jupyter labextension install @jupyter-widgets/jupyterlab-manager@^1.0.1 --no-build && \
+    jupyter-kernelspec install --user $(pip show sparkmagic | grep Location | cut -d" " -f2)/sparkmagic/kernels/sparkkernel && \
+    jupyter-kernelspec install --user $(pip show sparkmagic | grep Location | cut -d" " -f2)/sparkmagic/kernels/pysparkkernel && \
+    jupyter-kernelspec install --user $(pip show sparkmagic | grep Location | cut -d" " -f2)/sparkmagic/kernels/sparkrkernel && \
+    jupyter serverextension enable --sys-prefix --py sparkmagic && \
+    mkdir /home/$NB_USER/.sparkmagic && \
+    npm cache clean --force --silent && \
+    rm -rf /home/$NB_USER/.cache/yarn && \
+    rm -rf /home/$NB_USER/.node-gyp && \
+    fix-permissions $CONDA_DIR && \
+    fix-permissions /home/$NB_USER
+
+USER root
+# Install startup script to customize sparkmagic config
+COPY configure-sparkmagic.sh /usr/local/bin/start-notebook.d/configure-sparkmagic.sh
+RUN chmod +x /usr/local/bin/start-notebook.d/configure-sparkmagic.sh && \
+    fix-permissions /usr/local/bin/start-notebook.d/
+# Switch back to jovyan
+USER $NB_UID

--- a/sparkmagic-notebook/README.md
+++ b/sparkmagic-notebook/README.md
@@ -1,0 +1,116 @@
+[![docker pulls](https://img.shields.io/docker/pulls/jupyter/sparkmagic-notebook.svg)](https://hub.docker.com/r/jupyter/sparkmagic-notebook/) [![docker stars](https://img.shields.io/docker/stars/jupyter/sparkmagic-notebook.svg)](https://hub.docker.com/r/jupyter/sparkmagic-notebook/) [![image metadata](https://images.microbadger.com/badges/image/jupyter/sparkmagic-notebook.svg)](https://microbadger.com/images/jupyter/sparkmagic-notebook "jupyter/sparkmagic-notebook image metadata")
+
+# Sparkmagic Jupyter Notebook Stack
+
+Please visit the documentation site for help using and contributing to this image and others.
+
+* [Jupyter Docker Stacks on ReadTheDocs](http://jupyter-docker-stacks.readthedocs.io/en/latest/index.html)
+* [Selecting an Image :: Core Stacks :: jupyter/sparkmagic-notebook](http://jupyter-docker-stacks.readthedocs.io/en/latest/using/selecting.html#jupyter-sparkmagic-notebook)
+
+
+# Environment variables
+
+### SPARKMAGIC_CONFIG_CREDENTIALS_AUTH
+- Description : Authentication method to use when invoking the livy api
+- Default value : `None`
+
+See : https://github.com/jupyter-incubator/sparkmagic#authentication-methods
+
+### SPARKMAGIC_CONFIG_CREDENTIALS_URL
+- Description : Address where the remote livy api is running
+- Default value : `None`
+
+See : https://livy.apache.org
+
+### SPARKMAGIC_CONFIG_CREDENTIALS_USERNAME
+- Description : livy api username
+- Default value : ``
+
+### SPARKMAGIC_CONFIG_CREDENTIALS_PASSWORD
+- Description : livy api password
+- Default value : ``
+
+### SPARKMAGIC_CONFIG_LOG_LEVEL
+- Description : Sparkmagic log level
+- Default value : `DEBUG`
+
+### SPARKMAGIC_CONFIG_MAX_RESULTS_SQL
+- Description : Max number of results for a sql query
+- Default value : `2500`
+
+### SPARKMAGIC_CONFIG_LIVY_SESSION_STARTUP_TIMEOUT
+- Description : Livy session startup timeout
+- Default value : `60`
+
+### SPARKMAGIC_CONFIG_SESSION_CONFIG
+- Description : Json string containing Map of key=val spark configuration properties
+- Default value : `{}`
+
+### SPARKMAGIC_CONFIG
+- Description : Json string containing the `config.json` used by sparkmagic, if this property is set all  the other configurations are going to be ignored.
+- Default value :
+```json
+{
+    "kernel_python_credentials": {
+        "username": "$SPARKMAGIC_CONFIG_CREDENTIALS_USERNAME",
+        "password": "$SPARKMAGIC_CONFIG_CREDENTIALS_PASSWORD",
+        "url": "$SPARKMAGIC_CONFIG_CREDENTIALS_URL",
+        "auth": "$SPARKMAGIC_CONFIG_CREDENTIALS_AUTH"
+    },
+    "kernel_scala_credentials": {
+        "username": "$SPARKMAGIC_CONFIG_CREDENTIALS_USERNAME",
+        "password": "$SPARKMAGIC_CONFIG_CREDENTIALS_PASSWORD",
+        "url": "$SPARKMAGIC_CONFIG_CREDENTIALS_URL",
+        "auth": "$SPARKMAGIC_CONFIG_CREDENTIALS_AUTH"
+    },
+    "kernel_r_credentials": {
+        "username": "$SPARKMAGIC_CONFIG_CREDENTIALS_USERNAME",
+        "password": "$SPARKMAGIC_CONFIG_CREDENTIALS_PASSWORD",
+        "url": "$SPARKMAGIC_CONFIG_CREDENTIALS_URL",
+        "auth": "$SPARKMAGIC_CONFIG_CREDENTIALS_AUTH"
+    },
+    "logging_config": {
+        "version": 1,
+        "formatters": {
+            "magicsFormatter": {
+                "format": "%(asctime)s\t%(levelname)s\t%(message)s",
+                "datefmt": ""
+            }
+        },
+        "handlers": {
+            "magicsHandler": {
+                "class": "logging.FileHandler",
+                "formatter": "magicsFormatter",
+                "filename": "/dev/stdout",
+                "mode": "w"
+            }
+        },
+        "loggers": {
+            "magicsLogger": {
+                "handlers": [
+                    "magicsHandler"
+                ],
+                "level": "DEBUG",
+                "propagate": 0
+            }
+        }
+    },
+    "wait_for_idle_timeout_seconds": 15,
+    "livy_session_startup_timeout_seconds": $SPARKMAGIC_CONFIG_LIVY_SESSION_STARTUP_TIMEOUT,
+    "fatal_error_suggestion": "The code failed because of a fatal error:\n\t{}.\n\nSome things to try:\na) Make sure Spark has enough available resources for Jupyter to create a Spark context.\nb) Contact your Jupyter administrator to make sure the Spark magics library is configured correctly.\nc) Restart the kernel.",
+    "ignore_ssl_errors": false,
+    "session_configs": $SPARKMAGIC_CONFIG_SESSION_CONFIG,
+    "use_auto_viz": true,
+    "coerce_dataframe": true,
+    "max_results_sql": $SPARKMAGIC_CONFIG_MAX_RESULTS_SQL,
+    "pyspark_dataframe_encoding": "utf-8",
+    "heartbeat_refresh_seconds": 30,
+    "livy_server_heartbeat_timeout_seconds": $SPARKMAGIC_CONFIG_LIVY_SERVER_HEARTBEAT,
+    "heartbeat_retry_seconds": 10,
+    "server_extension_default_kernel_name": "pysparkkernel",
+    "custom_headers": {},
+    "retry_policy": "configurable",
+    "retry_seconds_to_sleep_list": [0.2, 0.5, 1, 3, 5],
+    "configurable_retry_policy_max_retries": 8
+}
+```

--- a/sparkmagic-notebook/configure-sparkmagic.sh
+++ b/sparkmagic-notebook/configure-sparkmagic.sh
@@ -1,0 +1,90 @@
+#!/bin/bash
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+
+set -e
+
+SPARKMAGIC_CONFIG_CREDENTIALS_AUTH=${SPARKMAGIC_CONFIG_CREDENTIALS_AUTH:-None}
+SPARKMAGIC_CONFIG_CREDENTIALS_USERNAME=${SPARKMAGIC_CONFIG_CREDENTIALS_USERNAME:-}
+SPARKMAGIC_CONFIG_CREDENTIALS_PASSWORD=${SPARKMAGIC_CONFIG_CREDENTIALS_PASSWORD:-}
+SPARKMAGIC_CONFIG_CREDENTIALS_URL=${SPARKMAGIC_CONFIG_CREDENTIALS_URL:-http://spark-livy:8998}
+
+SPARKMAGIC_CONFIG_LOG_LEVEL=${SPARKMAGIC_CONFIG_LOG_LEVEL:-DEBUG}
+SPARKMAGIC_CONFIG_MAX_RESULTS_SQL=${SPARKMAGIC_CONFIG_MAX_RESULTS_SQL:-2500}
+SPARKMAGIC_CONFIG_LIVY_SERVER_HEARTBEAT=${SPARKMAGIC_CONFIG_LIVY_SERVER_HEARTBEAT:-0}
+SPARKMAGIC_CONFIG_LIVY_SESSION_STARTUP_TIMEOUT=${SPARKMAGIC_CONFIG_LIVY_SESSION_STARTUP_TIMEOUT:-60}
+SPARKMAGIC_CONFIG_SESSION_CONFIG=${SPARKMAGIC_CONFIG_SESSION_CONFIG:-"{}"}
+
+if [ -z "$SPARKMAGIC_CONFIG" ]; then
+
+SPARKMAGIC_CONFIG=$(cat <<-END
+{
+    "kernel_python_credentials": {
+        "username": "$SPARKMAGIC_CONFIG_CREDENTIALS_USERNAME",
+        "password": "$SPARKMAGIC_CONFIG_CREDENTIALS_PASSWORD",
+        "url": "$SPARKMAGIC_CONFIG_CREDENTIALS_URL",
+        "auth": "$SPARKMAGIC_CONFIG_CREDENTIALS_AUTH"
+    },
+    "kernel_scala_credentials": {
+        "username": "$SPARKMAGIC_CONFIG_CREDENTIALS_USERNAME",
+        "password": "$SPARKMAGIC_CONFIG_CREDENTIALS_PASSWORD",
+        "url": "$SPARKMAGIC_CONFIG_CREDENTIALS_URL",
+        "auth": "$SPARKMAGIC_CONFIG_CREDENTIALS_AUTH"
+    },
+    "kernel_r_credentials": {
+        "username": "$SPARKMAGIC_CONFIG_CREDENTIALS_USERNAME",
+        "password": "$SPARKMAGIC_CONFIG_CREDENTIALS_PASSWORD",
+        "url": "$SPARKMAGIC_CONFIG_CREDENTIALS_URL",
+        "auth": "$SPARKMAGIC_CONFIG_CREDENTIALS_AUTH"
+    },
+    "logging_config": {
+        "version": 1,
+        "formatters": {
+            "magicsFormatter": {
+                "format": "%(asctime)s\t%(levelname)s\t%(message)s",
+                "datefmt": ""
+            }
+        },
+        "handlers": {
+            "magicsHandler": {
+                "class": "logging.FileHandler",
+                "formatter": "magicsFormatter",
+                "filename": "/dev/stdout",
+                "mode": "w"
+            }
+        },
+        "loggers": {
+            "magicsLogger": {
+                "handlers": [
+                    "magicsHandler"
+                ],
+                "level": "DEBUG",
+                "propagate": 0
+            }
+        }
+    },
+    "wait_for_idle_timeout_seconds": 15,
+    "livy_session_startup_timeout_seconds": $SPARKMAGIC_CONFIG_LIVY_SESSION_STARTUP_TIMEOUT,
+    "fatal_error_suggestion": "The code failed because of a fatal error:\n\t{}.\n\nSome things to try:\na) Make sure Spark has enough available resources for Jupyter to create a Spark context.\nb) Contact your Jupyter administrator to make sure the Spark magics library is configured correctly.\nc) Restart the kernel.",
+    "ignore_ssl_errors": false,
+    "session_configs": $SPARKMAGIC_CONFIG_SESSION_CONFIG,
+    "use_auto_viz": true,
+    "coerce_dataframe": true,
+    "max_results_sql": $SPARKMAGIC_CONFIG_MAX_RESULTS_SQL,
+    "pyspark_dataframe_encoding": "utf-8",
+    "heartbeat_refresh_seconds": 30,
+    "livy_server_heartbeat_timeout_seconds": $SPARKMAGIC_CONFIG_LIVY_SERVER_HEARTBEAT,
+    "heartbeat_retry_seconds": 10,
+    "server_extension_default_kernel_name": "pysparkkernel",
+    "custom_headers": {},
+    "retry_policy": "configurable",
+    "retry_seconds_to_sleep_list": [0.2, 0.5, 1, 3, 5],
+    "configurable_retry_policy_max_retries": 8
+}
+END
+)
+
+fi
+
+printf "%s" "$SPARKMAGIC_CONFIG" > /home/$NB_USER/.sparkmagic/config.json
+chown $NB_USER:$NB_GID /home/$NB_USER/.sparkmagic/config.json

--- a/sparkmagic-notebook/hooks/index.tmpl
+++ b/sparkmagic-notebook/hooks/index.tmpl
@@ -1,0 +1,2 @@
+INDEX_ROW="|\`${BUILD_TIMESTAMP}\`|\`jupyter/${IMAGE_SHORT_NAME}:${GIT_SHA_TAG}\`|[Git diff](https://github.com/jupyter/docker-stacks/commit/${SOURCE_COMMIT})<br />[Dockerfile](https://github.com/jupyter/docker-stacks/blob/${SOURCE_COMMIT}/${IMAGE_SHORT_NAME}/Dockerfile)<br />[Build manifest](./${IMAGE_SHORT_NAME}-${GIT_SHA_TAG})|"
+sed "/|-|/a ${INDEX_ROW}" -i "$INDEX_FILE"

--- a/sparkmagic-notebook/hooks/manifest.tmpl
+++ b/sparkmagic-notebook/hooks/manifest.tmpl
@@ -1,0 +1,30 @@
+cat << EOF > "$MANIFEST_FILE"
+* Build datetime: ${BUILD_TIMESTAMP}
+* DockerHub build code: ${BUILD_CODE}
+* Docker image: ${DOCKER_REPO}:${GIT_SHA_TAG}
+* Git commit SHA: [${SOURCE_COMMIT}](https://github.com/jupyter/docker-stacks/commit/${SOURCE_COMMIT})
+* Git commit message:
+\`\`\`
+${COMMIT_MSG}
+\`\`\`
+
+## Python Packages
+
+\`\`\`
+$(docker run --rm ${IMAGE_NAME} python --version)
+\`\`\`
+
+\`\`\`
+$(docker run --rm ${IMAGE_NAME} conda info)
+\`\`\`
+
+\`\`\`
+$(docker run --rm ${IMAGE_NAME} conda list)
+\`\`\`
+
+## Apt Packages
+
+\`\`\`
+$(docker run --rm ${IMAGE_NAME} apt list --installed)
+\`\`\`
+EOF

--- a/sparkmagic-notebook/hooks/post_push
+++ b/sparkmagic-notebook/hooks/post_push
@@ -1,0 +1,51 @@
+#!/bin/bash
+set -e
+
+# Tag the latest build with the short git sha. Push the tag in addition
+# to the "latest" tag already pushed.
+GIT_SHA_TAG=${SOURCE_COMMIT:0:12}
+docker tag $IMAGE_NAME $DOCKER_REPO:$GIT_SHA_TAG
+docker push $DOCKER_REPO:$GIT_SHA_TAG
+
+# Create a working directory.
+BUILD_TIMESTAMP=$(date -u +%FT%TZ)
+WORKDIR=$(mktemp -d)
+GIT_URI="git@github.com:jupyter/docker-stacks.wiki.git"
+GIT_SANDBOX="${WORKDIR}/docker-stacks.wiki"
+IMAGE_SHORT_NAME=$(basename $DOCKER_REPO)
+MANIFEST_FILE="${GIT_SANDBOX}/manifests/${IMAGE_SHORT_NAME}-${GIT_SHA_TAG}.md"
+INDEX_FILE="${GIT_SANDBOX}/Home.md"
+
+# Configure git so it can push back to GitHub.
+eval $(ssh-agent -s)
+ssh-add <(echo "$DEPLOY_KEY")
+ssh-add -l
+git config --global user.email "jupyter@googlegroups.com"
+git config --global user.name "Jupyter Docker Stacks"
+
+# Glone the GitHub project wiki.
+pushd "$WORKDIR"
+git clone "$GIT_URI"
+popd
+
+# Render the build manifest template.
+mkdir -p $(dirname "$MANIFEST_FILE")
+source hooks/manifest.tmpl
+source hooks/index.tmpl
+
+# Push the wiki update back to GitHub.
+pushd "$GIT_SANDBOX"
+git add .
+git commit -m "DOC: Build ${MANIFEST_FILE}"
+git push -u origin master
+popd
+
+# Shutdown the ssh agent for good measure.
+ssh-agent -k
+
+# Invoke all downstream build triggers.
+set +e
+for url in $(echo $NEXT_BUILD_TRIGGERS | sed "s/,/ /g")
+do
+    curl -X POST $url
+done


### PR DESCRIPTION
This patch add support for sparkmagic.

I understand that the preferred approach would be to include [recipe](https://jupyter-docker-stacks.readthedocs.io/en/latest/using/recipes.html) with steps on how to set sparkmagic
But the setup is a bit more complex than other recipes given that you need to customize sparkmagic.

And i don't think that adding this to all-spark-notebook make sense given the size of the images and that sparkmagic doesn't need spark running on the same host.