### PR TITLE
Regular update 2020 W18

### DIFF
--- a/all-spark-notebook/Dockerfile
+++ b/all-spark-notebook/Dockerfile
@@ -27,7 +27,7 @@ RUN conda install --quiet --yes \
     'r-ggplot2=3.3*' \
     'r-irkernel=1.1*' \
     'r-rcurl=1.98*' \
-    'r-sparklyr=1.1*' \
+    'r-sparklyr=1.2*' \
     && \
     conda clean --all -f -y && \
     fix-permissions $CONDA_DIR && \

--- a/base-notebook/Dockerfile
+++ b/base-notebook/Dockerfile
@@ -4,7 +4,7 @@
 # Ubuntu 18.04 (bionic)
 # https://hub.docker.com/_/ubuntu/?tab=tags&name=bionic
 # OS/ARCH: linux/amd64
-ARG ROOT_CONTAINER=ubuntu:bionic-20200311@sha256:e5dd9dbb37df5b731a6688fa49f4003359f6f126958c9c928f937bec69836320
+ARG ROOT_CONTAINER=ubuntu:bionic-20200403@sha256:b58746c8a89938b8c9f5b77de3b8cf1fe78210c696ab03a1442e235eea65d84f
 ARG BASE_CONTAINER=$ROOT_CONTAINER
 FROM $BASE_CONTAINER
 
@@ -112,7 +112,7 @@ RUN conda install --quiet --yes 'tini=0.18.0' && \
 RUN conda install --quiet --yes \
     'notebook=6.0.3' \
     'jupyterhub=1.1.0' \
-    'jupyterlab=2.0.1' && \
+    'jupyterlab=2.1.1' && \
     conda clean --all -f -y && \
     npm cache clean --force && \
     jupyter notebook --generate-config && \

--- a/datascience-notebook/Dockerfile
+++ b/datascience-notebook/Dockerfile
@@ -23,12 +23,12 @@ RUN apt-get update && \
 # install Julia packages in /opt/julia instead of $HOME
 ENV JULIA_DEPOT_PATH=/opt/julia
 ENV JULIA_PKGDIR=/opt/julia
-ENV JULIA_VERSION=1.3.1
+ENV JULIA_VERSION=1.4.1
 
 RUN mkdir /opt/julia-${JULIA_VERSION} && \
     cd /tmp && \
     wget -q https://julialang-s3.julialang.org/bin/linux/x64/`echo ${JULIA_VERSION} | cut -d. -f 1,2`/julia-${JULIA_VERSION}-linux-x86_64.tar.gz && \
-    echo "faa707c8343780a6fe5eaf13490355e8190acf8e2c189b9e7ecbddb0fa2643ad *julia-${JULIA_VERSION}-linux-x86_64.tar.gz" | sha256sum -c - && \
+    echo "fd6d8cadaed678174c3caefb92207a3b0e8da9f926af6703fb4d1e4e4f50610a *julia-${JULIA_VERSION}-linux-x86_64.tar.gz" | sha256sum -c - && \
     tar xzf julia-${JULIA_VERSION}-linux-x86_64.tar.gz -C /opt/julia-${JULIA_VERSION} --strip-components=1 && \
     rm /tmp/julia-${JULIA_VERSION}-linux-x86_64.tar.gz
 RUN ln -fs /opt/julia-*/bin/julia /usr/local/bin/julia
@@ -48,8 +48,8 @@ RUN conda install --quiet --yes \
     'r-base=3.6.3' \
     'r-caret=6.0*' \
     'r-crayon=1.3*' \
-    'r-devtools=2.2*' \
-    'r-forecast=8.11*' \
+    'r-devtools=2.3*' \
+    'r-forecast=8.12*' \
     'r-hexbin=1.28*' \
     'r-htmltools=0.4*' \
     'r-htmlwidgets=1.5*' \

--- a/datascience-notebook/test/test_julia.py
+++ b/datascience-notebook/test/test_julia.py
@@ -1,0 +1,20 @@
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+import logging
+
+import pytest
+
+LOGGER = logging.getLogger(__name__)
+
+
+def test_julia(container):
+    """Basic julia test"""
+    LOGGER.info(f"Test that julia is correctly installed ...")
+    running_container = container.run(
+        tty=True, command=["start.sh", "bash", "-c", "sleep infinity"]
+    )
+    command = f"julia --version"
+    cmd = running_container.exec_run(command)
+    output = cmd.output.decode("utf-8")
+    assert cmd.exit_code == 0, f"Command {command} failed {output}"
+    LOGGER.debug(output)

--- a/r-notebook/Dockerfile
+++ b/r-notebook/Dockerfile
@@ -28,8 +28,8 @@ RUN conda install --quiet --yes \
     'r-base=3.6.3' \
     'r-caret=6.0*' \
     'r-crayon=1.3*' \
-    'r-devtools=2.2*' \
-    'r-forecast=8.11*' \
+    'r-devtools=2.3*' \
+    'r-forecast=8.12*' \
     'r-hexbin=1.28*' \
     'r-htmltools=0.4*' \
     'r-htmlwidgets=1.5*' \

--- a/scipy-notebook/Dockerfile
+++ b/scipy-notebook/Dockerfile
@@ -29,7 +29,8 @@ RUN conda install --quiet --yes \
     'ipywidgets=7.5.*' \
     'ipympl=0.5.*'\
     'matplotlib-base=3.2.*' \
-    'numba=0.49.*' \
+    # numba update to 0.49 fails resolving deps.
+    'numba=0.48.*' \
     'numexpr=2.7.*' \
     'pandas=1.0.*' \
     'patsy=0.5.*' \

--- a/scipy-notebook/Dockerfile
+++ b/scipy-notebook/Dockerfile
@@ -16,20 +16,20 @@ USER $NB_UID
 
 # Install Python 3 packages
 RUN conda install --quiet --yes \
-    'beautifulsoup4=4.8.*' \
+    'beautifulsoup4=4.9.*' \
     'conda-forge::blas=*=openblas' \
     'bokeh=2.0.*' \
     'bottleneck=1.3.*' \
-    'cloudpickle=1.3.*' \
+    'cloudpickle=1.4.*' \
     'cython=0.29.*' \
-    'dask=2.14.*' \
+    'dask=2.15.*' \
     'dill=0.3.*' \
     'h5py=2.10.*' \
     'hdf5=1.10.*' \
     'ipywidgets=7.5.*' \
     'ipympl=0.5.*'\
     'matplotlib-base=3.2.*' \
-    'numba=0.48.*' \
+    'numba=0.49.*' \
     'numexpr=2.7.*' \
     'pandas=1.0.*' \
     'patsy=0.5.*' \
@@ -44,7 +44,7 @@ RUN conda install --quiet --yes \
     'sympy=1.5.*' \
     'vincent=0.4.*' \
     'widgetsnbextension=3.5.*'\
-    'xlrd' \
+    'xlrd=1.2.*' \
     && \
     conda clean --all -f -y && \
     # Activate ipywidgets extension in the environment that runs the notebook server


### PR DESCRIPTION
* Bump `base-notebook`
	* OS version
	* `jupyterlab`
* Bump `scipy-notebook`
	* `beautifulsoup4`
	* `cloudpickle`
	* `dask`
	* ~`numba`~
	* `xlrd`: version specified (it was not the case)
* Bump `datascience-notebook`
	* `r-devtools`
	* `r-forecast`
	* Julia version
	* Test added to check if Julia is correctly installed (`julia --version`)
	* Note: A new version of `r-base` is out `4.0.0` however it cannot be installed yet since dependencies with other packages cannot be resolved.
* Bump `r-notebook`
	* Same as `datascience-notebook` except Julia.
* Bump `all-spark-notebook`
	* `r-sparklyr`

# `numba` update

Dependencies resolution fails with `numba` `0.49`. I do not know the root cause.
Here is the difference between the two versions.

```bash
$ conda search --info numba

numba 0.48.0 py36hb3f55d8_0
---------------------------
file name   : numba-0.48.0-py36hb3f55d8_0.tar.bz2
name        : numba
version     : 0.48.0
[...]
constraints :
  - tbb >=2018.0.5
  - python_abi * *_cp36m
dependencies:
  - libgcc-ng >=7.3.0
  - libstdcxx-ng >=7.3.0
  - llvmlite >=0.31.0,<0.32.0a0
  - numpy >=1.14.6,<2.0a0
  - python >=3.6,<3.7.0a0
  - setuptools

numba 0.49.0 py36h0573a6f_0
---------------------------
file name   : numba-0.49.0-py36h0573a6f_0.conda
name        : numba
version     : 0.49.0
[...]
constraints :
  - tbb >=2018.0.5
dependencies:
  - libgcc-ng >=7.3.0
  - libstdcxx-ng >=7.3.0
  - llvmlite >=0.32.0
  - llvmlite >=0.32.0,<0.33.0a0
  - numpy >=1.14.6,<2.0a0
  - python >=3.6,<3.7.0a0
  - setuptools
  - tbb >=2020.0
 ```