### PR TITLE
Changed the regular expression in start.sh that reads the /etc/sudoer…

### DIFF
--- a/base-notebook/start.sh
+++ b/base-notebook/start.sh
@@ -93,7 +93,7 @@ if [ $(id -u) == 0 ] ; then
     fi
 
     # Add $CONDA_DIR/bin to sudo secure_path
-    sed -r "s#Defaults\s+secure_path=\"([^\"]+)\"#Defaults secure_path=\"\1:$CONDA_DIR/bin\"#" /etc/sudoers | grep secure_path > /etc/sudoers.d/path
+    sed -r "s#Defaults\s+secure_path\s*=\s*\"?([^\"]+)\"?#Defaults secure_path=\"\1:$CONDA_DIR/bin\"#" /etc/sudoers | grep secure_path > /etc/sudoers.d/path
 
     # Exec the command as NB_USER with the PATH and the rest of
     # the environment preserved


### PR DESCRIPTION
Fixes https://github.com/jupyter/docker-stacks/issues/1064

…s file and

adds the conda path as a secure path to sudo.

The regular expression expects that the equals sign has no leading and trailing
spaces after the parameter secure_path. Furthermore it expects that the value
is enclosed in double quotes.

This is the case for the sudoers file in debian based distributions, but the
in centos / redhat based distributions this is not the case. The default value
of the secure_path in centos / redhat based distributions has no double quotes
and leading and trailing spaces.

This change adds optional spaces before and after the space, and makes the
double quotes optional.