### PR TITLE
Bump scipy-notebook

### DIFF
--- a/scipy-notebook/Dockerfile
+++ b/scipy-notebook/Dockerfile
@@ -19,9 +19,9 @@ RUN conda install --quiet --yes \
     'beautifulsoup4=4.8.*' \
     'conda-forge::blas=*=openblas' \
     'bokeh=1.4.*' \
-    'cloudpickle=1.2.*' \
+    'cloudpickle=1.3.*' \
     'cython=0.29.*' \
-    'dask=2.9.*' \
+    'dask=2.11.*' \
     'dill=0.3.*' \
     'h5py=2.10.*' \
     'hdf5=1.10.*' \
@@ -29,13 +29,13 @@ RUN conda install --quiet --yes \
     'matplotlib-base=3.1.*' \
     'numba=0.48.*' \
     'numexpr=2.7.*' \
-    'pandas=0.25.*' \
+    'pandas=1.0.*' \
     'patsy=0.5.*' \
     'protobuf=3.11.*' \
     'scikit-image=0.16.*' \
     'scikit-learn=0.22.*' \
     'scipy=1.4.*' \
-    'seaborn=0.9.*' \
+    'seaborn=0.10.*' \
     'sqlalchemy=1.3.*' \
     'statsmodels=0.11.*' \
     'sympy=1.5.*' \


### PR DESCRIPTION
Bump `scipy-notebook` to the latest versions of packages.
See also #1014 and #1024 .

```
$ make check-outdated/scipy-notebook

# [...]
# INFO     test_outdated:test_outdated.py:80 9/33 (27%) packages could be updated
# INFO     test_outdated:test_outdated.py:82 
# Package      Current    Newest
# -----------  ---------  --------
# cloudpickle  1.2.2      1.3.0
# conda        4.7.12     4.8.2
# dask         2.9.2      2.11.0
# hdf5         1.10.5     1.10.6
# jupyterlab   1.2.5      1.2.6
# pandas       0.25.3     1.0.1
# python       3.7.4      3.8.2
# seaborn      0.9.0      0.10.0
# statsmodels  0.11.0     0.11.1
```