### PR TITLE
CONTRIBUTING.md misleading link to guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,5 @@
 Thanks for contributing! Please see the
-[Contributor Guide](https://jupyter-docker-stacks.readthedocs.io) in the documentation for
+__Contributor Guide__ section in [the documentation](https://jupyter-docker-stacks.readthedocs.io) for
 information about how to contribute
 [package updates](http://jupyter-docker-stacks.readthedocs.io/en/latest/contributing/packages.html),
 [recipes](http://jupyter-docker-stacks.readthedocs.io/en/latest/contributing/recipes.html),


### PR DESCRIPTION
The best links connects a linking object and its text occurrence, e.g. the link to documentation is near documentation's occurrence in the text. Since no explicit link to the guide the guide text font became bold but link to the docs moved to doc's text occurence