### PR TITLE
Fix #1041: Update JupyterLab start command

### DIFF
--- a/base-notebook/start-singleuser.sh
+++ b/base-notebook/start-singleuser.sh
@@ -34,10 +34,6 @@ fi
 if [ ! -z "$JPY_HUB_API_URL" ]; then
   NOTEBOOK_ARGS="--hub-api-url=$JPY_HUB_API_URL $NOTEBOOK_ARGS"
 fi
-if [ ! -z "$JUPYTER_ENABLE_LAB" ]; then
-  NOTEBOOK_BIN="jupyter labhub"
-else
-  NOTEBOOK_BIN="jupyterhub-singleuser"
-fi
+NOTEBOOK_BIN="jupyterhub-singleuser"
 
 . /usr/local/bin/start.sh $NOTEBOOK_BIN $NOTEBOOK_ARGS "$@"


### PR DESCRIPTION
As stated on https://jupyterlab.readthedocs.io/en/stable/getting_started/changelog.html

> JupyterHub users should use the c.Spawner.default_url = '/lab' setting instead of the deprecated and now removed labhubapp (#7724)

I removed the check for the JUPYTER_ENABLE_LAB in start-singleuser.sh as it is not necessary to call `jupyter labhub` anymore. The environment variable is still used in start-notebook.sh to determine whether the jupyter process should be started with argument `lab` instead of `notebook`, so it is not necessary to update the documentation. 