### PR TITLE
Add noninteractive flag for apt

### DIFF
--- a/minimal-notebook/Dockerfile
+++ b/minimal-notebook/Dockerfile
@@ -8,7 +8,7 @@ LABEL maintainer="Jupyter Project <jupyter@googlegroups.com>"
 USER root
 
 # Install all OS dependencies for fully functional notebook server
-RUN apt-get update && apt-get install -yq --no-install-recommends \
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -yq --no-install-recommends \
     build-essential \
     emacs \
     git \


### PR DESCRIPTION
In particular tzdata can hang a docker build because of this.