### PR TITLE
recipes: use COPY with --chown for jovyan's files

### DIFF
--- a/docs/using/recipes.md
+++ b/docs/using/recipes.md
@@ -48,7 +48,7 @@ packages desired. Next, create a new Dockerfile like the one shown below.
 # Start from a core stack version
 FROM jupyter/datascience-notebook:9f9e5ca8fe5a
 # Install from requirements.txt file
-COPY requirements.txt /tmp/
+COPY --chown=${NB_UID}:${NB_GID} requirements.txt /tmp/
 RUN pip install --requirement /tmp/requirements.txt && \
     fix-permissions $CONDA_DIR && \
     fix-permissions /home/$NB_USER
@@ -60,7 +60,7 @@ For conda, the Dockerfile is similar:
 # Start from a core stack version
 FROM jupyter/datascience-notebook:9f9e5ca8fe5a
 # Install from requirements.txt file
-COPY requirements.txt /tmp/
+COPY --chown=${NB_UID}:${NB_GID} requirements.txt /tmp/
 RUN conda install --yes --file /tmp/requirements.txt && \
     fix-permissions $CONDA_DIR && \
     fix-permissions /home/$NB_USER
@@ -118,7 +118,7 @@ RUN conda create --quiet --yes -p $CONDA_DIR/envs/$conda_env python=$py_ver ipyt
 # alternatively, you can comment out the lines above and uncomment those below
 # if you'd prefer to use a YAML file present in the docker build context
 
-# COPY environment.yml /home/$NB_USER/tmp/
+# COPY --chown=${NB_UID}:${NB_GID} environment.yml /home/$NB_USER/tmp/
 # RUN cd /home/$NB_USER/tmp/ && \
 #     conda env create -p $CONDA_DIR/envs/$conda_env -f environment.yml && \
 #     conda clean --all -f -y


### PR DESCRIPTION
By default, [Dockerfile's `COPY` creates files and directories with UID and GID 0](https://docs.docker.com/engine/reference/builder/#copy). When we put them in `jovyan`'s `$HOME` or want `jovyan` to manipulate these files, they should be owned by `jovyan` instead.

Specifically [recipe "Add a Python 3.x environment"](https://jupyter-docker-stacks.readthedocs.io/en/latest/using/recipes.html#add-a-python-3-x-environment) failed with a "permission denied" error when the code for using an `environment.yml` file was un-commented. I assume some of the other recipes might have failed like that, too, but I didn't test them.

(I didn't make this change for [recipe "Use jupyter/all-spark-notebooks with an existing Spark/YARN cluster"](https://jupyter-docker-stacks.readthedocs.io/en/latest/using/recipes.html#use-jupyter-all-spark-notebooks-with-an-existing-spark-yarn-cluster)), as `/usr/local/hadoop-2.7.3/etc/hadoop/` probably _should_ be owned by `root`.)