### PR TITLE
Fix GITHUB_REPOSITORY value

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -60,8 +60,8 @@ jobs:
         run: make -C main push-all
       - name: Push Wiki to GitHub
         if: github.ref == 'refs/heads/master'
-        run: make -C main git-commit
+        # Pass GITHUB_REPOSITORY directly to avoid conflict with GitHub Actions built-in env var
+        run: make -C main git-commit GITHUB_REPOSITORY='${{ github.repository }}.wiki'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITHUB_REPOSITORY: ${{github.repository}}.wiki
           LOCAL_PATH: ../wiki


### PR DESCRIPTION
`GITHUB_REPOSITORY` is a built-in env var for GitHub Actions. We cannot override it via env vars when trying to push to the wiki repo. Pass the desired value directly on the command line instead.