### PR TITLE
Fix ssh deploy key format

### DIFF
--- a/all-spark-notebook/hooks/post_push
+++ b/all-spark-notebook/hooks/post_push
@@ -18,7 +18,7 @@ INDEX_FILE="${GIT_SANDBOX}/Home.md"
 
 # Configure git so it can push back to GitHub.
 eval $(ssh-agent -s)
-ssh-add <(echo "$DEPLOY_KEY")
+ssh-add <(base64 -d <(echo "$DEPLOY_KEY"))
 ssh-add -l
 git config --global user.email "jupyter@googlegroups.com"
 git config --global user.name "Jupyter Docker Stacks"

--- a/datascience-notebook/hooks/post_push
+++ b/datascience-notebook/hooks/post_push
@@ -18,7 +18,7 @@ INDEX_FILE="${GIT_SANDBOX}/Home.md"
 
 # Configure git so it can push back to GitHub.
 eval $(ssh-agent -s)
-ssh-add <(echo "$DEPLOY_KEY")
+ssh-add <(base64 -d <(echo "$DEPLOY_KEY"))
 ssh-add -l
 git config --global user.email "jupyter@googlegroups.com"
 git config --global user.name "Jupyter Docker Stacks"

--- a/minimal-notebook/hooks/post_push
+++ b/minimal-notebook/hooks/post_push
@@ -18,7 +18,7 @@ INDEX_FILE="${GIT_SANDBOX}/Home.md"
 
 # Configure git so it can push back to GitHub.
 eval $(ssh-agent -s)
-ssh-add <(echo "$DEPLOY_KEY")
+ssh-add <(base64 -d <(echo "$DEPLOY_KEY"))
 ssh-add -l
 git config --global user.email "jupyter@googlegroups.com"
 git config --global user.name "Jupyter Docker Stacks"

--- a/pyspark-notebook/hooks/post_push
+++ b/pyspark-notebook/hooks/post_push
@@ -18,7 +18,7 @@ INDEX_FILE="${GIT_SANDBOX}/Home.md"
 
 # Configure git so it can push back to GitHub.
 eval $(ssh-agent -s)
-ssh-add <(echo "$DEPLOY_KEY")
+ssh-add <(base64 -d <(echo "$DEPLOY_KEY"))
 ssh-add -l
 git config --global user.email "jupyter@googlegroups.com"
 git config --global user.name "Jupyter Docker Stacks"

--- a/r-notebook/hooks/post_push
+++ b/r-notebook/hooks/post_push
@@ -18,7 +18,7 @@ INDEX_FILE="${GIT_SANDBOX}/Home.md"
 
 # Configure git so it can push back to GitHub.
 eval $(ssh-agent -s)
-ssh-add <(echo "$DEPLOY_KEY")
+ssh-add <(base64 -d <(echo "$DEPLOY_KEY"))
 ssh-add -l
 git config --global user.email "jupyter@googlegroups.com"
 git config --global user.name "Jupyter Docker Stacks"

--- a/scipy-notebook/hooks/post_push
+++ b/scipy-notebook/hooks/post_push
@@ -18,7 +18,7 @@ INDEX_FILE="${GIT_SANDBOX}/Home.md"
 
 # Configure git so it can push back to GitHub.
 eval $(ssh-agent -s)
-ssh-add <(echo "$DEPLOY_KEY")
+ssh-add <(base64 -d <(echo "$DEPLOY_KEY"))
 ssh-add -l
 git config --global user.email "jupyter@googlegroups.com"
 git config --global user.name "Jupyter Docker Stacks"

--- a/tensorflow-notebook/hooks/post_push
+++ b/tensorflow-notebook/hooks/post_push
@@ -18,7 +18,7 @@ INDEX_FILE="${GIT_SANDBOX}/Home.md"
 
 # Configure git so it can push back to GitHub.
 eval $(ssh-agent -s)
-ssh-add <(echo "$DEPLOY_KEY")
+ssh-add <(base64 -d <(echo "$DEPLOY_KEY"))
 ssh-add -l
 git config --global user.email "jupyter@googlegroups.com"
 git config --global user.name "Jupyter Docker Stacks"


### PR DESCRIPTION
New Docker Hub UI loses newlines in the env var settings. Loss of new lines leads ssh-add to prompt and fail when loading the key.

Base64 encode and decode the key to workaround the limitation.

🤞 the Docker Hub build env has the `base64` command line tool.