### PR TITLE
/usr/bin/nano-tiny does not exist

### DIFF
--- a/minimal-notebook/Dockerfile
+++ b/minimal-notebook/Dockerfile
@@ -32,7 +32,7 @@ RUN apt-get update && apt-get install -yq --no-install-recommends \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Create alternative for nano -> nano-tiny
-RUN update-alternatives --install /usr/bin/nano nano /usr/bin/nano-tiny 10
+RUN update-alternatives --install /usr/bin/nano nano /bin/nano-tiny 10
 
 # Switch back to jovyan to avoid accidental container runs as root
 USER $NB_UID


### PR DESCRIPTION
/usr/bin/nano-tiny does not exist, the good path is /bin/nano-tiny on ubuntu 18.04 and 20.40 (https://ubuntu.pkgs.org/20.04/ubuntu-universe-arm64/nano-tiny_4.8-1ubuntu1_arm64.deb.html).