### PR TITLE
Conda outdated package helper

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ build/%: ## build the latest image for a stack
 build-all: $(foreach I,$(ALL_IMAGES),arch_patch/$(I) build/$(I) ) ## build all stacks
 build-test-all: $(foreach I,$(ALL_IMAGES),arch_patch/$(I) build/$(I) test/$(I) ) ## build and test all stacks
 
-check_outdated/%: ## Check the outdated conda packages in a stack and produce a report (experimental)
+check-outdated/%: ## check the outdated conda packages in a stack and produce a report (experimental)
 	@TEST_IMAGE="$(OWNER)/$(notdir $@)" pytest test/test_outdated.py
 
 dev/%: ARGS?=

--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,9 @@ build/%: ## build the latest image for a stack
 build-all: $(foreach I,$(ALL_IMAGES),arch_patch/$(I) build/$(I) ) ## build all stacks
 build-test-all: $(foreach I,$(ALL_IMAGES),arch_patch/$(I) build/$(I) test/$(I) ) ## build and test all stacks
 
+check_outdated/%: ## Check the outdated conda packages in a stack and produce a report (experimental)
+	@TEST_IMAGE="$(OWNER)/$(notdir $@)" pytest test/test_outdated.py
+
 dev/%: ARGS?=
 dev/%: DARGS?=
 dev/%: PORT?=8888
@@ -89,4 +92,5 @@ tx-en: ## rebuild en locale strings and push to master (req: GH_TOKEN)
 	@git push -u origin-tx master
 
 test/%: ## run tests against a stack (only common tests or common tests + specific tests)
-	@if [ ! -d "$(notdir $@)/test" ]; then TEST_IMAGE="$(OWNER)/$(notdir $@)" pytest test; else TEST_IMAGE="$(OWNER)/$(notdir $@)" pytest test $(notdir $@)/test; fi
+	@if [ ! -d "$(notdir $@)/test" ]; then TEST_IMAGE="$(OWNER)/$(notdir $@)" pytest -m "not info" test; \
+	else TEST_IMAGE="$(OWNER)/$(notdir $@)" pytest -m "not info" test $(notdir $@)/test; fi

--- a/docs/contributing/packages.md
+++ b/docs/contributing/packages.md
@@ -13,3 +13,20 @@ make build/somestack-notebook
 4. [Submit a pull request](https://github.com/PointCloudLibrary/pcl/wiki/A-step-by-step-guide-on-preparing-and-submitting-a-pull-request) (PR) with your changes.
 5. Watch for Travis to report a build success or failure for your PR on GitHub.
 6. Discuss changes with the maintainers and address any build issues. Version conflicts are the most common problem. You may need to upgrade additional packages to fix build failures.
+
+## Notes
+
+In order to help identifying packages that can be updated you can use the following helper tool.
+It will list all the packages installed in the `Dockerfile` that can be updated -- dependencies are filtered to focus only on requested packages.
+
+```bash
+$ make check-outdated/base-notebook
+
+# INFO     test_outdated:test_outdated.py:80 3/8 (38%) packages could be updated
+# INFO     test_outdated:test_outdated.py:82 
+# Package     Current    Newest
+# ----------  ---------  --------
+# conda       4.7.12     4.8.2
+# jupyterlab  1.2.5      2.0.0
+# python      3.7.4      3.8.2
+```

--- a/pytest.ini
+++ b/pytest.ini
@@ -3,3 +3,5 @@ log_cli = 1
 log_cli_level = INFO
 log_cli_format = %(asctime)s [%(levelname)8s] %(message)s (%(filename)s:%(lineno)s)
 log_cli_date_format=%Y-%m-%d %H:%M:%S
+markers =
+    info: marks tests as info (deselect with '-m "not info"')

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
-addopts = -rA
+addopts = -ra
 log_cli = 1
 log_cli_level = INFO
 log_cli_format = %(asctime)s [%(levelname)8s] %(message)s (%(filename)s:%(lineno)s)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,4 +4,6 @@ recommonmark==0.5.0
 requests
 sphinx>=1.6
 sphinx-intl
+tabulate
 transifex-client
+

--- a/test/test_outdated.py
+++ b/test/test_outdated.py
@@ -1,128 +1,20 @@
-"""
-Based on the work https://oerpli.github.io/post/2019/06/conda-outdated/.
-See copyright below.
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
 
-MIT License
-Copyright (c) 2019 Abraham Hinteregger
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-"""
-
-import re
-import subprocess
-from collections import defaultdict
-from itertools import chain
 import logging
-import ast
 
 import pytest
 
-from tabulate import tabulate
+from helpers import CondaPackageHelper
 
 LOGGER = logging.getLogger(__name__)
 
 
-def get_versions(lines):
-    """Extract versions from the lines"""
-    ddict = defaultdict(set)
-    for line in lines.splitlines()[2:]:
-        pkg, version = re.match(r"^(\S+)\s+(\S+)", line, re.MULTILINE).groups()
-        ddict[pkg].add(version)
-    return ddict
-
-
-def semantic_cmp(version_string):
-    """Manage semantic versioning for comparison"""
-
-    def mysplit(string):
-        version_substrs = lambda x: re.findall(r"([A-z]+|\d+)", x)
-        return list(chain(map(version_substrs, string.split("."))))
-
-    def str_ord(string):
-        num = 0
-        for char in string:
-            num *= 255
-            num += ord(char)
-        return num
-
-    def try_int(version_str):
-        try:
-            return int(version_str)
-        except ValueError:
-            return str_ord(version_str)
-
-    mss = list(chain(*mysplit(version_string)))
-    return tuple(map(try_int, mss))
-
-
-def print_result(installed, specs, result):
-    """Print the result of the outdated check"""
-    if specs is None:
-        nb_packages = len(installed)
-    else:
-        nb_packages = len(specs)
-    nb_updatable = len(result)
-    updatable_ratio = nb_updatable / nb_packages
-    LOGGER.info(
-        f"{nb_updatable}/{nb_packages} ({updatable_ratio:.0%}) packages could be updated"
-    )
-    LOGGER.info(f"\n{tabulate(result, headers='keys')}\n")
-
-
 @pytest.mark.info
-def test_outdated_packages(container, remove_dependencies=True):
-    """Getting the list of outdated packages"""
+def test_outdated_packages(container, specifications_only=True):
+    """Getting the list of updatable packages"""
     LOGGER.info(f"Checking outdated packages in {container.image_name} ...")
-    c = container.run(tty=True, command=["start.sh", "bash", "-c", "sleep infinity"])
-    sp_i = c.exec_run(["conda", "list"])
-    sp_v = c.exec_run(["conda", "search", "--outdated"])
-    specs = None
-    if remove_dependencies:
-        raw_specs = c.exec_run(
-            ["grep", "^# update specs:", "/opt/conda/conda-meta/history"]
-        )
-
-    specs = parse_specs(raw_specs.output.decode("utf-8"))
-    installed = get_versions(sp_i.output.decode("utf-8"))
-    available = get_versions(sp_v.output.decode("utf-8"))
-    result = list()
-    for pkg, inst_vs in installed.items():
-        if not remove_dependencies or pkg in specs:
-            avail_vs = sorted(list(available[pkg]), key=semantic_cmp)
-            if not avail_vs:
-                continue
-            current = min(inst_vs, key=semantic_cmp)
-            newest = avail_vs[-1]
-            if avail_vs and current != newest:
-                if semantic_cmp(current) < semantic_cmp(newest):
-                    result.append(
-                        {"Package": pkg, "Current": current, "Newest": newest}
-                    )
-    print_result(installed, specs, result)
-
-
-def parse_specs(raw_specs):
-    """Return the list of requested packages (specs)
-    
-    Versions are removed from packages.
-    """
-    packages = list()
-    for spec in (spec for spec in raw_specs.split("\n") if spec.strip() != ""):
-        packages += map(
-            lambda x: x.split("=", 1)[0], ast.literal_eval(spec.split(": ")[1])
-        )
-    LOGGER.debug(f"List of specs from conda env: {packages}")
-    return packages
+    pkg_helper = CondaPackageHelper(container)
+    pkg_helper.check_updatable_packages(specifications_only)
+    LOGGER.info(pkg_helper.get_outdated_summary(specifications_only))
+    LOGGER.info(f"\n{pkg_helper.get_outdated_table()}\n")

--- a/test/test_outdated.py
+++ b/test/test_outdated.py
@@ -1,0 +1,100 @@
+"""
+Based on the work https://oerpli.github.io/post/2019/06/conda-outdated/.
+See copyright below.
+
+MIT License
+Copyright (c) 2019 Abraham Hinteregger
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+"""
+
+import re
+import subprocess
+from collections import defaultdict
+from itertools import chain
+import logging
+
+import pytest
+
+from tabulate import tabulate
+
+LOGGER = logging.getLogger(__name__)
+
+
+def get_versions(lines):
+    """Extract versions from the lines"""
+    ddict = defaultdict(set)
+    for line in lines.splitlines()[2:]:
+        pkg, version = re.match(r"^(\S+)\s+(\S+)", line, re.MULTILINE).groups()
+        ddict[pkg].add(version)
+    return ddict
+
+
+def semantic_cmp(version_string):
+    """Manage semantic versioning for comparison"""
+
+    def mysplit(string):
+        version_substrs = lambda x: re.findall(r"([A-z]+|\d+)", x)
+        return list(chain(map(version_substrs, string.split("."))))
+
+    def str_ord(string):
+        num = 0
+        for char in string:
+            num *= 255
+            num += ord(char)
+        return num
+
+    def try_int(version_str):
+        try:
+            return int(version_str)
+        except ValueError:
+            return str_ord(version_str)
+
+    mss = list(chain(*mysplit(version_string)))
+    return tuple(map(try_int, mss))
+
+
+def print_result(installed, result):
+    """Print the result of the outdated check"""
+    nb_packages = len(installed)
+    nb_updatable = len(result)
+    updatable_ratio = nb_updatable / nb_packages
+    LOGGER.info(
+        f"{nb_updatable} packages can be updated over {nb_packages} -> {updatable_ratio:.0%}"
+    )
+    LOGGER.info(f"\n{tabulate(result, headers='keys')}\n")
+
+
+@pytest.mark.info
+def test_outdated_packages(container):
+    """Getting the list of outdated packages"""
+    LOGGER.info(f"Checking outdated packages in {container.image_name} ...")
+    c = container.run(tty=True, command=["start.sh", "bash", "-c", "sleep infinity"])
+    sp_i = c.exec_run(["conda", "list"])
+    sp_v = c.exec_run(["conda", "search", "--outdated"])
+    installed = get_versions(sp_i.output.decode("utf-8"))
+    available = get_versions(sp_v.output.decode("utf-8"))
+    result = list()
+    for pkg, inst_vs in installed.items():
+        avail_vs = sorted(list(available[pkg]), key=semantic_cmp)
+        if not avail_vs:
+            continue
+        current = min(inst_vs, key=semantic_cmp)
+        newest = avail_vs[-1]
+        if avail_vs and current != newest:
+            if semantic_cmp(current) < semantic_cmp(newest):
+                result.append({"Package": pkg, "Current": current, "Newest": newest})
+    print_result(installed, result)

--- a/test/test_outdated.py
+++ b/test/test_outdated.py
@@ -73,7 +73,7 @@ def print_result(installed, result):
     nb_updatable = len(result)
     updatable_ratio = nb_updatable / nb_packages
     LOGGER.info(
-        f"{nb_updatable} packages can be updated over {nb_packages} -> {updatable_ratio:.0%}"
+        f"{nb_updatable}/{nb_packages} ({updatable_ratio:.0%}) packages could be updated"
     )
     LOGGER.info(f"\n{tabulate(result, headers='keys')}\n")
 


### PR DESCRIPTION
Hello,

I propose to integrate a feature--still experimental at this time-- in order to help identifying which packages can be updated. It could be useful in the frame of maintaining stacks up to date (see #1014). It could be part of the [Package Update documentation](https://jupyter-docker-stacks.readthedocs.io/en/latest/contributing/packages.html) documentation.

It's implemented as a test that is run through a specific command. It's skipped by default when running standard tests through `make test/<stack>`--however I can be integrated if we think it could be useful in the test context.

The principle is to call a specific entry `make check_outdated/<stack>` in the `Makefile` to get a report of the packages that can be updated.

```bash
$ make check_outdated/base-notebook

# 2020-02-12 20:13:51 [    INFO] 27 packages that can be updated over 110 -> 25% (test_outdated.py:76)
# 2020-02-12 20:13:51 [    INFO] 
# Package            Current     Newest
# -----------------  ----------  --------
# alembic            1.3.3       1.4.0
# ca-certificates    2019.11.28  2020.1.1
# cffi               1.13.2      1.14.0
# conda              4.7.12      4.8.2
# inflect            4.0.0       4.1.0
# ipython            7.11.1      7.12.0
# jinja2             2.11.0      2.11.1
# json5              0.8.5       0.9.1
# jupyter_core       4.6.1       4.6.2
# jupyter_telemetry  0.0.4       0.0.5
# jupyterlab         1.2.5       1.2.6
# krb5               1.16.4      1.17.1
# libcurl            7.65.3      7.68.0
# libsodium          1.0.17      1.0.18
# nodejs             13.7.0      13.8.0
# [...]                                                                                                                                                                                                 
```

It's a very first version, please give me your opinion!

PS: @parente here is the closed pull request #1008 .

## Notes 

- It's heavily based on the script provided in [this](https://oerpli.github.io/post/2019/06/conda-outdated/) blog post. I've kept the copyright notice but I'm not confortable with that.
- It uses [tabulate](https://github.com/astanin/python-tabulate) to display the table in the report. The dependency has been added in the `requirements-dev.txt`.