### PR TITLE
Remove sparklyr from datascience notebook

### DIFF
--- a/datascience-notebook/Dockerfile
+++ b/datascience-notebook/Dockerfile
@@ -62,7 +62,6 @@ RUN conda install --quiet --yes \
     'r-rmarkdown=2.1*' \
     'r-rsqlite=2.1*' \
     'r-shiny=1.3*' \
-    'r-sparklyr=1.1*' \
     'r-tidyverse=1.3*' \
     'rpy2=3.1*' \
     && \


### PR DESCRIPTION
Hello,

`r-sparklyr` was installed in the `datascience-notebook` but Spark was not installed. So IMHO this does not make sense -- I figured this out during the PR #1000 .

```R
library(sparklyr)
sc <- spark_connect(master = "local")

# Error in spark_install_find(version, hadoop_version, latest = FALSE, hint = TRUE): Spark version not installed. To install, use spark_install()
```

So, I've simply removed it.

Best.