### PR TITLE
Regular update 2020-11-05

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ ALL_IMAGES:=$(ALL_STACKS)
 
 # Dockerfile Linter
 HADOLINT="${HOME}/hadolint"
-HADOLINT_VERSION="v1.18.0"
+HADOLINT_VERSION="v1.18.2"
 
 help:
 # http://marmelab.com/blog/2016/02/29/auto-documented-makefile.html
@@ -68,7 +68,7 @@ cont-rm-all: ## remove all containers
 	-docker rm --force $(shell docker ps -a -q) 2> /dev/null
 
 dev/%: ARGS?=
-dev/%: DARGS?=
+dev/%: DARGS?=-e JUPYTER_ENABLE_LAB=yes
 dev/%: PORT?=8888
 dev/%: ## run a foreground container for a stack
 	docker run -it --rm -p $(PORT):8888 $(DARGS) $(OWNER)/$(notdir $@) $(ARGS)

--- a/base-notebook/Dockerfile
+++ b/base-notebook/Dockerfile
@@ -4,7 +4,7 @@
 # Ubuntu 20.04 (focal)
 # https://hub.docker.com/_/ubuntu/?tab=tags&name=focal
 # OS/ARCH: linux/amd64
-ARG ROOT_CONTAINER=ubuntu:focal-20200925@sha256:2e70e9c81838224b5311970dbf7ed16802fbfe19e7a70b3cbfa3d7522aa285b4
+ARG ROOT_CONTAINER=ubuntu:focal-20201008@sha256:1d7b639619bdca2d008eca2d5293e3c43ff84cbee597ff76de3b7a7de3e84956
 
 ARG BASE_CONTAINER=$ROOT_CONTAINER
 FROM $BASE_CONTAINER
@@ -129,8 +129,8 @@ RUN conda install --quiet --yes 'tini=0.18.0' && \
 # files across image layers when the permissions change
 RUN conda install --quiet --yes \
     'notebook=6.1.4' \
-    'jupyterhub=1.1.0' \
-    'jupyterlab=2.2.8' && \
+    'jupyterhub=1.2.1' \
+    'jupyterlab=2.2.9' && \
     conda clean --all -f -y && \
     npm cache clean --force && \
     jupyter notebook --generate-config && \

--- a/datascience-notebook/Dockerfile
+++ b/datascience-notebook/Dockerfile
@@ -70,7 +70,7 @@ RUN conda install --quiet --yes \
     'r-nycflights13=1.0*' \
     'r-randomforest=4.6*' \
     'r-rcurl=1.98*' \
-    'r-rmarkdown=2.4*' \
+    'r-rmarkdown=2.5*' \
     'r-rsqlite=2.2*' \
     'r-shiny=1.5*' \
     'r-tidyverse=1.3*' \

--- a/pyspark-notebook/Dockerfile
+++ b/pyspark-notebook/Dockerfile
@@ -51,7 +51,7 @@ USER $NB_UID
 
 # Install pyarrow
 RUN conda install --quiet --yes --satisfied-skip-solve \
-    'pyarrow=1.0.*' && \
+    'pyarrow=2.0.*' && \
     conda clean --all -f -y && \
     fix-permissions "${CONDA_DIR}" && \
     fix-permissions "/home/${NB_USER}"

--- a/r-notebook/Dockerfile
+++ b/r-notebook/Dockerfile
@@ -37,7 +37,7 @@ RUN conda install --quiet --yes \
     'r-nycflights13=1.0*' \
     'r-randomforest=4.6*' \
     'r-rcurl=1.98*' \
-    'r-rmarkdown=2.4*' \
+    'r-rmarkdown=2.5*' \
     'r-rodbc=1.3*' \
     'r-rsqlite=2.2*' \
     'r-shiny=1.5*' \


### PR DESCRIPTION
The following changes have been made.

- General
  - `Changed`: Bump hadolint (Docker linter)
  - `Changed`: Use Jupyterlab by default when using `make dev`
- `base-notebook`
  - `Changed`: Bump Ubuntu
  - `Changed`: Bump jupyterhub
  - `Changed`: Bump jupyterlab
- `r-notebook`
  - `Changed`: Bump `r-rmarkdown`
- `datascience-notebook`
  - `Changed`: Bump `r-rmarkdown`
- `pyspark-notebook`
  - `Change`: Bump `pyarrow`