### PR TITLE
[ci skip] Fix wiki commit, 'ci skip' support

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -20,7 +20,9 @@ jobs:
   build:
     name: Build Docker Images
     runs-on: ubuntu-latest
-    if: "!contains(github.event.head_commit.message , 'ci skip')"
+    if: >
+      "!contains(github.event.head_commit.message, 'ci skip') and
+      !contains(github.event.pull_request.title, 'ci skip')"
     steps:
       - name: Clone Main Repo
         uses: actions/checkout@v2

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -21,8 +21,8 @@ jobs:
     name: Build Docker Images
     runs-on: ubuntu-latest
     if: >
-      "!contains(github.event.head_commit.message, 'ci skip') and
-      !contains(github.event.pull_request.title, 'ci skip')"
+      !contains(github.event.head_commit.message, 'ci skip') &&
+      !contains(github.event.pull_request.title, 'ci skip')
     steps:
       - name: Clone Main Repo
         uses: actions/checkout@v2

--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -16,7 +16,9 @@ jobs:
   build:
     name: Build Sphinx Documentation
     runs-on: ubuntu-latest
-    if: "!contains(github.event.head_commit.message , 'ci skip')"
+    if: >
+      "!contains(github.event.head_commit.message, 'ci skip') and
+      !contains(github.event.pull_request.title, 'ci skip')"
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v2

--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -17,8 +17,8 @@ jobs:
     name: Build Sphinx Documentation
     runs-on: ubuntu-latest
     if: >
-      "!contains(github.event.head_commit.message, 'ci skip') and
-      !contains(github.event.pull_request.title, 'ci skip')"
+      !contains(github.event.head_commit.message , 'ci skip') &&
+      !contains(github.event.pull_request.title, 'ci skip')
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v2

--- a/Makefile
+++ b/Makefile
@@ -87,11 +87,11 @@ git-commit: ## commit outstading git changes and push to remote
 	@git config --global user.email "actions@users.noreply.github.com"
 	@git remote add publisher https://$(GITHUB_TOKEN)@github.com/$(GITHUB_REPOSITORY).git
 
-	@cd $(LOCAL_PATH)
-	@git checkout master
-	@git add -A -- .
-	@git commit -m "[ci skip] Automated publish for $(GITHUB_SHA)" || exit 0
-	@git push -u publisher master
+	@cd $(LOCAL_PATH) && \
+		git checkout master && \
+		git add -A -- . && \
+		git commit -m "[ci skip] Automated publish for $(GITHUB_SHA)" || exit 0 && \
+		git push -u publisher master
 
 hook/%: export COMMIT_MSG?=$(shell git log -1 --pretty=%B)
 hook/%: export GITHUB_SHA?=$(shell git rev-parse HEAD)


### PR DESCRIPTION
I forgot I was in make-land when using `cd` in the `git-commit` target. This afforded me the opportunity to fix the `ci skip` support which was not configured correctly for PRs.