### PR TITLE
Support multi-arch image for base-notebook

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -45,6 +45,10 @@ jobs:
         run: make -C main hadolint-all
       - name: Run pre-commit hooks
         run: make -C main pre-commit-all
+      - name: Setup buildx
+        run: make -C main buildx-setup
+      - name: Setup QEMU
+        run: make -C main qemu-setup
       - name: Build Multi-arch Docker Images
         run: make -C main build-test-multi-arch-all
       - name: Build Docker Images

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -45,10 +45,10 @@ jobs:
         run: make -C main hadolint-all
       - name: Run pre-commit hooks
         run: make -C main pre-commit-all
+      - name: Setup QEMU
+        run: make -C main qemu-setup
       - name: Setup buildx
         run: make -C main buildx-setup
-      # - name: Setup QEMU
-      #   run: make -C main qemu-setup
       - name: Build Multi-arch Docker Images
         run: make -C main build-multi-arch-all
       - name: Build Docker Images

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -47,10 +47,10 @@ jobs:
         run: make -C main pre-commit-all
       - name: Setup buildx
         run: make -C main buildx-setup
-      - name: Setup QEMU
-        run: make -C main qemu-setup
+      # - name: Setup QEMU
+      #   run: make -C main qemu-setup
       - name: Build Multi-arch Docker Images
-        run: make -C main build-test-multi-arch-all
+        run: make -C main build-multi-arch-all
       - name: Build Docker Images
         run: make -C main build-test-all
       - name: Run Post-Build Hooks

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -49,8 +49,20 @@ jobs:
         run: make -C main qemu-setup
       - name: Setup buildx
         run: make -C main buildx-setup
+      # Note dedicated actions exist to setup QEMU and Buildx
+      # https://github.com/docker/setup-buildx-action
+      # However we are sticking with a portable solution for the time being
+      # - name: Set up QEMU
+      #   uses: docker/setup-qemu-action@v1
+      # - name: Set up Docker Buildx
+      #   id: buildx
+      #   uses: docker/setup-buildx-action@v1
+      # - name: Builder instance name
+      #   run: echo ${{ steps.buildx.outputs.name }}
+      # - name: Available platforms
+      #   run: echo ${{ steps.buildx.outputs.platforms }}
       - name: Build Multi-arch Docker Images
-        run: make -C main build-multi-arch-all
+        run: make -C main build-test-multi-arch-all
       - name: Build Docker Images
         run: make -C main build-test-all
       - name: Run Post-Build Hooks

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -28,11 +28,11 @@ jobs:
         uses: actions/checkout@v2
         with:
           path: main
-      - name: Clone Wiki
-        uses: actions/checkout@v2
-        with:
-          repository: ${{github.repository}}.wiki
-          path: wiki
+      # - name: Clone Wiki
+      #   uses: actions/checkout@v2
+      #   with:
+      #     repository: ${{github.repository}}.wiki
+      #     path: wiki
       - name: Set Up Python
         uses: actions/setup-python@v2
         with:
@@ -45,6 +45,8 @@ jobs:
         run: make -C main hadolint-all
       - name: Run pre-commit hooks
         run: make -C main pre-commit-all
+      - name: Build Multi-arch Docker Images
+        run: make -C main build-test-multi-arch-all
       - name: Build Docker Images
         run: make -C main build-test-all
       - name: Run Post-Build Hooks

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -28,11 +28,11 @@ jobs:
         uses: actions/checkout@v2
         with:
           path: main
-      # - name: Clone Wiki
-      #   uses: actions/checkout@v2
-      #   with:
-      #     repository: ${{github.repository}}.wiki
-      #     path: wiki
+      - name: Clone Wiki
+        uses: actions/checkout@v2
+        with:
+          repository: ${{github.repository}}.wiki
+          path: wiki
       - name: Set Up Python
         uses: actions/setup-python@v2
         with:

--- a/Makefile
+++ b/Makefile
@@ -181,7 +181,7 @@ push-all: $(foreach I,$(ALL_IMAGES),push/$(I) ) ## push all tagged images
 # --- run helpers ---
 # container run helpers for development purpose
 
-run-sudo/%: TAG?=latest
+run/%: TAG?=latest
 run/%: DARGS?=
 run/%: ## run a bash in interactive mode in a stack
 	docker run -it --rm $(DARGS) "$(OWNER)/$(notdir $@):$(TAG)" $(SHELL)

--- a/Makefile
+++ b/Makefile
@@ -238,10 +238,6 @@ build-multi-arch-all: $(foreach I,$(ALL_M_ARCH_IMAGES),build-multi-arch/$(I) ) #
 build-test-multi-arch-all: qemu-setup
 build-test-multi-arch-all: $(foreach I,$(ALL_M_ARCH_IMAGES),build-multi-arch/$(I) test-multi-arch/$(I) ) ## build and test all multi-arch stacks
 
-qemu-setup: ## setup QEMU to be able to run all arch images through emulation
-	@echo "Setting up QEMU ..."
-	@docker run --rm --privileged multiarch/qemu-user-static --reset --persistent yes
-
 test-multi-arch/%: DARGS?=
 test-multi-arch/%: ## test the different arch of a the stack %  
 	@echo "Testing multi-arch image $(notdir $@) ..."
@@ -255,3 +251,14 @@ push-multi-arch/%: ## push all tags for a jupyter image
 		--rm --force-rm -t $(OWNER)/$(notdir $@):latest ./$(notdir $@) --push
 
 push-all: $(foreach I,$(ALL_M_ARCH_IMAGES),push/$(I) ) ## push all tagged images
+
+# --- multi-arch prerequisites ---
+
+qemu-setup: ## setup QEMU to be able to run all arch images through emulation
+	@echo "Setting up QEMU ..."
+	docker run --rm --privileged multiarch/qemu-user-static --reset --persistent yes
+
+buildx-setup: ## setup buildx to be able to build multi-arch images
+	@echo "Setting up buildx ..."	
+	docker buildx create --name multi --use
+	docker buildx inspect --bootstrap

--- a/Makefile
+++ b/Makefile
@@ -227,9 +227,9 @@ build-arch/%: ## build a arch image for a stack
 build-multi-arch/%: DARGS?=
 build-multi-arch/%: ## build multi-arch images for a stack  
 	@echo "Building multi-arch image $(OWNER)/$(notdir $@) ..." 
-	# @$(MAKE) -f $(THIS_FILE) build-arch/$(notdir $@) PLATFORM=amd64
-	# @$(MAKE) -f $(THIS_FILE) build-arch/$(notdir $@) PLATFORM=arm64 \
-	# 	DARGS="--build-arg miniforge_arch=aarch64 --build-arg miniforge_checksum=3c6f3f5dd5dcbd1fe8bce7cfc5c11b46ea51a432f8e3c03b60384680ea621b3a"
+	@$(MAKE) -f $(THIS_FILE) build-arch/$(notdir $@) PLATFORM=amd64
+	@$(MAKE) -f $(THIS_FILE) build-arch/$(notdir $@) PLATFORM=arm64 \
+	 	DARGS="--build-arg miniforge_arch=aarch64 --build-arg miniforge_checksum=3c6f3f5dd5dcbd1fe8bce7cfc5c11b46ea51a432f8e3c03b60384680ea621b3a"
 	@$(MAKE) -f $(THIS_FILE) build-arch/$(notdir $@) PLATFORM=ppc64le \
 		DARGS="--build-arg miniforge_arch=ppc64le --build-arg miniforge_checksum=2ac5780924f6eb6613b99ed7266d0b23126e555a45faf4ceff6e8f3fa3a48e0e"
 	docker tag $(OWNER)/$(notdir $@):$(DEFAULT_ARCH) $(OWNER)/$(notdir $@):latest

--- a/Makefile
+++ b/Makefile
@@ -235,7 +235,6 @@ build-multi-arch/%: ## build multi-arch images for a stack
 
 build-multi-arch-all: $(foreach I,$(ALL_M_ARCH_IMAGES),build-multi-arch/$(I) ) ## build all multi-arch stacks
 
-build-test-multi-arch-all: qemu-setup
 build-test-multi-arch-all: $(foreach I,$(ALL_M_ARCH_IMAGES),build-multi-arch/$(I) test-multi-arch/$(I) ) ## build and test all multi-arch stacks
 
 test-multi-arch/%: DARGS?=

--- a/Makefile
+++ b/Makefile
@@ -227,10 +227,11 @@ build-arch/%: ## build a arch image for a stack
 build-multi-arch/%: DARGS?=
 build-multi-arch/%: ## build multi-arch images for a stack  
 	@echo "Building multi-arch image $(OWNER)/$(notdir $@) ..." 
-	@$(MAKE) -f $(THIS_FILE) build-arch/$(notdir $@) PLATFORM=amd64
-	@$(MAKE) -f $(THIS_FILE) build-arch/$(notdir $@) PLATFORM=arm64 \
-		DARGS="--build-arg miniforge_arch=aarch64 --build-arg miniforge_checksum=3c6f3f5dd5dcbd1fe8bce7cfc5c11b46ea51a432f8e3c03b60384680ea621b3a"
-	# @$(MAKE) -f $(THIS_FILE) build-arch/$(notdir $@) PLATFORM=ppc64le
+	# @$(MAKE) -f $(THIS_FILE) build-arch/$(notdir $@) PLATFORM=amd64
+	# @$(MAKE) -f $(THIS_FILE) build-arch/$(notdir $@) PLATFORM=arm64 \
+	# 	DARGS="--build-arg miniforge_arch=aarch64 --build-arg miniforge_checksum=3c6f3f5dd5dcbd1fe8bce7cfc5c11b46ea51a432f8e3c03b60384680ea621b3a"
+	@$(MAKE) -f $(THIS_FILE) build-arch/$(notdir $@) PLATFORM=ppc64le \
+		DARGS="--build-arg miniforge_arch=ppc64le --build-arg miniforge_checksum=2ac5780924f6eb6613b99ed7266d0b23126e555a45faf4ceff6e8f3fa3a48e0e"
 	docker tag $(OWNER)/$(notdir $@):$(DEFAULT_ARCH) $(OWNER)/$(notdir $@):latest
 
 build-multi-arch-all: $(foreach I,$(ALL_M_ARCH_IMAGES),build-multi-arch/$(I) ) ## build all multi-arch stacks
@@ -240,9 +241,9 @@ build-test-multi-arch-all: $(foreach I,$(ALL_M_ARCH_IMAGES),build-multi-arch/$(I
 test-multi-arch/%: DARGS?=
 test-multi-arch/%: ## test the different arch of a the stack %  
 	@echo "Testing multi-arch image $(notdir $@) ..."
-	#@$(MAKE) -f $(THIS_FILE) test/$(notdir $@) TAG=amd64 
+	@$(MAKE) -f $(THIS_FILE) test/$(notdir $@) TAG=amd64 
 	@$(MAKE) -f $(THIS_FILE) test/$(notdir $@) TAG=arm64
-	#@$(MAKE) -f $(THIS_FILE) test/$(notdir $@) TAG=ppc64le
+	@$(MAKE) -f $(THIS_FILE) test/$(notdir $@) TAG=ppc64le
 
 push-multi-arch/%: DARGS?=
 push-multi-arch/%: ## push all tags for a jupyter image

--- a/Makefile
+++ b/Makefile
@@ -255,7 +255,7 @@ push-all: $(foreach I,$(ALL_M_ARCH_IMAGES),push/$(I) ) ## push all tagged images
 
 qemu-setup: ## setup QEMU to be able to run all arch images through emulation
 	@echo "Setting up QEMU ..."
-	docker run --rm --privileged multiarch/qemu-user-static --reset --persistent yes
+	docker run --rm --privileged multiarch/qemu-user-static --reset --persistent yes --credential yes
 
 buildx-setup: ## setup buildx to be able to build multi-arch images
 	@echo "Setting up buildx ..."	

--- a/base-notebook/Dockerfile
+++ b/base-notebook/Dockerfile
@@ -133,9 +133,7 @@ RUN wget --quiet "https://github.com/conda-forge/miniforge/releases/download/${m
 RUN conda install --quiet --yes \
     'notebook=6.1.5' \
     'jupyterhub=1.2.2' \
-    'jupyterlab=2.2.9' \
-    # apparently pandoc does not come with nbconvert on arm
-    'pandoc=2.11.3.*' && \
+    'jupyterlab=2.2.9' && \
     conda clean --all -f -y && \
     npm cache clean --force && \
     jupyter notebook --generate-config && \

--- a/base-notebook/Dockerfile
+++ b/base-notebook/Dockerfile
@@ -133,7 +133,9 @@ RUN wget --quiet "https://github.com/conda-forge/miniforge/releases/download/${m
 RUN conda install --quiet --yes \
     'notebook=6.1.5' \
     'jupyterhub=1.2.2' \
-    'jupyterlab=2.2.9' && \
+    'jupyterlab=2.2.9' \
+    # apparently pandoc does not come with nbconvert on arm
+    'pandoc=2.11.3.*' && \
     conda clean --all -f -y && \
     npm cache clean --force && \
     jupyter notebook --generate-config && \

--- a/base-notebook/Dockerfile
+++ b/base-notebook/Dockerfile
@@ -4,7 +4,7 @@
 # Ubuntu 20.04 (focal)
 # https://hub.docker.com/_/ubuntu/?tab=tags&name=focal
 # OS/ARCH: linux/amd64
-ARG ROOT_CONTAINER=ubuntu:focal-20201106@sha256:4e4bc990609ed865e07afc8427c30ffdddca5153fd4e82c20d8f0783a291e241
+ARG ROOT_CONTAINER=ubuntu:focal-20201106
 
 ARG BASE_CONTAINER=$ROOT_CONTAINER
 FROM $BASE_CONTAINER

--- a/base-notebook/test/test_pandoc.py
+++ b/base-notebook/test/test_pandoc.py
@@ -7,7 +7,7 @@ import pytest
 LOGGER = logging.getLogger(__name__)
 
 
-@pytest.mark.skip_arch("arm64")
+@pytest.mark.skip_arch(["arm64", "ppc64le"])
 def test_pandoc(container):
     """Pandoc shall be able to convert MD to HTML."""
     LOGGER.info(container.image_name)

--- a/base-notebook/test/test_pandoc.py
+++ b/base-notebook/test/test_pandoc.py
@@ -2,12 +2,15 @@
 # Distributed under the terms of the Modified BSD License.
 
 import logging
+import pytest
 
 LOGGER = logging.getLogger(__name__)
 
 
+@pytest.mark.skip_arch("arm64")
 def test_pandoc(container):
     """Pandoc shall be able to convert MD to HTML."""
+    LOGGER.info(container.image_name)
     c = container.run(
         tty=True, command=["start.sh", "bash", "-c", 'echo "**BOLD**" | pandoc']
     )

--- a/conftest.py
+++ b/conftest.py
@@ -104,3 +104,26 @@ def container(docker_client, image_name):
     )
     yield container
     container.remove()
+
+
+@pytest.fixture
+def arch(container):
+    """Return the architecture of the image based on its tag"""
+    # default
+    arch = "amd64"
+    # give something like this ['jupyter/base-notebook', 'arm64']
+    split = container.image_name.split(":", 1)
+    if len(split) > 1 and split[1] != "latest":
+        # setting the architecture to the tag if not latest
+        arch = split[1]
+    return arch
+
+
+@pytest.fixture(autouse=True)
+def skip_by_arch(request, arch):
+    """Define a skip_arch marker to skip tests that will not work on
+    Taken from: https://stackoverflow.com/a/28198398/4413446
+    """
+    if request.node.get_closest_marker('skip_arch'):
+        if request.node.get_closest_marker('skip_arch').args[0] == arch:
+            pytest.skip(f"skipped on the {arch} architecture")

--- a/conftest.py
+++ b/conftest.py
@@ -122,8 +122,8 @@ def arch(container):
 @pytest.fixture(autouse=True)
 def skip_by_arch(request, arch):
     """Define a skip_arch marker to skip tests that will not work on
-    Taken from: https://stackoverflow.com/a/28198398/4413446
+    Inspired by https://stackoverflow.com/a/28198398/4413446
     """
     if request.node.get_closest_marker('skip_arch'):
-        if request.node.get_closest_marker('skip_arch').args[0] == arch:
+        if arch in request.node.get_closest_marker('skip_arch').args[0]:
             pytest.skip(f"skipped on the {arch} architecture")

--- a/pytest.ini
+++ b/pytest.ini
@@ -6,3 +6,4 @@ log_cli_format = %(asctime)s [%(levelname)8s] %(message)s (%(filename)s:%(lineno
 log_cli_date_format=%Y-%m-%d %H:%M:%S
 markers =
     info: marks tests as info (deselect with '-m "not info"')
+    skip_arch: marks tests to be skipped on certain architecture


### PR DESCRIPTION
Hello,

I'm drafting a long PR to support **several CPU architectures** (multi-arch) for the `base-notebook` image: `linux/amd64` (default), `linux/arm64`, `linux/ppc64le`. It sounds interesting to propose an official base Jupyter image for alternative CPU architectures like the raising ARM. Tools are now available to make it *easy* to do:

- [Docker buildx](https://docs.docker.com/buildx/working-with-buildx/) to build images for different platforms,
- [QEMU](https://www.qemu.org/) and [qemu-user-static](https://github.com/multiarch/qemu-user-static) to emulate different architectures than the host,
- [Miniforge](https://github.com/conda-forge/miniforge) that provides installers for the different architectures,
- OS and packages / libraries ready to use on different CPU architectures.

And it works 🎉

<img width="947" alt="JupyterLab" src="https://user-images.githubusercontent.com/7131913/102775519-51fe4480-438d-11eb-8d40-7bf351257062.png">

## Todo list

- [x]  Build images for: `amd64`, `arm64` and `ppc64le`
- [x]  Test them by using the same code
- [ ]  Documentation update
    - Maintainer / collaborator
    - User documentation
        - supported architectures
        - limitations (for example pandoc is available only for amd64)
- [ ]  Manage the impact of in the manifest / hook
- [ ]  Makefile finalisation → need some polish, move things around, comments, etc.
- [ ]  Remove legacy `Dockerfile.ppc64le`
- [ ]  Push target finalization and test
- [ ]  Merge (if any) will have to use squash since I have made a lot of commits (trials and errors) to benefit from GitHub CI.

## Pros

- Propose Jupyter images for other CPU architectures
- Transparent for the user since the appropriate architecture will be pulled automatically from DockerHub (no increase of image size)
- One `Dockerfile` to rule them all: the same `Dockerfile` is used so there is no duplication
- Same tests are run against all images
- Get rid of the legacy `ppc64le` support

## Cons

- Build time increased
- Increase complexity (the build is more complex)
- Limited (at this time) to the `base-notebook` image, but could be extended
- Make the maintenance of the stack harder (more potential issues, updates more complex, etc.)

Your feedback is welcome as much on the usefulness of such a feature as on how to implement it.

Best