### PR TITLE
Fall back on symlink if mv fails

### DIFF
--- a/base-notebook/start.sh
+++ b/base-notebook/start.sh
@@ -66,7 +66,7 @@ if [ $(id -u) == 0 ] ; then
         # (it could be mounted, and we shouldn't create it if it already exists)
         if [[ ! -e "/home/$NB_USER" ]]; then
             echo "Relocating home dir to /home/$NB_USER"
-            mv /home/jovyan "/home/$NB_USER"
+            mv /home/jovyan "/home/$NB_USER" || ln -s /home/jovyan "/home/$NB_USER"
         fi
         # if workdir is in /home/jovyan, cd to /home/$NB_USER
         if [[ "$PWD/" == "/home/jovyan/"* ]]; then


### PR DESCRIPTION
In reference to jupyter#975.

Changes
```
mv /home/jovyan "/home/$NB_USER"
```
to
```
mv /home/jovyan "/home/$NB_USER" || ln -s /home/jovyan "/home/$NB_USER"
```
to fall back on a symlink for the home directory in the case that mv fails. mv can fail for some volume mounting options. (This was originally documented for AWS EBS-backed volume when running JupyterHub on Kubernetes.)