### PR TITLE
Resolve Docker lint (hadolint) errors

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,6 +21,8 @@ repos:
         name: Hadolint linter
         description: Runs Hadolint to check for Dockerfile best practices
         language: system
+        # Exclude ppc64le Dockerfile since cannot check their build easily
+        exclude: ppc64
         types:
           - dockerfile
         entry: hadolint

--- a/examples/docker-compose/notebook/Dockerfile
+++ b/examples/docker-compose/notebook/Dockerfile
@@ -4,12 +4,13 @@
 # Pick your favorite docker-stacks image
 FROM jupyter/minimal-notebook:55d5ca6be183
 
-USER jovyan
-
-# Add permanent pip/conda installs, data files, other user libs here
-# e.g., RUN pip install jupyter_dashboards
-
 USER root
 
 # Add permanent apt-get installs and other root commands here
 # e.g., RUN apt-get install npm nodejs
+
+USER $NB_UID
+
+# Switch back to jovyan to avoid accidental container runs as root
+# Add permanent pip/conda installs, data files, other user libs here
+# e.g., RUN pip install jupyter_dashboards

--- a/examples/make-deploy/Dockerfile
+++ b/examples/make-deploy/Dockerfile
@@ -4,12 +4,13 @@
 # Pick your favorite docker-stacks image
 FROM jupyter/minimal-notebook:2d125a7161b5
 
-USER jovyan
-
-# Add permanent pip/conda installs, data files, other user libs here
-# e.g., RUN pip install jupyter_dashboards
-
 USER root
 
 # Add permanent apt-get installs and other root commands here
 # e.g., RUN apt-get install npm nodejs
+
+USER $NB_UID
+
+# Switch back to jovyan to avoid accidental container runs as root
+# Add permanent pip/conda installs, data files, other user libs here
+# e.g., RUN pip install jupyter_dashboards


### PR DESCRIPTION
- Exclude `ppc64` `Dockerfiles` from the linting in pre-commit since we cannot check their build easily and so fix the lint errors without breaking something (already excluded in the `Makefile`)
- Fix examples `Dockerfiles` to invert root and jovyan user instructions ("Last user should not be root" `DL3002`)

Best