### PR TITLE
[WIP] Rework of start*.sh scripts

### DIFF
--- a/base-notebook/start-notebook.sh
+++ b/base-notebook/start-notebook.sh
@@ -4,16 +4,19 @@
 
 set -e
 
+if [[ ! -z "${JUPYTERHUB_API_TOKEN}" ]]; then
+  echo "WARNING: use start-singleuser.sh instead of start-notebook.sh to start a server associated with JupyterHub."
+  exec /usr/local/bin/start-singleuser.sh "$@"
+  exit
+fi
+
 wrapper=""
 if [[ "${RESTARTABLE}" == "yes" ]]; then
   wrapper="run-one-constantly"
 fi
 
-if [[ ! -z "${JUPYTERHUB_API_TOKEN}" ]]; then
-  # launched by JupyterHub, use single-user entrypoint
-  exec /usr/local/bin/start-singleuser.sh "$@"
-elif [[ ! -z "${JUPYTER_ENABLE_LAB}" ]]; then
-  . /usr/local/bin/start.sh $wrapper jupyter lab "$@"
+if [[ ! -z "${JUPYTER_ENABLE_LAB}" ]]; then
+  exec /usr/local/bin/start.sh $wrapper $NOTEBOOK_ARGS jupyter lab "$@"
 else
-  . /usr/local/bin/start.sh $wrapper jupyter notebook "$@"
+  exec /usr/local/bin/start.sh $wrapper $NOTEBOOK_ARGS jupyter notebook "$@"
 fi

--- a/base-notebook/start-singleuser.sh
+++ b/base-notebook/start-singleuser.sh
@@ -9,31 +9,4 @@ if [[ "$NOTEBOOK_ARGS $@" != *"--ip="* ]]; then
   NOTEBOOK_ARGS="--ip=0.0.0.0 $NOTEBOOK_ARGS"
 fi
 
-# handle some deprecated environment variables
-# from DockerSpawner < 0.8.
-# These won't be passed from DockerSpawner 0.9,
-# so avoid specifying --arg=empty-string
-if [ ! -z "$NOTEBOOK_DIR" ]; then
-  NOTEBOOK_ARGS="--notebook-dir='$NOTEBOOK_DIR' $NOTEBOOK_ARGS"
-fi
-if [ ! -z "$JPY_PORT" ]; then
-  NOTEBOOK_ARGS="--port=$JPY_PORT $NOTEBOOK_ARGS"
-fi
-if [ ! -z "$JPY_USER" ]; then
-  NOTEBOOK_ARGS="--user=$JPY_USER $NOTEBOOK_ARGS"
-fi
-if [ ! -z "$JPY_COOKIE_NAME" ]; then
-  NOTEBOOK_ARGS="--cookie-name=$JPY_COOKIE_NAME $NOTEBOOK_ARGS"
-fi
-if [ ! -z "$JPY_BASE_URL" ]; then
-  NOTEBOOK_ARGS="--base-url=$JPY_BASE_URL $NOTEBOOK_ARGS"
-fi
-if [ ! -z "$JPY_HUB_PREFIX" ]; then
-  NOTEBOOK_ARGS="--hub-prefix=$JPY_HUB_PREFIX $NOTEBOOK_ARGS"
-fi
-if [ ! -z "$JPY_HUB_API_URL" ]; then
-  NOTEBOOK_ARGS="--hub-api-url=$JPY_HUB_API_URL $NOTEBOOK_ARGS"
-fi
-NOTEBOOK_BIN="jupyterhub-singleuser"
-
-. /usr/local/bin/start.sh $NOTEBOOK_BIN $NOTEBOOK_ARGS "$@"
+. /usr/local/bin/start.sh jupyterhub-singleuser $NOTEBOOK_ARGS "$@"

--- a/base-notebook/start.sh
+++ b/base-notebook/start.sh
@@ -90,8 +90,13 @@ if [ $(id -u) == 0 ] ; then
     # home directory as a fallback if they don't have one mounted already.
     if [[ "$NB_USER" != "jovyan" ]]; then
         if [[ ! -e "/home/$NB_USER" ]]; then
-            echo "Relocating home dir to /home/$NB_USER"
-            mv /home/jovyan "/home/$NB_USER" || ln -s /home/jovyan "/home/$NB_USER"
+            echo "Attempting to move /home/jovyan to /home/${NB_USER}..."
+            if mv /home/jovyan "/home/$NB_USER"; then
+                echo "Done"
+            else
+                echo "Failed. Attempting to symlink /home/jovyan to /home/${NB_USER}..."
+                ln -s /home/jovyan "/home/$NB_USER" && echo "Done"
+            fi
         fi
         # Ensure the current working directory is updated
         if [[ "$PWD/" == "/home/jovyan/"* ]]; then

--- a/base-notebook/start.sh
+++ b/base-notebook/start.sh
@@ -11,24 +11,26 @@ else
     cmd=( "$@" )
 fi
 
+# The run-hooks function looks for .sh scripts and executable files
+# - .sh scripts will be sourced
+# - executable files (+x) will be executed
 run-hooks () {
-    # Source scripts or run executable files in a directory
     if [[ ! -d "$1" ]] ; then
         return
     fi
-    echo "$0: running hooks in $1"
+    echo "$0: running hooks in $1 as uid / gid: $(id -u) / $(id -g)"
     for f in "$1/"*; do
         case "$f" in
             *.sh)
-                echo "$0: running $f"
+                echo "$0: running script $f"
                 source "$f"
                 ;;
             *)
                 if [[ -x "$f" ]] ; then
-                    echo "$0: running $f"
+                    echo "$0: running executable $f"
                     "$f"
                 else
-                    echo "$0: ignoring $f"
+                    echo "$0: ignoring non-executable $f"
                 fi
                 ;;
         esac

--- a/base-notebook/start.sh
+++ b/base-notebook/start.sh
@@ -3,14 +3,16 @@
 # Distributed under the terms of the Modified BSD License.
 
 set -e
-echo "Running: start.sh $@"
 
-# Exec the specified command or fall back on bash
-if [ $# -eq 0 ]; then
-    cmd=( "bash" )
-else
-    cmd=( "$@" )
-fi
+# The _log function is passed everything this script wants to log. It will
+# always log errors and warnings, but can be silenced by setting
+# JUPYTER_DOCKER_STACKS_QUIET.
+_log () {
+    if [[ "$@" == "ERROR:"* ]] || [[ "$@" == "WARNING:"* ]] || [[ "$JUPYTER_DOCKER_STACKS_QUIET" != "" ]]; then
+        echo "$@"
+    fi
+}
+_log "Entered start.sh with args: $@"
 
 # The run-hooks function looks for .sh scripts to source and executable files to
 # run within a passed directory.
@@ -18,24 +20,24 @@ run-hooks () {
     if [[ ! -d "$1" ]] ; then
         return
     fi
-    echo "$0: running hooks in $1 as uid / gid: $(id -u) / $(id -g)"
+    _log "$0: running hooks in $1 as uid / gid: $(id -u) / $(id -g)"
     for f in "$1/"*; do
         case "$f" in
             *.sh)
-                echo "$0: running script $f"
+                _log "$0: running script $f"
                 source "$f"
                 ;;
             *)
                 if [[ -x "$f" ]] ; then
-                    echo "$0: running executable $f"
+                    _log "$0: running executable $f"
                     "$f"
                 else
-                    echo "$0: ignoring non-executable $f"
+                    _log "$0: ignoring non-executable $f"
                 fi
                 ;;
         esac
     done
-    echo "$0: done running hooks in $1"
+    _log "$0: done running hooks in $1"
 }
 
 # The unset_explicit_env_vars function unset environment variables listed in the
@@ -43,12 +45,19 @@ run-hooks () {
 unset_explicit_env_vars () {
     if [ ! -z "$JUPYTER_ENV_VARS_TO_UNSET" ]; then
         for env_var_to_unset in $(echo $JUPYTER_ENV_VARS_TO_UNSET | tr ',;:' ' '); do
-            echo "Unset ${env_var_to_unset} due to JUPYTER_ENV_VARS_TO_UNSET"
+            _log "Unset ${env_var_to_unset} due to JUPYTER_ENV_VARS_TO_UNSET"
             unset ${env_var_to_unset}
         done
         unset JUPYTER_ENV_VARS_TO_UNSET
     fi
 }
+
+# Default to starting bash if no command was specified
+if [ $# -eq 0 ]; then
+    cmd=( "bash" )
+else
+    cmd=( "$@" )
+fi
 
 # NOTE: This hook will run as the user the container was started with!
 run-hooks /usr/local/bin/start-notebook.d
@@ -72,20 +81,18 @@ if [ $(id -u) == 0 ] ; then
     # Refit the jovyan user to the desired the user (NB_USER)
     if id jovyan &> /dev/null; then
         if ! usermod --login $NB_USER --home /home/$NB_USER jovyan 2>&1 | grep "no changes" > /dev/null; then
-            echo "Updated the jovyan user:"
-            echo "- username: jovyan       -> $NB_USER"
-            echo "- home dir: /home/jovyan -> /home/$NB_USER"
+            _log "Updated the jovyan user:"
+            _log "- username: jovyan       -> $NB_USER"
+            _log "- home dir: /home/jovyan -> /home/$NB_USER"
         fi
     elif ! id -u $NB_USER &> /dev/null; then
-        echo "ERROR: Neither the jovyan user or '$NB_USER' exists."
-        echo "       This could be the result of stopping and starting, the"
-        echo "       container with a different NB_USER environment variable."
+        _log "ERROR: Neither the jovyan user or '$NB_USER' exists. This could be the result of stopping and starting, the container with a different NB_USER environment variable."
         exit 1
     fi
     # Ensure the desired user (NB_USER) gets its desired user id (NB_UID) and is
     # a member of the desired group (NB_GROUP, NB_GID)
     if [ "$NB_UID" != $(id -u $NB_USER) ] || [ "$NB_GID" != $(id -g $NB_USER) ]; then
-        echo "Update $NB_USER's UID:GID to $NB_UID:$NB_GID"
+        _log "Update $NB_USER's UID:GID to $NB_UID:$NB_GID"
         # Ensure the desired group's existance
         if [ "$NB_GID" != $(id -g $NB_USER) ]; then
             groupadd --gid $NB_GID --non-unique ${NB_GROUP:-${NB_USER}}
@@ -100,23 +107,23 @@ if [ $(id -u) == 0 ] ; then
     # directory to the new location if needed.
     if [[ "$NB_USER" != "jovyan" ]]; then
         if [[ ! -e "/home/$NB_USER" ]]; then
-            echo "Attempting to move /home/jovyan to /home/${NB_USER}..."
+            _log "Attempting to move /home/jovyan to /home/${NB_USER}..."
             if mv /home/jovyan "/home/$NB_USER"; then
-                echo "Success!"
+                _log "Success!"
             else
-                echo "Failed!"
-                echo "Attempting to symlink /home/jovyan to /home/${NB_USER}..."
+                _log "Failed!"
+                _log "Attempting to symlink /home/jovyan to /home/${NB_USER}..."
                 if ln -s /home/jovyan "/home/$NB_USER"; then
-                    echo "Success!"
+                    _log "Success!"
                 else
-                    echo "Failed!"
+                    _log "Failed!"
                 fi
             fi
         fi
         # Ensure the current working directory is updated to the new path
         if [[ "$PWD/" == "/home/jovyan/"* ]]; then
             new_wd="/home/$NB_USER/${PWD:13}"
-            echo "Changing working directory to $new_wd"
+            _log "Changing working directory to $new_wd"
             cd "$new_wd"
         fi
     fi
@@ -124,12 +131,12 @@ if [ $(id -u) == 0 ] ; then
     # Optionally ensure the desired user get filesystem ownership of it's home
     # folder and/or additional folders
     if [[ "$CHOWN_HOME" == "1" || "$CHOWN_HOME" == "yes" ]]; then
-        echo "Ensuring /home/$NB_USER is owned by $NB_UID:$NB_GID ${CHOWN_HOME_OPTS:+chown options: $CHOWN_HOME_OPTS}"
+        _log "Ensuring /home/$NB_USER is owned by $NB_UID:$NB_GID ${CHOWN_HOME_OPTS:+chown options: $CHOWN_HOME_OPTS}"
         chown $CHOWN_HOME_OPTS $NB_UID:$NB_GID /home/$NB_USER
     fi
     if [ ! -z "$CHOWN_EXTRA" ]; then
         for extra_dir in $(echo $CHOWN_EXTRA | tr ',' ' '); do
-            echo "Ensuring ${extra_dir} is owned by $NB_UID:$NB_GID ${CHOWN_HOME_OPTS:+(chown options: $CHOWN_HOME_OPTS)}"
+            _log "Ensuring ${extra_dir} is owned by $NB_UID:$NB_GID ${CHOWN_HOME_OPTS:+(chown options: $CHOWN_HOME_OPTS)}"
             chown $CHOWN_EXTRA_OPTS $NB_UID:$NB_GID $extra_dir
         done
     fi
@@ -166,7 +173,7 @@ if [ $(id -u) == 0 ] ; then
 
     # Optionally grant passwordless sudo rights for the desired user
     if [[ "$GRANT_SUDO" == "1" || "$GRANT_SUDO" == 'yes' ]]; then
-        echo "Granting $NB_USER passwordless sudo rights!"
+        _log "Granting $NB_USER passwordless sudo rights!"
         echo "$NB_USER ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers.d/added-by-start-script
     fi
 
@@ -174,7 +181,7 @@ if [ $(id -u) == 0 ] ; then
     run-hooks /usr/local/bin/before-notebook.d
 
     unset_explicit_env_vars
-    echo "Running (as $NB_USER): ${cmd[@]}"
+    _log "Running (as $NB_USER): ${cmd[@]}"
     exec sudo --preserve-env --set-home --user $NB_USER "${cmd[@]}"
 
 # The container didn't start as the root user, so we will have to act as the
@@ -182,18 +189,18 @@ if [ $(id -u) == 0 ] ; then
 else
     # Warn about misconfiguration of: desired username, user id, or group id
     if [[ ! -z "$NB_USER" && "$NB_USER" != "$(id -un)" ]]; then
-        echo "WARNING: container must be started as root to change the desired user's name with NB_USER!"
+        _log "WARNING: container must be started as root to change the desired user's name with NB_USER!"
     fi
     if [[ ! -z "$NB_UID" && "$NB_UID" != "$(id -u)" ]]; then
-        echo "WARNING: container must be started as root to change the desired user's id with NB_UID!"
+        _log "WARNING: container must be started as root to change the desired user's id with NB_UID!"
     fi
     if [[ ! -z "$NB_GID" && "$NB_GID" != "$(id -g)" ]]; then
-        echo "WARNING: container must be started as root to change the desired user's group id with NB_GID!"
+        _log "WARNING: container must be started as root to change the desired user's group id with NB_GID!"
     fi
 
     # Warn about misconfiguration of: granting sudo rights
     if [[ "$GRANT_SUDO" == "1" || "$GRANT_SUDO" == 'yes' ]]; then
-        echo "WARNING: container must be started as root to grant sudo permissions!"
+        _log "WARNING: container must be started as root to grant sudo permissions!"
     fi
 
     # Attempt to ensure the user uid we currently run as has a named entry in
@@ -205,24 +212,24 @@ else
     if ! whoami &> /dev/null; then
         if [[ -w /etc/passwd ]]; then
             sed --in-place "s/^jovyan:/nayvoj:/" /etc/passwd
-            echo "Renamed old jovyan user to nayvoy (1000:100)"
+            _log "Renamed old jovyan user to nayvoy (1000:100)"
 
             echo "jovyan:x:$(id -u):$(id -g):,,,:/home/jovyan:/bin/bash" >> /etc/passwd
-            echo "Added new jovyan user ($(id -u):$(id -g))"
+            _log "Added new jovyan user ($(id -u):$(id -g))"
         else
-            echo "WARNING: container must be started with group 'root' (0) to add a user entry in /etc/passwd!"
+            _log "WARNING: container must be started with group 'root' (0) to add a user entry in /etc/passwd!"
         fi
     fi
 
     # Warn if the user isn't able to write files to $HOME
     if [[ ! -w /home/jovyan ]]; then
-        echo "WARNING: container must be started with group 'users' (100) to be allowed to write to /home/jovyan!"
+        _log "WARNING: container must be started with group 'users' (100) to be allowed to write to /home/jovyan!"
     fi
 
     # NOTE: This hook is run as the user we started the container as!
     run-hooks /usr/local/bin/before-notebook.d
 
     unset_explicit_env_vars
-    echo "Running: ${cmd[@]}"
+    _log "Running: ${cmd[@]}"
     exec "${cmd[@]}"
 fi

--- a/base-notebook/start.sh
+++ b/base-notebook/start.sh
@@ -38,57 +38,79 @@ run-hooks () {
     echo "$0: done running hooks in $1"
 }
 
+
+
+# NOTE: This hook will run as the user the container was started with!
 run-hooks /usr/local/bin/start-notebook.d
 
-# Handle special flags if we're root
+
+
+# If we have started the container as the root user, then we have permission to
+# manipulate user identities and storage file permissions before we start the
+# server as a non-root user.
+#
+# Environment variables of relevance:
+# - NB_UID: the user we want to run as, uniquely identified by an id
+# - NB_USER: the username and associated home folder we want for our user
+# - NB_GID: a group we want our user to belong to, uniquely identified by an id
+# - NB_GROUP: the groupname we want for the group
 if [ $(id -u) == 0 ] ; then
 
-    # Only attempt to change the jovyan username if it exists
-    if id jovyan &> /dev/null ; then
-        echo "Set username to: $NB_USER"
-        usermod -d /home/$NB_USER -l $NB_USER jovyan
+    # Optionally ensure the user we want to run as (NB_UID) get filesystem
+    # ownership of it's home folder and additional folders. This can be relevant
+    # for attached NFS storage.
+    #
+    # Environment variables:
+    # - CHOWN_HOME: a boolean ("1" or "yes") to chown the user's home folder
+    # - CHOWN_EXTRA: a comma separated list of paths to chown
+    # - CHOWN_HOME_OPTS / CHOWN_EXTRA_OPTS: arguments to the chown command
+    if [[ "$CHOWN_HOME" == "1" || "$CHOWN_HOME" == "yes" ]]; then
+        echo "Updating ownership of /home/$NB_USER to $NB_UID:$NB_GID with options '${CHOWN_HOME_OPTS}'"
+        chown $CHOWN_HOME_OPTS $NB_UID:$NB_GID /home/$NB_USER
+    fi
+    if [ ! -z "$CHOWN_EXTRA" ]; then
+        for extra_dir in $(echo $CHOWN_EXTRA | tr ',' ' '); do
+            echo "Updating ownership of ${extra_dir} to $NB_UID:$NB_GID with options '${CHOWN_EXTRA_OPTS}'"
+            chown $CHOWN_EXTRA_OPTS $NB_UID:$NB_GID $extra_dir
+        done
+    fi
+
+    # Update the jovyan identity to get desired username and its associated home folder.
+    if id jovyan &> /dev/null; then
+        echo "Updating the default jovyan user:"
+        echo "username: jovyan -> $NB_USER"
+        echo "home dir: /home/jovyan -> /home/$NB_USER"
+        usermod --login $NB_USER --home /home/$NB_USER jovyan
     fi
     # Update any environment variables we set during build of the
     # Dockerfile that contained the home directory path.
     export XDG_CACHE_HOME=/home/$NB_USER/.cache
 
-    # Handle case where provisioned storage does not have the correct permissions by default
-    # Ex: default NFS/EFS (no auto-uid/gid)
-    if [[ "$CHOWN_HOME" == "1" || "$CHOWN_HOME" == 'yes' ]]; then
-        echo "Changing ownership of /home/$NB_USER to $NB_UID:$NB_GID with options '${CHOWN_HOME_OPTS}'"
-        chown $CHOWN_HOME_OPTS $NB_UID:$NB_GID /home/$NB_USER
-    fi
-    if [ ! -z "$CHOWN_EXTRA" ]; then
-        for extra_dir in $(echo $CHOWN_EXTRA | tr ',' ' '); do
-            echo "Changing ownership of ${extra_dir} to $NB_UID:$NB_GID with options '${CHOWN_EXTRA_OPTS}'"
-            chown $CHOWN_EXTRA_OPTS $NB_UID:$NB_GID $extra_dir
-        done
-    fi
-
-    # handle home and working directory if the username changed
+    # For non-jovyan username's, populate their home directory with the jovyan's
+    # home directory as a fallback if they don't have one mounted already.
     if [[ "$NB_USER" != "jovyan" ]]; then
-        # changing username, make sure homedir exists
-        # (it could be mounted, and we shouldn't create it if it already exists)
         if [[ ! -e "/home/$NB_USER" ]]; then
             echo "Relocating home dir to /home/$NB_USER"
             mv /home/jovyan "/home/$NB_USER" || ln -s /home/jovyan "/home/$NB_USER"
         fi
-        # if workdir is in /home/jovyan, cd to /home/$NB_USER
+        # Ensure the current working directory is updated
         if [[ "$PWD/" == "/home/jovyan/"* ]]; then
             newcwd="/home/$NB_USER/${PWD:13}"
-            echo "Setting CWD to $newcwd"
+            echo "Changing working directory to $newcwd"
             cd "$newcwd"
         fi
     fi
 
-    # Change UID:GID of NB_USER to NB_UID:NB_GID if it does not match
+    # Ensure NB_USER gets the NB_UID user id and is a member of the NB_GID group
     if [ "$NB_UID" != $(id -u $NB_USER) ] || [ "$NB_GID" != $(id -g $NB_USER) ]; then
-        echo "Set user $NB_USER UID:GID to: $NB_UID:$NB_GID"
+        echo "Update $NB_USER's UID:GID to $NB_UID:$NB_GID"
+        # Ensure the group's existance
         if [ "$NB_GID" != $(id -g $NB_USER) ]; then
-            groupadd -g $NB_GID -o ${NB_GROUP:-${NB_USER}}
+            groupadd --gid $NB_GID --non-unique ${NB_GROUP:-${NB_USER}}
         fi
+        # Recreate the user as we want it
         userdel $NB_USER
-        useradd --home /home/$NB_USER -u $NB_UID -g $NB_GID -G 100 -l $NB_USER
+        useradd --home /home/$NB_USER --uid $NB_UID --gid $NB_GID --groups 100 --no-log-init $NB_USER
     fi
 
     # Conditionally enable passwordless sudo usage for the jovyan user
@@ -128,6 +150,10 @@ if [ $(id -u) == 0 ] ; then
 
     echo "Running as $NB_USER with preserved environment: ${cmd[@]}"
     exec sudo --preserve-env --set-home --user $NB_USER "${cmd[@]}"
+
+
+
+# The container didn't start as the root user.
 else
     if [[ "$NB_UID" == "$(id -u jovyan)" && "$NB_GID" == "$(id -g jovyan)" ]]; then
         # User is not attempting to override user/group via environment
@@ -143,13 +169,13 @@ else
                 cat /tmp/passwd > /etc/passwd
                 rm /tmp/passwd
             else
-                echo 'Container must be run with group "root" to update passwd file'
+                echo "WARNING: Container must be run with group 'root' to update passwd file"
             fi
         fi
 
         # Warn if the user isn't going to be able to write files to $HOME.
         if [[ ! -w /home/jovyan ]]; then
-            echo 'Container must be run with group "users" to update files'
+            echo "WARNING: Container must be run with group 'users' to update files"
         fi
     else
         # Warn if looks like user want to override uid/gid but hasn't
@@ -162,14 +188,12 @@ else
         fi
     fi
 
-    # Warn if looks like user want to run in sudo mode but hasn't run
-    # the container as root.
+    # Warn about a probable misconfiguration of sudo
     if [[ "$GRANT_SUDO" == "1" || "$GRANT_SUDO" == 'yes' ]]; then
-        echo 'Container must be run as root to grant sudo permissions'
+        echo "WARNING: container must be started up as root to grant sudo permissions."
     fi
 
-    # Execute the command
     run-hooks /usr/local/bin/before-notebook.d
-    echo "Executing the command: ${cmd[@]}"
+    echo "Running: ${cmd[@]}"
     exec "${cmd[@]}"
 fi

--- a/docs/using/common.md
+++ b/docs/using/common.md
@@ -36,6 +36,7 @@ the notebook server. You do so by passing arguments to the `docker run` command.
 * `-e RESTARTABLE=yes` - Runs Jupyter in a loop so that quitting Jupyter does not cause the container to exit.  This may be useful when you need to install extensions that require restarting Jupyter.
 * `-v /some/host/folder/for/work:/home/jovyan/work` - Mounts a host machine directory as folder in the container. Useful when you want to preserve notebooks and other work even after the container is destroyed. **You must grant the within-container notebook user or group (`NB_UID` or `NB_GID`) write access to the host directory (e.g., `sudo chown 1000 /some/host/folder/for/work`).**
 * `--user 5000 --group-add users` - Launches the container with a specific user ID and adds that user to the `users` group so that it can modify files in the default home directory and `/opt/conda`. You can use these arguments as alternatives to setting `$NB_UID` and `$NB_GID`.
+* `-e JUPYTER_ENV_VARS_TO_UNSET=ADMIN_SECRET_1,ADMIN_SECRET_2` - Allow you to list environment variables that will unset by the default startup script after the hooks have executed but before we run the command provided to the startup script.
 
 ## Startup Hooks
 


### PR DESCRIPTION
# PR Summary

Fixes #1053, Fixes #1034, Closes #1054

When we transition from a root user to the actual user that runs the command passed to start.sh, we are doing a lot of complicated things to preserve the environment variables, but we currently fail with this while also having a complicated bash script that is hard to understand.

With this PR, we will start to properly preserve the `PATH`, `LD_LIBRARY_PATH`, 
and `PYTHON*` variables. We will also allow the $NB_USER's that were granted sudo to retain its own PATH when running sudo commands.

The original use case for me was that I needed to set `LD_LIBRARY_PATH` and `GRANT_SUDO`, but `LD_LIBRARY_PATH` was stripped by the default configuration when using `sudo` even with the custom configuration to preserve it, because it was part of the default `env_delete` list of environment variables in the sudoers configuration.

### Related extra part of the PR

I've also added a feature in the last commit, which I could extract to a standalone PR later, introduced an environment variable named `JUPYTER_ENV_VARS_TO_UNSET` that allow us to list environment variables to unset just before we exec the command given to start.sh. This allow hooks to use something sensitive to be stripped from the environment later.

### Review suggestions

Read the PR summary, then review the commit changes commit by commit in order.


# Original outdated text below

When we run `sudo -u jovyan`, even with `-E` (`--preserve-env`), we end
up with reset environment variables. By running `sudo -V` as a root user
or `sudo sudo -V` we get information about what environment variables
will be reset when we would do for example `sudo -E -u jovyan`.

```
Environment variables to remove:
        *=()*
        RUBYOPT
        RUBYLIB
        PYTHONUSERBASE
        PYTHONINSPECT
        PYTHONPATH
        PYTHONHOME
        TMPPREFIX
        ZDOTDIR
        READNULLCMD
        NULLCMD
        FPATH
        PERL5DB
        PERL5OPT
        PERL5LIB
        PERLLIB
        PERLIO_DEBUG
        JAVA_TOOL_OPTIONS
        SHELLOPTS
        BASHOPTS
        GLOBIGNORE
        PS4
        BASH_ENV
        ENV
        TERMCAP
        TERMPATH
        TERMINFO_DIRS
        TERMINFO
        _RLD*
        LD_*
        PATH_LOCALE
        NLSPATH
        HOSTALIASES
        RES_OPTIONS
        LOCALDOMAIN
        CDPATH
        IFS
```

A use case I ran into was the need to preserve the `LD_LIBRARY_PATH`
variable. I want to help provide information about where to find
libraries installed after the image is built. If they were installed
before the image was built I could have done...

```dockerfile
RUN echo "/usr/local/nvidia/lib64" > /etc/ld.so.conf.d/nvidia.conf \
 && ldconfig
```

... which would have `ldconfig` search through the folder and summarize
information about libraries into `/etc/ld.so.cache`. But, they are not
there yet, and there will be plenty of files in there later.

Anyhow. This PR ensures we preserve LD_LIBRARY_PATH as well when we
switch from the root user to the jovyan kind of user with sudo
privileges.