### PR TITLE
Removed optional texlive-fonts-extra

### DIFF
--- a/minimal-notebook/Dockerfile
+++ b/minimal-notebook/Dockerfile
@@ -25,8 +25,6 @@ RUN apt-get update && apt-get install -yq --no-install-recommends \
     texlive-xetex \
     texlive-fonts-recommended \
     texlive-plain-generic \
-    # Optional dependency
-    texlive-fonts-extra \
     # ----
     tzdata \
     unzip \


### PR DESCRIPTION
`texlive-fonts-extra` seems not be be a requirement of `nbconvert`.
Reduces the image size by ~ 1.3 GB which will affect all images that build on the `minimal-notebook` image.

```bash
REPOSITORY                    TAG                 IMAGE ID            CREATED             SIZE
minimal-notebook-nofonts      latest              9641ee9dd31c        3 minutes ago       1.7GB
minimal-notebook              latest              e23d7794a410        14 minutes ago      3.01GB
```
I opened a [issues ](https://github.com/jupyter/docker-stacks/issues/1129)questioning if there is any reason to keep this package. See also the comment [here](https://github.com/jupyter/docker-stacks/pull/1013#discussion_r379897106) in [PR 1013](https://github.com/jupyter/docker-stacks/issues/1129).
So this PR closes #1129.