### PR TITLE
Add -f option with groupadd to gracefully exit when adding existing groups

### DIFF
--- a/base-notebook/start.sh
+++ b/base-notebook/start.sh
@@ -80,7 +80,7 @@ if [ $(id -u) == 0 ] ; then
     if [ "$NB_UID" != $(id -u $NB_USER) ] || [ "$NB_GID" != $(id -g $NB_USER) ]; then
         echo "Set user $NB_USER UID:GID to: $NB_UID:$NB_GID"
         if [ "$NB_GID" != $(id -g $NB_USER) ]; then
-            groupadd -g $NB_GID -o ${NB_GROUP:-${NB_USER}}
+            groupadd -f -g $NB_GID -o ${NB_GROUP:-${NB_USER}}
         fi
         userdel $NB_USER
         useradd --home /home/$NB_USER -u $NB_UID -g $NB_GID -G 100 -l $NB_USER


### PR DESCRIPTION
Starting the container with `--user root`, as indicated by the [Docker Options section of the docs](https://jupyter-docker-stacks.readthedocs.io/en/latest/using/common.html#docker-options) in conjunction with a script using the `start-notebook.d` or the `before-notebook.d` hooks that set a custom`NB_UID`, `NB_UID`, and using the standard `NB_USER` (jovyan) environment variables results in the container exiting stating that the groupadd failed because the `jovyan` group already exists.

This fix adds the `-f` flag to the `groupadd` command to either add the [group if it doesn't exist or exit gracefully if it does exist](http://manpages.ubuntu.com/manpages/cosmic/man8/groupadd.8.html).

Another viable option is to use `groupadd --gid $NB_GID --non-unique ${NB_GROUP:-${NB_USER}}` as done in PR #1052 

Might be related to #956 #885 