### PR TITLE
Fix contributing doc make image -> make build

### DIFF
--- a/docs/contributing/features.md
+++ b/docs/contributing/features.md
@@ -26,7 +26,7 @@ If there's agreement that the feature belongs in one or more of the core stacks:
 1. Implement the feature in a local clone of the `jupyter/docker-stacks` project.
 2. Please build the image locally before submitting a pull request. Building the image locally shortens the debugging cycle by taking some load off [Travis CI](http://travis-ci.org/), which graciously provides free build services for open source projects like this one.  If you use `make`, call:
 ```
-make image/somestack-notebook
+make build/somestack-notebook
 ```
 3. [Submit a pull request](https://github.com/PointCloudLibrary/pcl/wiki/A-step-by-step-guide-on-preparing-and-submitting-a-pull-request) (PR) with your changes.
 4. Watch for Travis to report a build success or failure for your PR on GitHub.

--- a/docs/contributing/packages.md
+++ b/docs/contributing/packages.md
@@ -8,7 +8,7 @@ Please follow the process below to update a package version:
 2. Adjust the version number for the package. We prefer to pin the major and minor version number of packages so as to minimize rebuild side-effects when users submit pull requests (PRs). For example, you'll find the Jupyter Notebook package, `notebook`, installed using conda with `notebook=5.4.*`.
 3. Please build the image locally before submitting a pull request. Building the image locally shortens the debugging cycle by taking some load off [Travis CI](http://travis-ci.org/), which graciously provides free build services for open source projects like this one. If you use `make`, call:
 ```
-make image/somestack-notebook
+make build/somestack-notebook
 ```
 4. [Submit a pull request](https://github.com/PointCloudLibrary/pcl/wiki/A-step-by-step-guide-on-preparing-and-submitting-a-pull-request) (PR) with your changes.
 5. Watch for Travis to report a build success or failure for your PR on GitHub.

--- a/docs/contributing/tests.md
+++ b/docs/contributing/tests.md
@@ -14,7 +14,7 @@ Please follow the process below to add new tests:
 2. If your test should run against a single image, add your test code to one of the modules in `some-notebook/test/` or create a new module.
 3. Build one or more images you intend to test and run the tests locally. If you use `make`, call:
 ```
-make image/somestack-notebook
+make build/somestack-notebook
 make test/somestack-notebook
 ```
 4. [Submit a pull request](https://github.com/PointCloudLibrary/pcl/wiki/A-step-by-step-guide-on-preparing-and-submitting-a-pull-request) (PR) with your changes.


### PR DESCRIPTION
Hello,

Just fixed the **contributing documentation** to use the correct `Makefile` target `build` instead of `image`:

```bash
make image/somestack-notebook -> make build/somestack-notebook 
```

Best.