### PR TITLE
Combine jobs within workflows

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -48,21 +48,16 @@ jobs:
         env:
           COMMIT_MSG: "${{github.event.head_commit.message}}"
           WIKI_PATH: ../wiki
-
-  push:
-    name: Push Docker Images
-    runs-on: ubuntu-latest
-    needs:
-      - build
-    if: github.ref == 'refs/heads/master'
-    steps:
       - name: Login to Docker Hub
+        if: github.ref == 'refs/heads/master'
         run: >
           echo '${{secrets.DOCKERHUB_PASSWORD}}' | docker login --username
           '${{secrets.DOCKERHUB_USERNAME}}' --password-stdin
       - name: Push Images to DockerHub
+        if: github.ref == 'refs/heads/master'
         run: make -C main push-all
       - name: Push Wiki to GitHub
+        if: github.ref == 'refs/heads/master'
         run: make -C main git-commit
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -30,20 +30,14 @@ jobs:
           make dev-env
       - name: Build Documentation
         run: make docs
-
-  gettext:
-    name: Update Translation Source Strings
-    runs-on: ubuntu-latest
-    needs:
-      - build
-    if: github.ref == 'refs/heads/master'
-    steps:
       - name: Extract Source Strings
+        if: github.ref == 'refs/heads/master'
         working-directory: docs
         run: |
           make gettext
           sphinx-intl update -p _build/gettext -l en
       - name: Push Strings to Master
+        if: github.ref == 'refs/heads/master'
         run: make git-commit
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Job results are not accessible to other jobs within a workflow unless [the job stores them as artifacts](https://docs.github.com/en/actions/configuring-and-managing-workflows/persisting-workflow-data-using-artifacts). Instead of introducing that complexity, this PR combines the build and deploy docker image jobs into one, with the deploy steps guarded by a conditional that evaluates true for the master branch only. The PR combines the Sphinx build and gettext jobs in a similar manner.