### PR TITLE
[Bug fix] Create home directory before changing ownership

### DIFF
--- a/base-notebook/start.sh
+++ b/base-notebook/start.sh
@@ -47,19 +47,6 @@ if [ $(id -u) == 0 ] ; then
         usermod -d /home/$NB_USER -l $NB_USER jovyan
     fi
 
-    # Handle case where provisioned storage does not have the correct permissions by default
-    # Ex: default NFS/EFS (no auto-uid/gid)
-    if [[ "$CHOWN_HOME" == "1" || "$CHOWN_HOME" == 'yes' ]]; then
-        echo "Changing ownership of /home/$NB_USER to $NB_UID:$NB_GID with options '${CHOWN_HOME_OPTS}'"
-        chown $CHOWN_HOME_OPTS $NB_UID:$NB_GID /home/$NB_USER
-    fi
-    if [ ! -z "$CHOWN_EXTRA" ]; then
-        for extra_dir in $(echo $CHOWN_EXTRA | tr ',' ' '); do
-            echo "Changing ownership of ${extra_dir} to $NB_UID:$NB_GID with options '${CHOWN_EXTRA_OPTS}'"
-            chown $CHOWN_EXTRA_OPTS $NB_UID:$NB_GID $extra_dir
-        done
-    fi
-
     # handle home and working directory if the username changed
     if [[ "$NB_USER" != "jovyan" ]]; then
         # changing username, make sure homedir exists
@@ -74,6 +61,19 @@ if [ $(id -u) == 0 ] ; then
             echo "Setting CWD to $newcwd"
             cd "$newcwd"
         fi
+    fi
+
+    # Handle case where provisioned storage does not have the correct permissions by default
+    # Ex: default NFS/EFS (no auto-uid/gid)
+    if [[ "$CHOWN_HOME" == "1" || "$CHOWN_HOME" == 'yes' ]]; then
+        echo "Changing ownership of /home/$NB_USER to $NB_UID:$NB_GID with options '${CHOWN_HOME_OPTS}'"
+        chown $CHOWN_HOME_OPTS $NB_UID:$NB_GID /home/$NB_USER
+    fi
+    if [ ! -z "$CHOWN_EXTRA" ]; then
+        for extra_dir in $(echo $CHOWN_EXTRA | tr ',' ' '); do
+            echo "Changing ownership of ${extra_dir} to $NB_UID:$NB_GID with options '${CHOWN_EXTRA_OPTS}'"
+            chown $CHOWN_EXTRA_OPTS $NB_UID:$NB_GID $extra_dir
+        done
     fi
 
     # Change UID:GID of NB_USER to NB_UID:NB_GID if it does not match

--- a/base-notebook/test/test_container_options.py
+++ b/base-notebook/test/test_container_options.py
@@ -76,7 +76,6 @@ def test_nb_user_change(container):
             f"NB_USER={nb_user}",
             "CHOWN_HOME=yes"
         ],
-        working_dir=f"/home/{nb_user}",
         command=['start.sh', 'bash', '-c', 'sleep infinity']
     )
 
@@ -90,14 +89,14 @@ def test_nb_user_change(container):
     LOGGER.info(f"Checking {nb_user} id ...")
     command = "id"
     expected_output = f"uid=1000({nb_user}) gid=100(users) groups=100(users)"
-    cmd = running_container.exec_run(command, user=nb_user)
+    cmd = running_container.exec_run(command, user=nb_user, workdir=f"/home/{nb_user}")
     output = cmd.output.decode("utf-8").strip("\n")
     assert output == expected_output, f"Bad user {output}, expected {expected_output}"
 
     LOGGER.info(f"Checking if {nb_user} owns his home folder ...")
     command = f'stat -c "%U %G" /home/{nb_user}/'
     expected_output = f"{nb_user} users"
-    cmd = running_container.exec_run(command)
+    cmd = running_container.exec_run(command, workdir=f"/home/{nb_user}")
     output = cmd.output.decode("utf-8").strip("\n")
     assert output == expected_output, f"Bad owner for the {nb_user} home folder {output}, expected {expected_output}"
 


### PR DESCRIPTION
There's a bug in the `start.sh` that causes a crash when starting a notebook with `NB_USER=<username>` and `CHOWN_HOME=yes` environment variable. For example:
```
$ mkdir -p pr/base
$ cd pr/base
$ git clone https://github.com/jupyter/docker-stacks.git
$ cd docker-stacks
$ make build/base-notebook
$ docker tag jupyter/base-notebook:latest jupyter/base-notebook:base
$ docker run -e NB_USER=steven -e CHOWN_HOME=yes --user root jupyter/base-notebook:base
Set username to: steven
Changing ownership of /home/steven to 1000:100 with options ''
chown: cannot access '/home/steven': No such file or directory
```
This happens because `chown` gets called in  `start.sh` before moving/creating the directory `/home/$NB_USER`: https://github.com/jupyter/docker-stacks/blob/master/base-notebook/start.sh#L50-L77

I've flipped the order of these so that `/home/$NB_USER` is made before `chown`: https://github.com/stevenstetzler/docker-stacks/blob/master/base-notebook/start.sh#L50-L77

This results in a success:
```
$ mkdir -p pr/head
$ cd pr/head
$ git clone https://github.com/stevenstetzler/docker-stacks.git
$ cd docker-stacks
$ make build/base-notebook
$ docker tag jupyter/base-notebook:latest jupyter/base-notebook:head
$ docker run -e NB_USER=steven -e CHOWN_HOME=yes --user root jupyter/base-notebook:head
Set username to: steven
Relocating home dir to /home/steven
Setting CWD to /home/steven/
Changing ownership of /home/steven to 1000:100 with options ''
Executing the command: jupyter notebook
...
```