### PR TITLE
limit fix permissions to /opt/conda

### DIFF
--- a/base-notebook/Dockerfile
+++ b/base-notebook/Dockerfile
@@ -59,7 +59,7 @@ RUN echo "auth requisite pam_deny.so" >> /etc/pam.d/su && \
     chown $NB_USER:$NB_GID $CONDA_DIR && \
     chmod g+w /etc/passwd && \
     fix-permissions $HOME && \
-    fix-permissions "$(dirname $CONDA_DIR)"
+    fix-permissions $CONDA_DIR
 
 USER $NB_UID
 WORKDIR $HOME


### PR DESCRIPTION
I am building a custom container by using the base-notebook/Dockerfile and overriding BASE_CONTAINER from the command line. My base image has additional software installed in /opt. The dockerfile is trying to fix permissions on the entire /opt tree, which blows up the image size. Is it OK to limit the fix permissions to /opt/conda?