### PR TITLE
Bump version of R packages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,6 +68,12 @@ n-docs-diff: ## number of docs/ files changed since branch from master
 n-other-diff: ## number of files outside docs/ changed since branch from master
 	@git diff --name-only $(DIFF_RANGE) -- ':!docs/' | wc -l | awk '{print $$1}'
 
+run/%: ## run a bash in interactive mode in a stack
+	docker run -it --rm jupyter/$(notdir $@) /bin/bash
+
+run-sudo/%: ## run a bash in interactive mode as root in a stack
+	docker run -it --rm -u root jupyter/$(notdir $@) /bin/bash
+
 tx-en: ## rebuild en locale strings and push to master (req: GH_TOKEN)
 	@git config --global user.email "travis@travis-ci.org"
 	@git config --global user.name "Travis CI"
@@ -88,3 +94,6 @@ test/%: ## run tests against a stack
 
 test/base-notebook: ## test supported options in the base notebook
 	@TEST_IMAGE="$(OWNER)/$(notdir $@)" pytest test base-notebook/test
+
+up/%: ## launch a stack
+	docker run --rm -p 8888:8888 jupyter/$(notdir $@)

--- a/Makefile
+++ b/Makefile
@@ -69,10 +69,10 @@ n-other-diff: ## number of files outside docs/ changed since branch from master
 	@git diff --name-only $(DIFF_RANGE) -- ':!docs/' | wc -l | awk '{print $$1}'
 
 run/%: ## run a bash in interactive mode in a stack
-	docker run -it --rm jupyter/$(notdir $@) /bin/bash
+	docker run -it --rm $(OWNER)/$(notdir $@) $(SHELL)
 
 run-sudo/%: ## run a bash in interactive mode as root in a stack
-	docker run -it --rm -u root jupyter/$(notdir $@) /bin/bash
+	docker run -it --rm -u root $(OWNER)/$(notdir $@) $(SHELL)
 
 tx-en: ## rebuild en locale strings and push to master (req: GH_TOKEN)
 	@git config --global user.email "travis@travis-ci.org"
@@ -94,6 +94,3 @@ test/%: ## run tests against a stack
 
 test/base-notebook: ## test supported options in the base notebook
 	@TEST_IMAGE="$(OWNER)/$(notdir $@)" pytest test base-notebook/test
-
-up/%: ## launch a stack
-	docker run --rm -p 8888:8888 jupyter/$(notdir $@)

--- a/all-spark-notebook/Dockerfile
+++ b/all-spark-notebook/Dockerfile
@@ -23,11 +23,11 @@ USER $NB_UID
 
 # R packages
 RUN conda install --quiet --yes \
-    'r-base=3.6.1' \
+    'r-base=3.6.2' \
     'r-ggplot2=3.2*' \
-    'r-irkernel=1.0*' \
-    'r-rcurl=1.95*' \
-    'r-sparklyr=1.0*' \
+    'r-irkernel=1.1*' \
+    'r-rcurl=1.98*' \
+    'r-sparklyr=1.1*' \
     && \
     conda clean --all -f -y && \
     fix-permissions $CONDA_DIR && \

--- a/datascience-notebook/Dockerfile
+++ b/datascience-notebook/Dockerfile
@@ -45,26 +45,26 @@ USER $NB_UID
 
 # R packages including IRKernel which gets installed globally.
 RUN conda install --quiet --yes \
-    'r-base=3.6.1' \
+    'r-base=3.6.2' \
     'r-caret=6.0*' \
     'r-crayon=1.3*' \
-    'r-devtools=2.1*' \
-    'r-forecast=8.7*' \
-    'r-hexbin=1.27*' \
-    'r-htmltools=0.3*' \
-    'r-htmlwidgets=1.3*' \
-    'r-irkernel=1.0*' \
+    'r-devtools=2.2*' \
+    'r-forecast=8.10*' \
+    'r-hexbin=1.28*' \
+    'r-htmltools=0.4*' \
+    'r-htmlwidgets=1.5*' \
+    'r-irkernel=1.1*' \
     'r-nycflights13=1.0*' \
     'r-plyr=1.8*' \
     'r-randomforest=4.6*' \
-    'r-rcurl=1.95*' \
+    'r-rcurl=1.98*' \
     'r-reshape2=1.4*' \
-    'r-rmarkdown=1.14*' \
+    'r-rmarkdown=2.1*' \
     'r-rsqlite=2.1*' \
     'r-shiny=1.3*' \
-    'r-sparklyr=1.0*' \
-    'r-tidyverse=1.2*' \
-    'rpy2=2.9*' \
+    'r-sparklyr=1.1*' \
+    'r-tidyverse=1.3*' \
+    'rpy2=3.1*' \
     && \
     conda clean --all -f -y && \
     fix-permissions $CONDA_DIR && \


### PR DESCRIPTION
Bump version of R packages in `datascience-notebook` and `all-spark-notebook` focusing mainly on R Base `3.6.2` and Sparklyr `1.1`.

Notes: 

- I've not intentionally updated `r-notebook` since it's deprecated -> #693
- I do not know why `r-sparklyr` is installed in the `datascience-notebook` since Spark is not installed. I think it could be removed however I've not done it yet, I will create a dedicated issue for that.

```R
library(sparklyr)
sc <- spark_connect(master = "local")

# Error in spark_install_find(version, hadoop_version, latest = FALSE, hint = TRUE): Spark version not installed. To install, use spark_install()
```

## Makefile

Also added two new targets in the `Makefile` that I find handy to quick debug and check in the images

- `run`: run a bash in interactive mode in a stack
- `run-sudo`:  run a bash in interactive mode as root in a stack

So for example

```bash
$ make run/all-spark-notebook
docker run -it --rm jupyter/all-spark-notebook bash

jovyan@454192dd1836:~$ 

$ make run-sudo/all-spark-notebook
docker run -it --rm -u root jupyter/all-spark-notebook bash

root@09a440ff22ff:~# 
```

PS: @parente I've read that you are searching for new maintainers. If it's still the case, I will be happy to help :-).