### PR TITLE
Turning channel priority to strict

### DIFF
--- a/base-notebook/Dockerfile
+++ b/base-notebook/Dockerfile
@@ -84,6 +84,7 @@ RUN cd /tmp && \
     conda config --system --prepend channels conda-forge && \
     conda config --system --set auto_update_conda false && \
     conda config --system --set show_channel_urls true && \
+    conda config --system --set channel_priority strict && \
     if [ ! $PYTHON_VERSION = 'default' ]; then conda install --yes python=$PYTHON_VERSION; fi && \
     conda list python | grep '^python ' | tr -s ' ' | cut -d '.' -f 1,2 | sed 's/$/.*/' >> $CONDA_DIR/conda-meta/pinned && \
     conda install --quiet --yes conda && \
@@ -126,9 +127,7 @@ ENTRYPOINT ["tini", "-g", "--"]
 CMD ["start-notebook.sh"]
 
 # Copy local files as late as possible to avoid cache busting
-COPY start.sh /usr/local/bin/
-COPY start-notebook.sh /usr/local/bin/
-COPY start-singleuser.sh /usr/local/bin/
+COPY start.sh start-notebook.sh start-singleuser.sh /usr/local/bin/
 COPY jupyter_notebook_config.py /etc/jupyter/
 
 # Fix permissions on /etc/jupyter as root

--- a/r-notebook/Dockerfile
+++ b/r-notebook/Dockerfile
@@ -25,26 +25,25 @@ USER $NB_UID
 
 # R packages
 RUN conda install --quiet --yes \
-    'r-base=3.6.1' \
+    'r-base=3.6.2' \
     'r-caret=6.0*' \
     'r-crayon=1.3*' \
-    'r-devtools=2.0*' \
-    'r-forecast=8.7*' \
-    'r-hexbin=1.27*' \
-    'r-htmltools=0.3*' \
-    'r-htmlwidgets=1.3*' \
-    'r-irkernel=1.0*' \
+    'r-devtools=2.2*' \
+    'r-forecast=8.11*' \
+    'r-hexbin=1.28*' \
+    'r-htmltools=0.4*' \
+    'r-htmlwidgets=1.5*' \
+    'r-irkernel=1.1*' \
     'r-nycflights13=1.0*' \
     'r-plyr=1.8*' \
     'r-randomforest=4.6*' \
-    'r-rcurl=1.95*' \
+    'r-rcurl=1.98*' \
     'r-reshape2=1.4*' \
-    'r-rmarkdown=1.14*' \
+    'r-rmarkdown=2.1*' \
     'r-rodbc=1.3*' \
     'r-rsqlite=2.1*' \
-    'r-shiny=1.3*' \
-    'r-sparklyr=1.0*' \
-    'r-tidyverse=1.2*' \
+    'r-shiny=1.4*' \
+    'r-tidyverse=1.3*' \
     'unixodbc=2.3.*' \
     && \
     conda clean --all -f -y && \


### PR DESCRIPTION
I'm thinking of speeding up conda (because it's really slow) either during the build of the stacks and for the user when they want to install additional package.

> As of version 4.6.0, Conda has a strict channel priority feature. Strict channel priority can dramatically speed up conda operations and also reduce package incompatibility problems. We recommend it as a default. However, it may break old environment files, so we plan to delay making it conda's out-of-the-box default until the next major version bump, conda 5.0.
>
> -- <cite>https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-channels.html#strict</cite>

As we prepend `conda-forge` channel, I think the impact could be limited since I think the goal is to privilege `conda-forge` packages.

> With strict channel priority, packages in lower priority channels are not considered if a package with the same name appears in a higher priority channel.

Here are the differences on `base-notebook` between `flexible` (default) and `strict` channel priority.

```diff
+ ld_impl_linux-64          2.33.1               h53a641e_8    conda-forge
- libedit                   3.1.20181209         hc058e9b_0    defaults
+ libedit                   3.1.20170329      hf8c457e_1001    conda-forge
- python                    3.7.4                h265db76_1    defaults
+ python                    3.7.6                h357f687_2    conda-forge
- readline                  7.0               hf8c457e_1001    conda-forge
+ readline                  8.0                  hf8c457e_0    conda-forge
- sqlite                    3.31.1               h7b6447c_0    defaults
+ sqlite                    3.30.1               hcee41ef_0    conda-forge
```

In terms of improvement what I have observed locally at build is not meaningful let's check with the full stack build if we can see a difference.

What do you think about performing this change? 

Best.