### PR TITLE
Activate conda base environment by default

### DIFF
--- a/base-notebook/Dockerfile
+++ b/base-notebook/Dockerfile
@@ -84,7 +84,7 @@ WORKDIR /tmp
 RUN wget --quiet https://repo.continuum.io/miniconda/Miniconda3-py38_${MINICONDA_VERSION}-Linux-x86_64.sh && \
     echo "${MINICONDA_MD5} *Miniconda3-py38_${MINICONDA_VERSION}-Linux-x86_64.sh" | md5sum -c - && \
     /bin/bash Miniconda3-py38_${MINICONDA_VERSION}-Linux-x86_64.sh -f -b -p $CONDA_DIR && \
-    printf "__conda_setup=\"\$(\"${CONDA_DIR}bin/conda\" \"shell.bash\" \"hook\" 2> /dev/null)\"\nif [ $? -eq 0 ]; then\n    eval \"\$__conda_setup\"\nelse\n    if [ -f \"${CONDA_DIR}etc/profile.d/conda.sh\" ]; then\n        . \"${CONDA_DIR}etc/profile.d/conda.sh\"\n    else\n         export PATH=\"${CONDA_DIR}bin:\$PATH\"\n    fi\nfi\nunset __conda_setup\n" > ${HOME}/.profile && \
+    printf '__conda_setup=\"\$(\"%s/bin/conda\" \"shell.bash\" \"hook\" 2> /dev/null)\"\nif [ $? -eq 0 ]; then\n    eval \"\$__conda_setup\"\nelse\n    if [ -f \"%s/etc/profile.d/conda.sh\" ]; then\n        . \"%s/etc/profile.d/conda.sh\"\n    else\n         export PATH=\"%s/bin:\$PATH\"\n    fi\nfi\nunset __conda_setup\n' "${CONDA_DIR}" > ${HOME}/.profile && \
     rm Miniconda3-py38_${MINICONDA_VERSION}-Linux-x86_64.sh && \
     echo "conda ${CONDA_VERSION}" >> $CONDA_DIR/conda-meta/pinned && \
     conda config --system --prepend channels conda-forge && \

--- a/base-notebook/Dockerfile
+++ b/base-notebook/Dockerfile
@@ -84,7 +84,7 @@ WORKDIR /tmp
 RUN wget --quiet https://repo.continuum.io/miniconda/Miniconda3-py38_${MINICONDA_VERSION}-Linux-x86_64.sh && \
     echo "${MINICONDA_MD5} *Miniconda3-py38_${MINICONDA_VERSION}-Linux-x86_64.sh" | md5sum -c - && \
     /bin/bash Miniconda3-py38_${MINICONDA_VERSION}-Linux-x86_64.sh -f -b -p $CONDA_DIR && \
-    echo "__conda_setup=\"\$(\"${CONDA_DIR}bin/conda\" \"shell.bash\" \"hook\" 2> /dev/null)\"\nif [ $? -eq 0 ]; then\n    eval \"\$__conda_setup\"\nelse\n    if [ -f \"${CONDA_DIR}etc/profile.d/conda.sh\" ]; then\n        . \"${CONDA_DIR}etc/profile.d/conda.sh\"\n    else\n         export PATH=\"${CONDA_DIR}bin:\$PATH\"\n    fi\nfi\nunset __conda_setup\n" > ${HOME}/.profile && \
+    printf "__conda_setup=\"\$(\"${CONDA_DIR}bin/conda\" \"shell.bash\" \"hook\" 2> /dev/null)\"\nif [ $? -eq 0 ]; then\n    eval \"\$__conda_setup\"\nelse\n    if [ -f \"${CONDA_DIR}etc/profile.d/conda.sh\" ]; then\n        . \"${CONDA_DIR}etc/profile.d/conda.sh\"\n    else\n         export PATH=\"${CONDA_DIR}bin:\$PATH\"\n    fi\nfi\nunset __conda_setup\n" > ${HOME}/.profile && \
     rm Miniconda3-py38_${MINICONDA_VERSION}-Linux-x86_64.sh && \
     echo "conda ${CONDA_VERSION}" >> $CONDA_DIR/conda-meta/pinned && \
     conda config --system --prepend channels conda-forge && \

--- a/base-notebook/Dockerfile
+++ b/base-notebook/Dockerfile
@@ -84,7 +84,7 @@ WORKDIR /tmp
 RUN wget --quiet https://repo.continuum.io/miniconda/Miniconda3-py38_${MINICONDA_VERSION}-Linux-x86_64.sh && \
     echo "${MINICONDA_MD5} *Miniconda3-py38_${MINICONDA_VERSION}-Linux-x86_64.sh" | md5sum -c - && \
     /bin/bash Miniconda3-py38_${MINICONDA_VERSION}-Linux-x86_64.sh -f -b -p $CONDA_DIR && \
-    printf '__conda_setup=\"\$(\"%s/bin/conda\" \"shell.bash\" \"hook\" 2> /dev/null)\"\nif [ $? -eq 0 ]; then\n    eval \"\$__conda_setup\"\nelse\n    if [ -f \"%s/etc/profile.d/conda.sh\" ]; then\n        . \"%s/etc/profile.d/conda.sh\"\n    else\n         export PATH=\"%s/bin:\$PATH\"\n    fi\nfi\nunset __conda_setup\n' "${CONDA_DIR}" "${CONDA_DIR}" "${CONDA_DIR}" "${CONDA_DIR}" > ${HOME}/.profile && \
+    printf "__conda_setup=\"\$(\"%s/bin/conda\" \"shell.bash\" \"hook\" 2> /dev/null)\"\nif [ $? -eq 0 ]; then\n    eval \"\$__conda_setup\"\nelse\n    if [ -f \"%s/etc/profile.d/conda.sh\" ]; then\n        . \"%s/etc/profile.d/conda.sh\"\n    else\n         export PATH=\"%s/bin:\$PATH\"\n    fi\nfi\nunset __conda_setup\n" "${CONDA_DIR}" "${CONDA_DIR}" "${CONDA_DIR}" "${CONDA_DIR}" > ${HOME}/.profile && \
     rm Miniconda3-py38_${MINICONDA_VERSION}-Linux-x86_64.sh && \
     echo "conda ${CONDA_VERSION}" >> $CONDA_DIR/conda-meta/pinned && \
     conda config --system --prepend channels conda-forge && \

--- a/base-notebook/Dockerfile
+++ b/base-notebook/Dockerfile
@@ -84,6 +84,7 @@ WORKDIR /tmp
 RUN wget --quiet https://repo.continuum.io/miniconda/Miniconda3-py38_${MINICONDA_VERSION}-Linux-x86_64.sh && \
     echo "${MINICONDA_MD5} *Miniconda3-py38_${MINICONDA_VERSION}-Linux-x86_64.sh" | md5sum -c - && \
     /bin/bash Miniconda3-py38_${MINICONDA_VERSION}-Linux-x86_64.sh -f -b -p $CONDA_DIR && \
+    echo "__conda_setup=\"\$(\"${CONDA_DIR}bin/conda\" \"shell.bash\" \"hook\" 2> /dev/null)\"\nif [ $? -eq 0 ]; then\n    eval \"\$__conda_setup\"\nelse\n    if [ -f \"${CONDA_DIR}etc/profile.d/conda.sh\" ]; then\n        . \"${CONDA_DIR}etc/profile.d/conda.sh\"\n    else\n         export PATH=\"${CONDA_DIR}bin:\$PATH\"\n    fi\nfi\nunset __conda_setup\n" > ${HOME}/.profile && \
     rm Miniconda3-py38_${MINICONDA_VERSION}-Linux-x86_64.sh && \
     echo "conda ${CONDA_VERSION}" >> $CONDA_DIR/conda-meta/pinned && \
     conda config --system --prepend channels conda-forge && \

--- a/base-notebook/Dockerfile
+++ b/base-notebook/Dockerfile
@@ -87,7 +87,6 @@ WORKDIR /tmp
 RUN wget --quiet https://repo.continuum.io/miniconda/Miniconda3-py38_${MINICONDA_VERSION}-Linux-x86_64.sh && \
     echo "${MINICONDA_MD5} *Miniconda3-py38_${MINICONDA_VERSION}-Linux-x86_64.sh" | md5sum -c - && \
     /bin/bash Miniconda3-py38_${MINICONDA_VERSION}-Linux-x86_64.sh -f -b -p $CONDA_DIR && \
-    printf "__conda_setup=\"\$(\"%s/bin/conda\" \"shell.bash\" \"hook\" 2> /dev/null)\"\nif [ $? -eq 0 ]; then\n    eval \"\$__conda_setup\"\nelse\n    if [ -f \"%s/etc/profile.d/conda.sh\" ]; then\n        . \"%s/etc/profile.d/conda.sh\"\n    else\n         export PATH=\"%s/bin:\$PATH\"\n    fi\nfi\nunset __conda_setup\n" "${CONDA_DIR}" "${CONDA_DIR}" "${CONDA_DIR}" "${CONDA_DIR}" > ${HOME}/.profile && \
     rm Miniconda3-py38_${MINICONDA_VERSION}-Linux-x86_64.sh && \
     echo "conda ${CONDA_VERSION}" >> $CONDA_DIR/conda-meta/pinned && \
     conda config --system --prepend channels conda-forge && \

--- a/base-notebook/Dockerfile
+++ b/base-notebook/Dockerfile
@@ -84,7 +84,7 @@ WORKDIR /tmp
 RUN wget --quiet https://repo.continuum.io/miniconda/Miniconda3-py38_${MINICONDA_VERSION}-Linux-x86_64.sh && \
     echo "${MINICONDA_MD5} *Miniconda3-py38_${MINICONDA_VERSION}-Linux-x86_64.sh" | md5sum -c - && \
     /bin/bash Miniconda3-py38_${MINICONDA_VERSION}-Linux-x86_64.sh -f -b -p $CONDA_DIR && \
-    printf '__conda_setup=\"\$(\"%s/bin/conda\" \"shell.bash\" \"hook\" 2> /dev/null)\"\nif [ $? -eq 0 ]; then\n    eval \"\$__conda_setup\"\nelse\n    if [ -f \"%s/etc/profile.d/conda.sh\" ]; then\n        . \"%s/etc/profile.d/conda.sh\"\n    else\n         export PATH=\"%s/bin:\$PATH\"\n    fi\nfi\nunset __conda_setup\n' "${CONDA_DIR}" > ${HOME}/.profile && \
+    printf '__conda_setup=\"\$(\"%s/bin/conda\" \"shell.bash\" \"hook\" 2> /dev/null)\"\nif [ $? -eq 0 ]; then\n    eval \"\$__conda_setup\"\nelse\n    if [ -f \"%s/etc/profile.d/conda.sh\" ]; then\n        . \"%s/etc/profile.d/conda.sh\"\n    else\n         export PATH=\"%s/bin:\$PATH\"\n    fi\nfi\nunset __conda_setup\n' "${CONDA_DIR}" "${CONDA_DIR}" "${CONDA_DIR}" "${CONDA_DIR}" > ${HOME}/.profile && \
     rm Miniconda3-py38_${MINICONDA_VERSION}-Linux-x86_64.sh && \
     echo "conda ${CONDA_VERSION}" >> $CONDA_DIR/conda-meta/pinned && \
     conda config --system --prepend channels conda-forge && \

--- a/base-notebook/Dockerfile
+++ b/base-notebook/Dockerfile
@@ -53,7 +53,10 @@ COPY fix-permissions /usr/local/bin/fix-permissions
 RUN chmod a+rx /usr/local/bin/fix-permissions
 
 # Enable prompt color in the skeleton .bashrc before creating the default NB_USER
-RUN sed -i 's/^#force_color_prompt=yes/force_color_prompt=yes/' /etc/skel/.bashrc
+# hadolint ignore=SC2016
+RUN sed -i 's/^#force_color_prompt=yes/force_color_prompt=yes/' /etc/skel/.bashrc && \
+   # Add call to conda init script see https://stackoverflow.com/a/58081608/4413446
+   echo 'eval "$(command conda shell.bash hook 2> /dev/null)"' >> /etc/skel/.bashrc 
 
 # Create NB_USER with name jovyan user with UID=1000 and in the 'users' group
 # and make sure these dirs are writable by the `users` group.


### PR DESCRIPTION
Some conda packages rely in the `conda activate` to set the corresponding environment variables, therefore just including the `bin` directory in the `PATH` is not sufficient.