### PR TITLE
Stack update

### DIFF
--- a/base-notebook/Dockerfile
+++ b/base-notebook/Dockerfile
@@ -4,7 +4,7 @@
 # Ubuntu 20.04 (focal)
 # https://hub.docker.com/_/ubuntu/?tab=tags&name=focal
 # OS/ARCH: linux/amd64
-ARG ROOT_CONTAINER=ubuntu:focal-20200703@sha256:d5a6519d9f048100123c568eb83f7ef5bfcad69b01424f420f17c932b00dea76
+ARG ROOT_CONTAINER=ubuntu:focal-20200729@sha256:6f2fb2f9fb5582f8b587837afd6ea8f37d8d1d9e41168c90f410a6ef15fa8ce5
 
 ARG BASE_CONTAINER=$ROOT_CONTAINER
 FROM $BASE_CONTAINER
@@ -114,9 +114,9 @@ RUN conda install --quiet --yes 'tini=0.18.0' && \
 # Do all this in a single RUN command to avoid duplicating all of the
 # files across image layers when the permissions change
 RUN conda install --quiet --yes \
-    'notebook=6.1.3' \
+    'notebook=6.1.4' \
     'jupyterhub=1.1.0' \
-    'jupyterlab=2.2.5' && \
+    'jupyterlab=2.2.7' && \
     conda clean --all -f -y && \
     npm cache clean --force && \
     jupyter notebook --generate-config && \

--- a/base-notebook/Dockerfile
+++ b/base-notebook/Dockerfile
@@ -4,7 +4,7 @@
 # Ubuntu 20.04 (focal)
 # https://hub.docker.com/_/ubuntu/?tab=tags&name=focal
 # OS/ARCH: linux/amd64
-ARG ROOT_CONTAINER=ubuntu:focal-20200729@sha256:6f2fb2f9fb5582f8b587837afd6ea8f37d8d1d9e41168c90f410a6ef15fa8ce5
+ARG ROOT_CONTAINER=ubuntu:focal-20200916@sha256:028d7303257c7f36c721b40099bf5004a41f666a54c0896d5f229f1c0fd99993
 
 ARG BASE_CONTAINER=$ROOT_CONTAINER
 FROM $BASE_CONTAINER
@@ -18,6 +18,17 @@ ARG NB_GID="100"
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 USER root
+
+# Miniconda installation
+# Default values can be overridden at build time
+# (ARGS are in lower case to distinguish them from ENV)
+# Check https://repo.anaconda.com/miniconda/
+# Miniconda archive to install
+ARG miniconda_version="4.8.3"
+# Archive MD5 checksum
+ARG miniconda_checksum="d63adf39f2c220950a063e0529d4ff74"
+# Conda version that can be different from the archive
+ARG conda_version="4.8.5"
 
 # Install all OS dependencies for notebook server that starts but lacks all
 # features (e.g., download as all possible file formats)
@@ -76,15 +87,15 @@ RUN mkdir /home/$NB_USER/work && \
     fix-permissions /home/$NB_USER
 
 # Install conda as jovyan and check the md5 sum provided on the download site
-ENV MINICONDA_VERSION=4.8.3 \
-    MINICONDA_MD5=d63adf39f2c220950a063e0529d4ff74 \
-    CONDA_VERSION=4.8.3
+ENV MINICONDA_VERSION="${miniconda_version}" \
+    CONDA_VERSION="${conda_version}"
 
 WORKDIR /tmp
 RUN wget --quiet https://repo.continuum.io/miniconda/Miniconda3-py38_${MINICONDA_VERSION}-Linux-x86_64.sh && \
-    echo "${MINICONDA_MD5} *Miniconda3-py38_${MINICONDA_VERSION}-Linux-x86_64.sh" | md5sum -c - && \
+    echo "${miniconda_checksum} *Miniconda3-py38_${MINICONDA_VERSION}-Linux-x86_64.sh" | md5sum -c - && \
     /bin/bash Miniconda3-py38_${MINICONDA_VERSION}-Linux-x86_64.sh -f -b -p $CONDA_DIR && \
     rm Miniconda3-py38_${MINICONDA_VERSION}-Linux-x86_64.sh && \
+    # Conda configuration see https://conda.io/projects/conda/en/latest/configuration.html
     echo "conda ${CONDA_VERSION}" >> $CONDA_DIR/conda-meta/pinned && \
     conda config --system --prepend channels conda-forge && \
     conda config --system --set auto_update_conda false && \
@@ -92,7 +103,7 @@ RUN wget --quiet https://repo.continuum.io/miniconda/Miniconda3-py38_${MINICONDA
     conda config --system --set channel_priority strict && \
     if [ ! $PYTHON_VERSION = 'default' ]; then conda install --yes python=$PYTHON_VERSION; fi && \
     conda list python | grep '^python ' | tr -s ' ' | cut -d '.' -f 1,2 | sed 's/$/.*/' >> $CONDA_DIR/conda-meta/pinned && \
-    conda install --quiet --yes conda && \
+    conda install --quiet --yes "conda=${CONDA_VERSION}" && \
     conda install --quiet --yes pip && \
     conda update --all --quiet --yes && \
     conda clean --all -f -y && \
@@ -116,7 +127,7 @@ RUN conda install --quiet --yes 'tini=0.18.0' && \
 RUN conda install --quiet --yes \
     'notebook=6.1.4' \
     'jupyterhub=1.1.0' \
-    'jupyterlab=2.2.7' && \
+    'jupyterlab=2.2.8' && \
     conda clean --all -f -y && \
     npm cache clean --force && \
     jupyter notebook --generate-config && \

--- a/datascience-notebook/Dockerfile
+++ b/datascience-notebook/Dockerfile
@@ -14,6 +14,14 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 USER root
 
+# Julia installation
+# Default values can be overridden at build time
+# (ARGS are in lower case to distinguish them from ENV)
+# Check https://julialang.org/downloads/
+ARG julia_version="1.5.1"
+# SHA256 checksum
+ARG julia_checksum="f5d37cb7fe40e3a730f721da8f7be40310f133220220949939d8f892ce2e86e3"
+
 # R pre-requisites
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
@@ -24,16 +32,16 @@ RUN apt-get update && \
 
 # Julia dependencies
 # install Julia packages in /opt/julia instead of $HOME
-ENV JULIA_DEPOT_PATH=/opt/julia
-ENV JULIA_PKGDIR=/opt/julia
-ENV JULIA_VERSION=1.5.0
+ENV JULIA_DEPOT_PATH=/opt/julia \
+    JULIA_PKGDIR=/opt/julia \
+    JULIA_VERSION="${julia_version}"
 
 WORKDIR /tmp
 
 # hadolint ignore=SC2046
 RUN mkdir "/opt/julia-${JULIA_VERSION}" && \
     wget -q https://julialang-s3.julialang.org/bin/linux/x64/$(echo "${JULIA_VERSION}" | cut -d. -f 1,2)"/julia-${JULIA_VERSION}-linux-x86_64.tar.gz" && \
-    echo "be7af676f8474afce098861275d28a0eb8a4ece3f83a11027e3554dcdecddb91 *julia-${JULIA_VERSION}-linux-x86_64.tar.gz" | sha256sum -c - && \
+    echo "${julia_checksum} *julia-${JULIA_VERSION}-linux-x86_64.tar.gz" | sha256sum -c - && \
     tar xzf "julia-${JULIA_VERSION}-linux-x86_64.tar.gz" -C "/opt/julia-${JULIA_VERSION}" --strip-components=1 && \
     rm "/tmp/julia-${JULIA_VERSION}-linux-x86_64.tar.gz"
 RUN ln -fs /opt/julia-*/bin/julia /usr/local/bin/julia
@@ -50,13 +58,13 @@ USER $NB_UID
 
 # R packages including IRKernel which gets installed globally.
 RUN conda install --quiet --yes \
-    'r-base=3.6.3' \
+    'r-base=4.0.2' \
     'r-caret=6.0*' \
     'r-crayon=1.3*' \
     'r-devtools=2.3*' \
-    'r-forecast=8.12*' \
+    'r-forecast=8.13*' \
     'r-hexbin=1.28*' \
-    'r-htmltools=0.4*' \
+    'r-htmltools=0.5*' \
     'r-htmlwidgets=1.5*' \
     'r-irkernel=1.1*' \
     'r-nycflights13=1.0*' \
@@ -64,11 +72,11 @@ RUN conda install --quiet --yes \
     'r-randomforest=4.6*' \
     'r-rcurl=1.98*' \
     'r-reshape2=1.4*' \
-    'r-rmarkdown=2.1*' \
+    'r-rmarkdown=2.3*' \
     'r-rsqlite=2.2*' \
-    'r-shiny=1.4*' \
+    'r-shiny=1.5*' \
     'r-tidyverse=1.3*' \
-    'rpy2=3.1*' \
+    'rpy2=3.3*' \
     && \
     conda clean --all -f -y && \
     fix-permissions "${CONDA_DIR}" && \

--- a/datascience-notebook/Dockerfile
+++ b/datascience-notebook/Dockerfile
@@ -58,7 +58,7 @@ USER $NB_UID
 
 # R packages including IRKernel which gets installed globally.
 RUN conda install --quiet --yes \
-    'r-base=4.0.2' \
+    'r-base=3.6.3' \
     'r-caret=6.0*' \
     'r-crayon=1.3*' \
     'r-devtools=2.3*' \

--- a/pyspark-notebook/Dockerfile
+++ b/pyspark-notebook/Dockerfile
@@ -50,7 +50,8 @@ ENV PYTHONPATH="${SPARK_HOME}/python:${SPARK_HOME}/python/lib/py4j-${py4j_versio
 USER $NB_UID
 
 # Install pyarrow
-RUN conda install --quiet -y 'pyarrow' && \
+RUN conda install --quiet --yes --satisfied-skip-solve \
+    'pyarrow=1.0.*' && \
     conda clean --all -f -y && \
     fix-permissions "${CONDA_DIR}" && \
     fix-permissions "/home/${NB_USER}"

--- a/r-notebook/Dockerfile
+++ b/r-notebook/Dockerfile
@@ -25,22 +25,22 @@ USER $NB_UID
 
 # R packages
 RUN conda install --quiet --yes \
-    'r-base=4.0.0' \
+    'r-base=4.0.2' \
     'r-caret=6.*' \
     'r-crayon=1.3*' \
     'r-devtools=2.3*' \
-    'r-forecast=8.12*' \
+    'r-forecast=8.13*' \
     'r-hexbin=1.28*' \
-    'r-htmltools=0.4*' \
+    'r-htmltools=0.5*' \
     'r-htmlwidgets=1.5*' \
     'r-irkernel=1.1*' \
     'r-nycflights13=1.0*' \
     'r-randomforest=4.6*' \
     'r-rcurl=1.98*' \
-    'r-rmarkdown=2.2*' \
+    'r-rmarkdown=2.3*' \
     'r-rodbc=1.3*' \
     'r-rsqlite=2.2*' \
-    'r-shiny=1.4*' \
+    'r-shiny=1.5*' \
     'r-tidyverse=1.3*' \
     'unixodbc=2.3.*' \
     'r-tidymodels=0.1*' \

--- a/scipy-notebook/Dockerfile
+++ b/scipy-notebook/Dockerfile
@@ -18,30 +18,31 @@ USER $NB_UID
 RUN conda install --quiet --yes \
     'beautifulsoup4=4.9.*' \
     'conda-forge::blas=*=openblas' \
-    'bokeh=2.1.*' \
+    'bokeh=2.2.*' \
     'bottleneck=1.3.*' \
-    'cloudpickle=1.5.*' \
+    'cloudpickle=1.6.*' \
     'cython=0.29.*' \
-    'dask=2.20.*' \
+    'dask=2.26.*' \
     'dill=0.3.*' \
     'h5py=2.10.*' \
+    # hdf5 update to > 1.10 fails resolving deps
     'hdf5=1.10.*' \
     'ipywidgets=7.5.*' \
     'ipympl=0.5.*'\
-    'matplotlib-base=3.2.*' \
-    # numba update to 0.49 fails resolving deps.
+    'matplotlib-base=3.3.*' \
+    # numba update to > 0.49 fails resolving deps
     'numba=0.48.*' \
     'numexpr=2.7.*' \
     'pandas=1.1.*' \
     'patsy=0.5.*' \
-    'protobuf=3.12.*' \
+    'protobuf=3.13.*' \
     'pytables=3.6.*' \
     'scikit-image=0.17.*' \
     'scikit-learn=0.23.*' \
     'scipy=1.5.*' \
-    'seaborn=0.10.*' \
+    'seaborn=0.11.*' \
     'sqlalchemy=1.3.*' \
-    'statsmodels=0.11.*' \
+    'statsmodels=0.12.*' \
     'sympy=1.6.*' \
     'vincent=0.4.*' \
     'widgetsnbextension=3.5.*'\

--- a/scipy-notebook/Dockerfile
+++ b/scipy-notebook/Dockerfile
@@ -22,20 +22,17 @@ RUN conda install --quiet --yes \
     'bottleneck=1.3.*' \
     'cloudpickle=1.6.*' \
     'cython=0.29.*' \
-    'dask=2.26.*' \
+    'dask=2.25.*' \
     'dill=0.3.*' \
     'h5py=2.10.*' \
-    # hdf5 update to > 1.10 fails resolving deps
-    'hdf5=1.10.*' \
     'ipywidgets=7.5.*' \
     'ipympl=0.5.*'\
     'matplotlib-base=3.3.*' \
-    # numba update to > 0.49 fails resolving deps
-    'numba=0.48.*' \
+    'numba=0.51.*' \
     'numexpr=2.7.*' \
     'pandas=1.1.*' \
     'patsy=0.5.*' \
-    'protobuf=3.13.*' \
+    'protobuf=3.12.*' \
     'pytables=3.6.*' \
     'scikit-image=0.17.*' \
     'scikit-learn=0.23.*' \

--- a/tensorflow-notebook/Dockerfile
+++ b/tensorflow-notebook/Dockerfile
@@ -7,6 +7,6 @@ LABEL maintainer="Jupyter Project <jupyter@googlegroups.com>"
 
 # Install Tensorflow
 RUN pip install --quiet --no-cache-dir \
-    'tensorflow==2.2.0' && \
+    'tensorflow==2.3.0' && \
     fix-permissions "${CONDA_DIR}" && \
     fix-permissions "/home/${NB_USER}"


### PR DESCRIPTION
Following images updated

## `base-notebook`

Updated

- Ubuntu
- `notebook`
- `jupyterlab`
- `conda`

Improved the way Miniconda is installed to
 
- enable overriding defaults by using arguments
- permit to install a different version of `conda` than the default provided in the Miniconda installer

## `scipy-notebook`

Updated

- `bokeh`
- `cloudpickle`
- `dask`
- `matplotlib-base`
- `protobuf`
- `seaborn`
- `statsmodel`

Dropped `hdf5` installation specification since it's a dependency of `h5py`.

## `tensorflow-notebook`

Updated

- `tensorflow`

## `datascience-notebook`

Updated

- `r-forecast`
- `r-htmltools`
- `r-rmarkdown`
- `r-shiny`
- `rpy2`
- Julia 

Improved the way Julia is installed to enable overriding Julia version by using arguments.

Failed to update

```bash
Package          Current    Newest
---------------  ---------  --------

r-base       3.6.3      4.0.2
```

## `r-notebook`

Updated

- `r-base`
- `r-forecast`
- `r-htmltools`
- `r-rmarkdown`
- `r-shiny`

## `pyspark-notebook`

Pin version of `pyarrow` in order to be consistent with other packages installation

## `all-spark-notebook`

Failed to update

```bash
Package          Current    Newest
---------------  ---------  --------

r-base       3.6.3      4.0.2
```