### PR TITLE
Use pip --no-cache-dir to install tensorflow

### DIFF
--- a/tensorflow-notebook/Dockerfile
+++ b/tensorflow-notebook/Dockerfile
@@ -7,6 +7,6 @@ LABEL maintainer="Jupyter Project <jupyter@googlegroups.com>"
 
 # Install Tensorflow
 RUN pip install --quiet --no-cache-dir \
-    'tensorflow==2.1.0' && \
+    'tensorflow==2.2.0' && \
     fix-permissions $CONDA_DIR && \
     fix-permissions /home/$NB_USER

--- a/tensorflow-notebook/Dockerfile
+++ b/tensorflow-notebook/Dockerfile
@@ -6,7 +6,7 @@ FROM $BASE_CONTAINER
 LABEL maintainer="Jupyter Project <jupyter@googlegroups.com>"
 
 # Install Tensorflow
-RUN pip install --quiet \
+RUN pip install --quiet --no-cache-dir \
     'tensorflow==2.1.0' && \
     fix-permissions $CONDA_DIR && \
     fix-permissions /home/$NB_USER


### PR DESCRIPTION
Before image size was 5.21GB, after fix: 4.78GB - ~430MB saved.