### PR TITLE
Switch from Miniconda to Miniforge

### DIFF
--- a/base-notebook/Dockerfile
+++ b/base-notebook/Dockerfile
@@ -27,8 +27,9 @@ USER root
 ARG conda_version="4.9.0"
 # Miniforge archive to install
 ARG miniforge_version="${conda_version}-3"
-# Miniforge installer
+# Miniforge installer and its checksum
 ARG miniforge_installer="Miniforge3-${miniforge_version}-Linux-x86_64.sh"
+ARG miniforge_checksum="29f0eb17dd02aceb0dfd4dad2654e974b1699baed06ee6d350b0ab4a2ccf3d02"
 
 # Install all OS dependencies for notebook server that starts but lacks all
 # features (e.g., download as all possible file formats)
@@ -93,10 +94,9 @@ RUN mkdir "/home/$NB_USER/work" && \
 WORKDIR /tmp
 
 RUN wget --quiet "https://github.com/conda-forge/miniforge/releases/download/${miniforge_version}/${miniforge_installer}" && \
-    wget --quiet "https://github.com/conda-forge/miniforge/releases/download/${miniforge_version}/${miniforge_installer}.sha256" && \
-    sha256sum -c "${miniforge_installer}.sha256" && \
+    echo "${miniforge_checksum} *${miniforge_installer}" | sha256sum --check && \
     /bin/bash "${miniforge_installer}" -f -b -p $CONDA_DIR && \
-    rm "${miniforge_installer}" "${miniforge_installer}.sha256" && \
+    rm "${miniforge_installer}" && \
     # Conda configuration see https://conda.io/projects/conda/en/latest/configuration.html
     echo "conda ${CONDA_VERSION}" >> $CONDA_DIR/conda-meta/pinned && \
     conda config --system --set auto_update_conda false && \

--- a/base-notebook/Dockerfile
+++ b/base-notebook/Dockerfile
@@ -19,16 +19,25 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 USER root
 
-# Miniforge installation
+# ---- Miniforge installer ----
 # Default values can be overridden at build time
 # (ARGS are in lower case to distinguish them from ENV)
 # Check https://github.com/conda-forge/miniforge/releases
 # Conda version
 ARG conda_version="4.9.0"
+# Miniforge installer patch version
+ARG miniforge_patch_number="3"
+# Miniforge installer architecture
+ARG miniforge_arch="x86_64"
+# Python implementation to use 
+# can be either Miniforge3 to use Python or Miniforge-pypy3 to use PyPy
+ARG miniforge_python="Miniforge3"
+
 # Miniforge archive to install
-ARG miniforge_version="${conda_version}-3"
-# Miniforge installer and its checksum
-ARG miniforge_installer="Miniforge3-${miniforge_version}-Linux-x86_64.sh"
+ARG miniforge_version="${conda_version}-${miniforge_patch_number}"
+# Miniforge installer
+ARG miniforge_installer="${miniforge_python}-${miniforge_version}-Linux-${miniforge_arch}.sh"
+# Miniforge checksum
 ARG miniforge_checksum="29f0eb17dd02aceb0dfd4dad2654e974b1699baed06ee6d350b0ab4a2ccf3d02"
 
 # Install all OS dependencies for notebook server that starts but lacks all

--- a/base-notebook/Dockerfile
+++ b/base-notebook/Dockerfile
@@ -101,7 +101,6 @@ RUN wget --quiet "https://github.com/conda-forge/miniforge/releases/download/${m
     echo "conda ${CONDA_VERSION}" >> $CONDA_DIR/conda-meta/pinned && \
     conda config --system --set auto_update_conda false && \
     conda config --system --set show_channel_urls true && \
-    conda config --system --set channel_priority strict && \
     if [ ! $PYTHON_VERSION = 'default' ]; then conda install --yes python=$PYTHON_VERSION; fi && \
     conda list python | grep '^python ' | tr -s ' ' | cut -d '.' -f 1,2 | sed 's/$/.*/' >> $CONDA_DIR/conda-meta/pinned && \
     conda install --quiet --yes "conda=${CONDA_VERSION}" && \

--- a/base-notebook/Dockerfile
+++ b/base-notebook/Dockerfile
@@ -26,7 +26,7 @@ USER root
 # Conda version
 ARG conda_version="4.9.0"
 # Miniforge installer patch version
-ARG miniforge_patch_number="3"
+ARG miniforge_patch_number="4"
 # Miniforge installer architecture
 ARG miniforge_arch="x86_64"
 # Python implementation to use 
@@ -38,7 +38,7 @@ ARG miniforge_version="${conda_version}-${miniforge_patch_number}"
 # Miniforge installer
 ARG miniforge_installer="${miniforge_python}-${miniforge_version}-Linux-${miniforge_arch}.sh"
 # Miniforge checksum
-ARG miniforge_checksum="29f0eb17dd02aceb0dfd4dad2654e974b1699baed06ee6d350b0ab4a2ccf3d02"
+ARG miniforge_checksum="dae28a05f0fcfed0b47c66468e8434ab42cb1ff90de96540a506949cdecd2b5a"
 
 # Install all OS dependencies for notebook server that starts but lacks all
 # features (e.g., download as all possible file formats)

--- a/base-notebook/Dockerfile
+++ b/base-notebook/Dockerfile
@@ -19,16 +19,16 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 USER root
 
-# Miniconda installation
+# Miniforge installation
 # Default values can be overridden at build time
 # (ARGS are in lower case to distinguish them from ENV)
-# Check https://repo.anaconda.com/miniconda/
-# Miniconda archive to install
-ARG miniconda_version="4.8.3"
-# Archive MD5 checksum
-ARG miniconda_checksum="d63adf39f2c220950a063e0529d4ff74"
-# Conda version that can be different from the archive
+# Check https://github.com/conda-forge/miniforge/releases
+# Conda version
 ARG conda_version="4.9.0"
+# Miniforge archive to install
+ARG miniforge_version="${conda_version}-3"
+# Miniforge installer
+ARG miniforge_installer="Miniforge3-${miniforge_version}-Linux-x86_64.sh"
 
 # Install all OS dependencies for notebook server that starts but lacks all
 # features (e.g., download as all possible file formats)
@@ -57,7 +57,8 @@ ENV CONDA_DIR=/opt/conda \
     LANG=en_US.UTF-8 \
     LANGUAGE=en_US.UTF-8
 ENV PATH=$CONDA_DIR/bin:$PATH \
-    HOME=/home/$NB_USER
+    HOME=/home/$NB_USER \
+    CONDA_VERSION="${conda_version}"
 
 # Copy a script that we will use to correct permissions after running certain commands
 COPY fix-permissions /usr/local/bin/fix-permissions
@@ -82,25 +83,22 @@ RUN echo "auth requisite pam_deny.so" >> /etc/pam.d/su && \
     fix-permissions $CONDA_DIR
 
 USER $NB_UID
-WORKDIR $HOME
 ARG PYTHON_VERSION=default
 
 # Setup work directory for backward-compatibility
-RUN mkdir /home/$NB_USER/work && \
-    fix-permissions /home/$NB_USER
+RUN mkdir "/home/$NB_USER/work" && \
+    fix-permissions "/home/$NB_USER"
 
-# Install conda as jovyan and check the md5 sum provided on the download site
-ENV MINICONDA_VERSION="${miniconda_version}" \
-    CONDA_VERSION="${conda_version}"
-
+# Install conda as jovyan and check the sha256 sum provided on the download site
 WORKDIR /tmp
-RUN wget --quiet https://repo.continuum.io/miniconda/Miniconda3-py38_${MINICONDA_VERSION}-Linux-x86_64.sh && \
-    echo "${miniconda_checksum} *Miniconda3-py38_${MINICONDA_VERSION}-Linux-x86_64.sh" | md5sum -c - && \
-    /bin/bash Miniconda3-py38_${MINICONDA_VERSION}-Linux-x86_64.sh -f -b -p $CONDA_DIR && \
-    rm Miniconda3-py38_${MINICONDA_VERSION}-Linux-x86_64.sh && \
+
+RUN wget --quiet "https://github.com/conda-forge/miniforge/releases/download/${miniforge_version}/${miniforge_installer}" && \
+    wget --quiet "https://github.com/conda-forge/miniforge/releases/download/${miniforge_version}/${miniforge_installer}.sha256" && \
+    sha256sum -c "${miniforge_installer}.sha256" && \
+    /bin/bash "${miniforge_installer}" -f -b -p $CONDA_DIR && \
+    rm "${miniforge_installer}" "${miniforge_installer}.sha256" && \
     # Conda configuration see https://conda.io/projects/conda/en/latest/configuration.html
     echo "conda ${CONDA_VERSION}" >> $CONDA_DIR/conda-meta/pinned && \
-    conda config --system --prepend channels conda-forge && \
     conda config --system --set auto_update_conda false && \
     conda config --system --set show_channel_urls true && \
     conda config --system --set channel_priority strict && \

--- a/docs/using/common.md
+++ b/docs/using/common.md
@@ -117,7 +117,7 @@ conda install some-package
 
 Conda is configured by default to use only the [`conda-forge`](https://anaconda.org/conda-forge) channel. 
 However, alternative channels can be used either one shot by overwriting the default channel in the installation command or by configuring `conda` to use different channels.
-The examples below shows how to use the [anaconda default channels](https://repo.anaconda.com/pkgs/main) instead of `conda-forge` to install packages.
+The examples below show how to use the [anaconda default channels](https://repo.anaconda.com/pkgs/main) instead of `conda-forge` to install packages.
 
 ```bash
 # using defaults channels to install a package

--- a/docs/using/common.md
+++ b/docs/using/common.md
@@ -113,3 +113,17 @@ pip install some-package
 conda install some-package
 ```
 
+### Using alternative channels
+
+Conda is configured by default to use only the [`conda-forge`](https://anaconda.org/conda-forge) channel. 
+However, alternative channels can be used either one shot by overwriting the default channel in the installation command or by configuring `conda` to use different channels.
+The examples below shows how to use the [anaconda default channels](https://repo.anaconda.com/pkgs/main) instead of `conda-forge` to install packages.
+
+```bash
+# using defaults channels to install a package
+conda install --channel defaults humanize
+# configure conda to add default channels at the top of the list
+conda config --system --prepend channels defaults
+# install a package
+conda install humanize
+```

--- a/docs/using/selecting.md
+++ b/docs/using/selecting.md
@@ -28,7 +28,7 @@ and versioning strategy.
 [options common across all core stacks](common.md). It is the basis for all other stacks.
 
 - Minimally-functional Jupyter Notebook server (e.g., no LaTeX support for saving notebooks as PDFs)
-- [Miniconda](https://conda.io/miniconda.html) Python 3.x in `/opt/conda`
+- [Miniforge](https://github.com/conda-forge/miniforge) Python 3.x in `/opt/conda`
 - No preinstalled scientific computing packages
 - Unprivileged user `jovyan` (`uid=1000`, configurable, see options) in group `users` (`gid=100`)
   with ownership over the `/home/jovyan` and `/opt/conda` paths

--- a/test/helpers.py
+++ b/test/helpers.py
@@ -93,11 +93,11 @@ class CondaPackageHelper:
         # Since we only manage packages installed through conda here
         dependencies = filter(lambda x: isinstance(x, str), dependencies)
         packages_dict = dict()
-        for split in map(lambda x: x.split("=", 1), dependencies):
+        for split in map(lambda x: re.split("=?=", x), dependencies):
             # default values
             package = split[0]
             version = set()
-            # cheking if it's a proper version by testing if the first char is a digit
+            # checking if it's a proper version by testing if the first char is a digit
             if len(split) > 1:
                 if split[1][0].isdigit():
                     # package + version case

--- a/test/test_packages.py
+++ b/test/test_packages.py
@@ -68,6 +68,7 @@ EXCLUDED_PACKAGES = [
     "protobuf",
     "r-irkernel",
     "unixodbc",
+    "bzip2"
 ]
 
 


### PR DESCRIPTION
Hello,

I'm _trying_ to perform a structuring change by switching from [Miniconda](https://docs.conda.io/en/latest/miniconda.html) installer to [Miniforge](https://github.com/conda-forge/miniforge).

> This repository holds a minimal installer for conda specific to conda-forge.

Here are the main reasons

* Switch to **open source** since Anaconda has recently updated its [TOS](https://www.anaconda.com/terms-of-service) to restrict commercial usage of its repositories (including the repo hosting Miniconda installers) -> This could impact users of Jupyter Docker images
* It's built to use `conda-forge` channel by default
  * it is the channel we are using that is not restricted
  * there is no need to prepend it anymore
  * other [default channels](https://repo.anaconda.com/pkgs/) that are concerned by the new TOS are not configured
* Support various CPU architecture (installer can be adapted through `ARGS`), could be a good asset to build [multi-arch](https://www.docker.com/blog/multi-arch-build-and-images-the-simple-way/) images.
* Support for [pypy](https://www.pypy.org/) by using alternative installers `Miniforge-pypy3` (thanks @mathbunnyru)

Some minor pros

* There is almost no change in the installation process
* Base image size seems to identical or slightly reduced
* Speed up the package dependencies resolution (only one channel)

## Implementation

* Installation is pretty much the same 😊 
* Split the installer definition in several `ARGs` to ease overriding and for better clarity (I hope)
* Removed the environment variable `MINICONDA_VERSION` because I'm not sure it makes sense to replace it by the Miniforge equivalent
* Removed the `strict` channel priority of the `conda` installer because 
  * it is no more necessary with only one channel
  * it makes installation of packages from other channels (set by users) harder
* Decision to keep the installer checksum as an `ARG` instead of downloading it for security reasons (@mathbunnyru suggestion)
* Documented in "Common Features" the way to install packages from `defaults` channels

## Notes on multi-arch images

Here is a table displaying the various CPU architecture available

| Ubuntu    | Miniforge       | Miniconda          |
|-----------|-----------------|--------------------|
| `arm64`   | `linux-aarch64` |  -                 |
| `amd64`   | `linux-x86_64`  | `Linux-x86_64.sh`  |
| `ppc64le` | `linux-ppc64le` | `Linux-ppc64le.sh` |

List of `ubuntu:focal` architectures

```bash
curl -s https://hub.docker.com/v2/repositories/library/ubuntu/tags | \
    jq -r '.results[] | select(.name=="focal") | .images[].architecture'

# arm64
# s390x
# amd64
# ppc64le
# arm
```