### PR TITLE
Fix .dockerignore by adding default hooks + test dirs

### DIFF
--- a/all-spark-notebook/.dockerignore
+++ b/all-spark-notebook/.dockerignore
@@ -1,2 +1,4 @@
 # Documentation
 README.md
+hooks
+test

--- a/base-notebook/.dockerignore
+++ b/base-notebook/.dockerignore
@@ -1,2 +1,4 @@
 # Documentation
 README.md
+hooks
+test

--- a/datascience-notebook/.dockerignore
+++ b/datascience-notebook/.dockerignore
@@ -1,2 +1,4 @@
 # Documentation
 README.md
+hooks
+test

--- a/minimal-notebook/.dockerignore
+++ b/minimal-notebook/.dockerignore
@@ -1,2 +1,4 @@
 # Documentation
 README.md
+hooks
+test

--- a/pyspark-notebook/.dockerignore
+++ b/pyspark-notebook/.dockerignore
@@ -1,2 +1,4 @@
 # Documentation
 README.md
+hooks
+test

--- a/r-notebook/.dockerignore
+++ b/r-notebook/.dockerignore
@@ -1,2 +1,4 @@
 # Documentation
 README.md
+hooks
+test

--- a/scipy-notebook/.dockerignore
+++ b/scipy-notebook/.dockerignore
@@ -1,2 +1,4 @@
 # Documentation
 README.md
+hooks
+test

--- a/tensorflow-notebook/.dockerignore
+++ b/tensorflow-notebook/.dockerignore
@@ -1,2 +1,4 @@
 # Documentation
 README.md
+hooks
+test


### PR DESCRIPTION
Hello,

Just figured out that standards `hooks` and `test` directories that are part of most of the Docker image's folder were not included in the `.dockerignore`.
It's not a big improvement but they will not be anymore send to the daemon now.

Best