### PR TITLE
suppress "id: jovyan: no such user" message during start

### DIFF
--- a/base-notebook/start.sh
+++ b/base-notebook/start.sh
@@ -101,7 +101,7 @@ if [ $(id -u) == 0 ] ; then
     echo "Executing the command: ${cmd[@]}"
     exec sudo -E -H -u $NB_USER PATH=$PATH XDG_CACHE_HOME=/home/$NB_USER/.cache PYTHONPATH=${PYTHONPATH:-} "${cmd[@]}"
 else
-    if [[ "$NB_UID" == "$(id -u jovyan)" && "$NB_GID" == "$(id -g jovyan)" ]]; then
+    if [[ "$NB_UID" == "$(id -u jovyan 2>/dev/null)" && "$NB_GID" == "$(id -g jovyan 2>/dev/null)" ]]; then
         # User is not attempting to override user/group via environment
         # variables, but they could still have overridden the uid/gid that
         # container runs as. Check that the user has an entry in the passwd


### PR DESCRIPTION
Suppress `id: jovyan: no such user` stderr output when determining whether to override user/group info. This aligns it with the rest of the startup script, which already suppresses this. 