### PR TITLE
include dvipng

### DIFF
--- a/scipy-notebook/Dockerfile
+++ b/scipy-notebook/Dockerfile
@@ -7,9 +7,9 @@ LABEL maintainer="Jupyter Project <jupyter@googlegroups.com>"
 
 USER root
 
-# ffmpeg for matplotlib anim
+# ffmpeg for matplotlib anim & dvipng for latex labels
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends ffmpeg && \
+    apt-get install -y --no-install-recommends ffmpeg dvipng && \
     rm -rf /var/lib/apt/lists/*
 
 USER $NB_UID


### PR DESCRIPTION
This responds to #1043 adding the dvipng packaged used by matplotlib to render latex.

I don't think this requires an update for the docs since this tends to only outline the python packages, but a note could be added if needed.