### PR TITLE
Bump: notebook (6.0.0 > 6.0.2), jupyterhub (1.0.0 > 1.1.0), jupyterlab (1.2.1 > 1.2.5).

### DIFF
--- a/base-notebook/Dockerfile
+++ b/base-notebook/Dockerfile
@@ -106,9 +106,9 @@ RUN conda install --quiet --yes 'tini=0.18.0' && \
 # Do all this in a single RUN command to avoid duplicating all of the
 # files across image layers when the permissions change
 RUN conda install --quiet --yes \
-    'notebook=6.0.0' \
-    'jupyterhub=1.0.0' \
-    'jupyterlab=1.2.1' && \
+    'notebook=6.0.2' \
+    'jupyterhub=1.1.0' \
+    'jupyterlab=1.2.5' && \
     conda clean --all -f -y && \
     npm cache clean --force && \
     jupyter notebook --generate-config && \


### PR DESCRIPTION
JupyterHub 1.1.0 just landed, so I figured I'd go ahead and bump it in the base-notebook image. While doing so I bumped the patch version of `notebook` and `jupyterlab` as well.

I have now ignored the seemingly unmaintained Dockerfile.ppc64le and Dockerfile.ppc64le.patch.