### PR TITLE
Update docker stacks 2020-11-20

### DIFF
--- a/all-spark-notebook/Dockerfile
+++ b/all-spark-notebook/Dockerfile
@@ -17,17 +17,17 @@ RUN apt-get update && \
     fonts-dejavu \
     gfortran \
     gcc && \
-    rm -rf /var/lib/apt/lists/*
+    apt-get clean && rm -rf /var/lib/apt/lists/*
 
 USER $NB_UID
 
 # R packages
 RUN conda install --quiet --yes \
-    'r-base=3.6.3' \
+    'r-base=4.0.3' \
     'r-ggplot2=3.3*' \
     'r-irkernel=1.1*' \
     'r-rcurl=1.98*' \
-    'r-sparklyr=1.2*' \
+    'r-sparklyr=1.4*' \
     && \
     conda clean --all -f -y && \
     fix-permissions "${CONDA_DIR}" && \

--- a/base-notebook/Dockerfile
+++ b/base-notebook/Dockerfile
@@ -4,7 +4,7 @@
 # Ubuntu 20.04 (focal)
 # https://hub.docker.com/_/ubuntu/?tab=tags&name=focal
 # OS/ARCH: linux/amd64
-ARG ROOT_CONTAINER=ubuntu:focal-20200916@sha256:028d7303257c7f36c721b40099bf5004a41f666a54c0896d5f229f1c0fd99993
+ARG ROOT_CONTAINER=ubuntu:focal-20200925@sha256:2e70e9c81838224b5311970dbf7ed16802fbfe19e7a70b3cbfa3d7522aa285b4
 
 ARG BASE_CONTAINER=$ROOT_CONTAINER
 FROM $BASE_CONTAINER
@@ -28,7 +28,7 @@ ARG miniconda_version="4.8.3"
 # Archive MD5 checksum
 ARG miniconda_checksum="d63adf39f2c220950a063e0529d4ff74"
 # Conda version that can be different from the archive
-ARG conda_version="4.8.5"
+ARG conda_version="4.9.0"
 
 # Install all OS dependencies for notebook server that starts but lacks all
 # features (e.g., download as all possible file formats)

--- a/datascience-notebook/Dockerfile
+++ b/datascience-notebook/Dockerfile
@@ -18,9 +18,9 @@ USER root
 # Default values can be overridden at build time
 # (ARGS are in lower case to distinguish them from ENV)
 # Check https://julialang.org/downloads/
-ARG julia_version="1.5.1"
+ARG julia_version="1.5.2"
 # SHA256 checksum
-ARG julia_checksum="f5d37cb7fe40e3a730f721da8f7be40310f133220220949939d8f892ce2e86e3"
+ARG julia_checksum="6da704fadcefa39725503e4c7a9cfa1a570ba8a647c4bd8de69a118f43584630"
 
 # R pre-requisites
 RUN apt-get update && \
@@ -28,7 +28,7 @@ RUN apt-get update && \
     fonts-dejavu \
     gfortran \
     gcc && \
-    rm -rf /var/lib/apt/lists/*
+    apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Julia dependencies
 # install Julia packages in /opt/julia instead of $HOME
@@ -58,26 +58,23 @@ USER $NB_UID
 
 # R packages including IRKernel which gets installed globally.
 RUN conda install --quiet --yes \
-    'r-base=3.6.3' \
+    'r-base=4.0.3'  \
     'r-caret=6.0*' \
     'r-crayon=1.3*' \
     'r-devtools=2.3*' \
-    'r-forecast=8.13*' \
+    'r-forecast=8.13*' \ 
     'r-hexbin=1.28*' \
     'r-htmltools=0.5*' \
-    'r-htmlwidgets=1.5*' \
+    'r-htmlwidgets=1.5*' \ 
     'r-irkernel=1.1*' \
     'r-nycflights13=1.0*' \
-    'r-plyr=1.8*' \
     'r-randomforest=4.6*' \
     'r-rcurl=1.98*' \
-    'r-reshape2=1.4*' \
-    'r-rmarkdown=2.3*' \
+    'r-rmarkdown=2.4*' \
     'r-rsqlite=2.2*' \
     'r-shiny=1.5*' \
     'r-tidyverse=1.3*' \
-    'rpy2=3.3*' \
-    && \
+    'rpy2=3.3*' && \
     conda clean --all -f -y && \
     fix-permissions "${CONDA_DIR}" && \
     fix-permissions "/home/${NB_USER}"

--- a/docs/using/selecting.md
+++ b/docs/using/selecting.md
@@ -11,6 +11,8 @@ Using one of the Jupyter Docker Stacks requires two choices:
 
 This section provides details about the first.
 
+Note: Deprecated feature or image content is displayed with ~~strikethrough~~ formatting.
+
 ## Core Stacks
 
 The Jupyter team maintains a set of Docker image definitions in the
@@ -48,8 +50,8 @@ and versioning strategy.
 
 - Everything in `jupyter/base-notebook`
 - [TeX Live](https://www.tug.org/texlive/) for notebook document conversion
-- [git](https://git-scm.com/), [emacs](https://www.gnu.org/software/emacs/) (actually `emacs-nox`),
-  [vi](https://vim.org/) (actually `vim-tiny`), [jed](https://www.jedsoft.org/jed/),
+- [git](https://git-scm.com/), ~~[emacs](https://www.gnu.org/software/emacs/) (actually `emacs-nox`)~~,
+  [vi](https://vim.org/) (actually `vim-tiny`),
   [nano](https://www.nano-editor.org/) (actually `nano-tiny`), tzdata, and unzip
 
 ### jupyter/r-notebook
@@ -63,12 +65,7 @@ and versioning strategy.
 - Everything in `jupyter/minimal-notebook` and its ancestor images
 - The [R](https://www.r-project.org/) interpreter and base environment
 - [IRKernel](https://irkernel.github.io/) to support R code in Jupyter notebooks
-- [tidyverse](https://www.tidyverse.org/) packages, including [ggplot2](http://ggplot2.org/),
-  [dplyr](http://dplyr.tidyverse.org/), [tidyr](http://tidyr.tidyverse.org/),
-  [readr](http://readr.tidyverse.org/), [purrr](http://purrr.tidyverse.org/),
-  [tibble](http://tibble.tidyverse.org/), [stringr](http://stringr.tidyverse.org/),
-  [lubridate](http://lubridate.tidyverse.org/), and
-  [broom](https://cran.r-project.org/web/packages/broom/vignettes/broom.html) from
+- [tidyverse](https://www.tidyverse.org/) packages from
   [conda-forge](https://conda-forge.github.io/feedstocks)
 - [devtools](https://cran.r-project.org/web/packages/devtools/index.html),
   [shiny](https://shiny.rstudio.com/), [rmarkdown](http://rmarkdown.rstudio.com/),

--- a/docs/using/selecting.md
+++ b/docs/using/selecting.md
@@ -11,8 +11,6 @@ Using one of the Jupyter Docker Stacks requires two choices:
 
 This section provides details about the first.
 
-Note: Deprecated feature or image content is displayed with ~~strikethrough~~ formatting.
-
 ## Core Stacks
 
 The Jupyter team maintains a set of Docker image definitions in the
@@ -50,8 +48,8 @@ and versioning strategy.
 
 - Everything in `jupyter/base-notebook`
 - [TeX Live](https://www.tug.org/texlive/) for notebook document conversion
-- [git](https://git-scm.com/), ~~[emacs](https://www.gnu.org/software/emacs/) (actually `emacs-nox`)~~,
-  [vi](https://vim.org/) (actually `vim-tiny`),
+- [git](https://git-scm.com/), [emacs](https://www.gnu.org/software/emacs/) (actually `emacs-nox`),
+  [vi](https://vim.org/) (actually `vim-tiny`), [jed](https://www.jedsoft.org/jed/),
   [nano](https://www.nano-editor.org/) (actually `nano-tiny`), tzdata, and unzip
 
 ### jupyter/r-notebook

--- a/minimal-notebook/Dockerfile
+++ b/minimal-notebook/Dockerfile
@@ -10,11 +10,11 @@ USER root
 # Install all OS dependencies for fully functional notebook server
 RUN apt-get update && apt-get install -yq --no-install-recommends \
     build-essential \
-    # Emacs installation is deprecated
     emacs-nox \
     vim-tiny \
     git \
     inkscape \
+    jed \
     libsm6 \
     libxext-dev \
     libxrender1 \

--- a/minimal-notebook/Dockerfile
+++ b/minimal-notebook/Dockerfile
@@ -10,11 +10,11 @@ USER root
 # Install all OS dependencies for fully functional notebook server
 RUN apt-get update && apt-get install -yq --no-install-recommends \
     build-essential \
+    # Emacs installation is deprecated
     emacs-nox \
     vim-tiny \
     git \
     inkscape \
-    jed \
     libsm6 \
     libxext-dev \
     libxrender1 \

--- a/pyspark-notebook/Dockerfile
+++ b/pyspark-notebook/Dockerfile
@@ -26,7 +26,7 @@ RUN apt-get -y update && \
     apt-get install --no-install-recommends -y \
     "openjdk-${openjdk_version}-jre-headless" \
     ca-certificates-java && \
-    rm -rf /var/lib/apt/lists/*
+    apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Spark installation
 WORKDIR /tmp
@@ -51,7 +51,7 @@ USER $NB_UID
 
 # Install pyarrow
 RUN conda install --quiet --yes --satisfied-skip-solve \
-    'pyarrow=1.0.*' && \
+    'pyarrow=2.0.*' && \
     conda clean --all -f -y && \
     fix-permissions "${CONDA_DIR}" && \
     fix-permissions "/home/${NB_USER}"

--- a/pyspark-notebook/Dockerfile
+++ b/pyspark-notebook/Dockerfile
@@ -51,7 +51,7 @@ USER $NB_UID
 
 # Install pyarrow
 RUN conda install --quiet --yes --satisfied-skip-solve \
-    'pyarrow=2.0.*' && \
+    'pyarrow=1.0.*' && \
     conda clean --all -f -y && \
     fix-permissions "${CONDA_DIR}" && \
     fix-permissions "/home/${NB_USER}"

--- a/r-notebook/Dockerfile
+++ b/r-notebook/Dockerfile
@@ -16,7 +16,7 @@ RUN apt-get update && \
     r-cran-rodbc \
     gfortran \
     gcc && \
-    rm -rf /var/lib/apt/lists/*
+    apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Fix for devtools https://github.com/conda-forge/r-devtools-feedstock/issues/4
 RUN ln -s /bin/tar /bin/gtar
@@ -25,7 +25,7 @@ USER $NB_UID
 
 # R packages
 RUN conda install --quiet --yes \
-    'r-base=4.0.2' \
+    'r-base=4.0.3' \
     'r-caret=6.*' \
     'r-crayon=1.3*' \
     'r-devtools=2.3*' \
@@ -37,7 +37,7 @@ RUN conda install --quiet --yes \
     'r-nycflights13=1.0*' \
     'r-randomforest=4.6*' \
     'r-rcurl=1.98*' \
-    'r-rmarkdown=2.3*' \
+    'r-rmarkdown=2.4*' \
     'r-rodbc=1.3*' \
     'r-rsqlite=2.2*' \
     'r-shiny=1.5*' \

--- a/scipy-notebook/Dockerfile
+++ b/scipy-notebook/Dockerfile
@@ -10,7 +10,7 @@ USER root
 # ffmpeg for matplotlib anim & dvipng+cm-super for latex labels
 RUN apt-get update && \
     apt-get install -y --no-install-recommends ffmpeg dvipng cm-super && \
-    rm -rf /var/lib/apt/lists/*
+    apt-get clean && rm -rf /var/lib/apt/lists/*
 
 USER $NB_UID
 
@@ -22,7 +22,7 @@ RUN conda install --quiet --yes \
     'bottleneck=1.3.*' \
     'cloudpickle=1.6.*' \
     'cython=0.29.*' \
-    'dask=2.25.*' \
+    'dask=2.30.*' \
     'dill=0.3.*' \
     'h5py=2.10.*' \
     'ipywidgets=7.5.*' \
@@ -32,7 +32,7 @@ RUN conda install --quiet --yes \
     'numexpr=2.7.*' \
     'pandas=1.1.*' \
     'patsy=0.5.*' \
-    'protobuf=3.12.*' \
+    'protobuf=3.13.*' \
     'pytables=3.6.*' \
     'scikit-image=0.17.*' \
     'scikit-learn=0.23.*' \

--- a/tensorflow-notebook/Dockerfile
+++ b/tensorflow-notebook/Dockerfile
@@ -7,6 +7,6 @@ LABEL maintainer="Jupyter Project <jupyter@googlegroups.com>"
 
 # Install Tensorflow
 RUN pip install --quiet --no-cache-dir \
-    'tensorflow==2.3.0' && \
+    'tensorflow==2.3.1' && \
     fix-permissions "${CONDA_DIR}" && \
     fix-permissions "/home/${NB_USER}"


### PR DESCRIPTION
The following changes have been made.

- `base-notebook`
  - `Changed`: Bump Ubuntu
  - `Changed`: Bump conda
  - `Fixed`: Add missing `apt-get clean`
- `scipy-notebook`
  - `Fixed`: Add missing `apt-get clean`
  - `Changed`: Bump `dask`
  - `Changed`: Bump `protobuf`
- `r-notebook`
  - `Changed`: Bump `r-base`
  - `Changed`: Bump `r-rmarkdown`
  - `Removed`: The description of `tidyverse` packages because it's not the place to do that and it will always be obsolete.
- `datascience-notebook`
  - `Changed`: Bump `r-base` to `4.0.x` see #1102 (partial)
  - `Removed`: `plyr` package because it's retired fixes #1103
  - `Removed`: `r-reshape2` package because it's retired fixes #1103
  - `Changed`: Bump `r-rmarkdown`
  - `Changed`: Bump Julia
- `tensorflow-notebook`
  - `Changed`: Bump `tensorflow`
- `pyspark-notebook`
  - `Fixed`: Add missing `apt-get clean`
- `all-spark-notebook`
  - `Fixed`: Add missing `apt-get clean`
  - `Changed`: Bump `r-base` to `4.0.x` see #1102 (partial)
  - `Changed`: Bump `r-sparklyr`