### PR TITLE
Jupyter Notebook Deprecation Notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ in working on the project.
 
 Following [Jupyter Notebook notice](https://github.com/jupyter/notebook#notice), we encourage users to transition to JupyterLab.
 This can be done by passing the environment variable `JUPYTER_ENABLE_LAB=yes` at container startup, 
-more information is available in the [documentation](https://jupyter-docker-stacks.readthedocs.io/en/latest/using/common.html).
+more information is available in the [documentation](https://jupyter-docker-stacks.readthedocs.io/en/latest/using/common.html#docker-options).
 
 In April 2021 JupyterLab will become the default, however a new environment variable will be introduced to switch back to Jupyter Notebook if needed.
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Following [Jupyter Notebook notice](https://github.com/jupyter/notebook#notice),
 This can be done by passing the environment variable `JUPYTER_ENABLE_LAB=yes` at container startup, 
 more information is available in the [documentation](https://jupyter-docker-stacks.readthedocs.io/en/latest/using/common.html#docker-options).
 
-In April 2021 JupyterLab will become the default, however a new environment variable will be introduced to switch back to Jupyter Notebook if needed.
+In April 2021 JupyterLab will become the default for all of the Jupyter Docker stack images, however a new environment variable will be introduced to switch back to Jupyter Notebook if needed.
 
 After the change of default, and according to the Jupyter Notebook project status and its compatibility with JupyterLab, these Docker images may remove the classic Jupyter Notebook interface altogether in favor of another *classic-like* UI built atop JupyterLab.
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,13 @@ Anyone in the community can jump in and help with these activities at any time. 
 grant additional permissions (e.g., ability to merge PRs) to anyone who shows an on-going interest
 in working on the project.
 
+## Jupyter Notebook Deprecation Notice
+
+Following [Jupyter Notebook notice](https://github.com/jupyter/notebook#notice), we encourage users to transition to JupyterLab.
+This can be done by passing the environment variable `JUPYTER_ENABLE_LAB=yes` at container startup, 
+more information in the [documentation](https://jupyter-docker-stacks.readthedocs.io/en/latest/using/common.html).
+This change is followed in the issue [#1217](https://github.com/jupyter/docker-stacks/issues/1217).
+
 ## Quick Start
 
 You can try a

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ more information is available in the [documentation](https://jupyter-docker-stac
 
 In April 2021 JupyterLab will become the default, however a new environment variable will be introduced to switch back to Jupyter Notebook if needed.
 
-Next, and according to the Jupyter Notebook project status and its compatibility with JupyterLab, it could be abandoned in favor of another *classic-like* UI.
+After the change of default, and according to the Jupyter Notebook project status and its compatibility with JupyterLab, these Docker images may remove the classic Jupyter Notebook interface altogether in favor of another *classic-like* UI built atop JupyterLab.
 
 This change is tracked in the issue [#1217](https://github.com/jupyter/docker-stacks/issues/1217), please check its content for more information.
 

--- a/README.md
+++ b/README.md
@@ -32,8 +32,13 @@ in working on the project.
 
 Following [Jupyter Notebook notice](https://github.com/jupyter/notebook#notice), we encourage users to transition to JupyterLab.
 This can be done by passing the environment variable `JUPYTER_ENABLE_LAB=yes` at container startup, 
-more information in the [documentation](https://jupyter-docker-stacks.readthedocs.io/en/latest/using/common.html).
-This change is followed in the issue [#1217](https://github.com/jupyter/docker-stacks/issues/1217).
+more information is available in the [documentation](https://jupyter-docker-stacks.readthedocs.io/en/latest/using/common.html).
+
+In April 2021 JupyterLab will become the default, however a new environment variable will be introduced to switch back to Jupyter Notebook if needed.
+
+Next, and according to the Jupyter Notebook project status and its compatibility with JupyterLab, it could be abandoned in favor of another *classic-like* UI.
+
+This change is tracked in the issue [#1217](https://github.com/jupyter/docker-stacks/issues/1217), please check its content for more information.
 
 ## Quick Start
 

--- a/base-notebook/start-notebook.sh
+++ b/base-notebook/start-notebook.sh
@@ -12,8 +12,12 @@ fi
 if [[ ! -z "${JUPYTERHUB_API_TOKEN}" ]]; then
     # launched by JupyterHub, use single-user entrypoint
     exec /usr/local/bin/start-singleuser.sh "$@"
-elif [[ ! -z "${JUPYTER_ENABLE_LAB}" ]]; then
-    . /usr/local/bin/start.sh $wrapper jupyter lab "$@"
-else
+elif [[ ! -z "${JUPYTER_ENABLE_NB}" ]]; then
+    echo "WARN: We encourage users to transition to JupyterLab, Notebook support could be removed"
     . /usr/local/bin/start.sh $wrapper jupyter notebook "$@"
+else
+    if [[ ! -z "${JUPYTER_ENABLE_LAB}" ]]; then
+        echo "WARN: The JUPYTER_ENABLE_LAB environment variable is not required anymore"
+    fi
+    . /usr/local/bin/start.sh $wrapper jupyter lab "$@"
 fi

--- a/base-notebook/start-notebook.sh
+++ b/base-notebook/start-notebook.sh
@@ -12,12 +12,9 @@ fi
 if [[ ! -z "${JUPYTERHUB_API_TOKEN}" ]]; then
     # launched by JupyterHub, use single-user entrypoint
     exec /usr/local/bin/start-singleuser.sh "$@"
-elif [[ ! -z "${JUPYTER_ENABLE_NB}" ]]; then
-    echo "WARN: We encourage users to transition to JupyterLab, Notebook support could be removed"
-    . /usr/local/bin/start.sh $wrapper jupyter notebook "$@"
-else
-    if [[ ! -z "${JUPYTER_ENABLE_LAB}" ]]; then
-        echo "WARN: The JUPYTER_ENABLE_LAB environment variable is not required anymore"
-    fi
+elif [[ ! -z "${JUPYTER_ENABLE_LAB}" ]]; then
     . /usr/local/bin/start.sh $wrapper jupyter lab "$@"
+else
+    echo "WARN: Jupyter Notebook deprecation notice https://github.com/jupyter/notebook#notice."
+    . /usr/local/bin/start.sh $wrapper jupyter notebook "$@"
 fi

--- a/base-notebook/start-notebook.sh
+++ b/base-notebook/start-notebook.sh
@@ -15,6 +15,6 @@ if [[ ! -z "${JUPYTERHUB_API_TOKEN}" ]]; then
 elif [[ ! -z "${JUPYTER_ENABLE_LAB}" ]]; then
     . /usr/local/bin/start.sh $wrapper jupyter lab "$@"
 else
-    echo "WARN: Jupyter Notebook deprecation notice https://github.com/jupyter/notebook#notice."
+    echo "WARN: Jupyter Notebook deprecation notice https://github.com/jupyter/docker-stacks#jupyter-notebook-deprecation-notice."
     . /usr/local/bin/start.sh $wrapper jupyter notebook "$@"
 fi

--- a/base-notebook/test/test_start_script.py
+++ b/base-notebook/test/test_start_script.py
@@ -29,5 +29,5 @@ def test_start_notebook(container, http_client, env, expected_server):
     ), f"Not the expected command (jupyter {expected_server}) was launched"
     # Checking warning messages
     if not env:
-        msg = "WARN: Jupyter Notebook deprecation notice https://github.com/jupyter/notebook#notice."
+        msg = "WARN: Jupyter Notebook deprecation notice"
         assert msg in logs, f"Expected warning message {msg} not printed"

--- a/base-notebook/test/test_start_script.py
+++ b/base-notebook/test/test_start_script.py
@@ -10,9 +10,8 @@ LOGGER = logging.getLogger(__name__)
 @pytest.mark.parametrize(
     "env,expected_server",
     [
-        (["JUPYTER_ENABLE_NB=yes"], "notebook"),
         (["JUPYTER_ENABLE_LAB=yes"], "lab"),
-        (None, "lab"),
+        (None, "notebook"),
     ],
 )
 def test_start_notebook(container, http_client, env, expected_server):
@@ -28,10 +27,7 @@ def test_start_notebook(container, http_client, env, expected_server):
     assert (
         f"Executing the command: jupyter {expected_server}" in logs
     ), f"Not the expected command (jupyter {expected_server}) was launched"
-    if env:
-        # Checking warning messages
-        if "JUPYTER_ENABLE_LAB=yes" in env:
-            msg = "WARN: The JUPYTER_ENABLE_LAB environment variable is not required anymore"
-        elif "JUPYTER_ENABLE_NB=yes" in env:
-            msg = "WARN: We encourage users to transition to JupyterLab, Notebook support could be removed"
+    # Checking warning messages
+    if not env:
+        msg = "WARN: Jupyter Notebook deprecation notice https://github.com/jupyter/notebook#notice."
         assert msg in logs, f"Expected warning message {msg} not printed"

--- a/base-notebook/test/test_start_script.py
+++ b/base-notebook/test/test_start_script.py
@@ -1,0 +1,37 @@
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+
+import logging
+import pytest
+
+LOGGER = logging.getLogger(__name__)
+
+
+@pytest.mark.parametrize(
+    "env,expected_server",
+    [
+        (["JUPYTER_ENABLE_NB=yes"], "notebook"),
+        (["JUPYTER_ENABLE_LAB=yes"], "lab"),
+        (None, "lab"),
+    ],
+)
+def test_start_notebook(container, http_client, env, expected_server):
+    """Test the notebook start-notebook script"""
+    LOGGER.info(
+        f"Test that the start-notebook launches the {expected_server} server from the env {env} ..."
+    )
+    c = container.run(tty=True, environment=env, command=["start-notebook.sh"])
+    resp = http_client.get("http://localhost:8888")
+    assert resp.status_code == 200, "Server is not listening"
+    logs = c.logs(stdout=True).decode("utf-8")
+    LOGGER.debug(logs)
+    assert (
+        f"Executing the command: jupyter {expected_server}" in logs
+    ), f"Not the expected command (jupyter {expected_server}) was launched"
+    if env:
+        # Checking warning messages
+        if "JUPYTER_ENABLE_LAB=yes" in env:
+            msg = "WARN: The JUPYTER_ENABLE_LAB environment variable is not required anymore"
+        elif "JUPYTER_ENABLE_NB=yes" in env:
+            msg = "WARN: We encourage users to transition to JupyterLab, Notebook support could be removed"
+        assert msg in logs, f"Expected warning message {msg} not printed"


### PR DESCRIPTION
Hello,

This is a very first step of the feature #1217 that consists in printing a deprecation notice in the `start-notebook.sh`.

Here is the new behavior

- **With no option (no specific environment variable)**: Jupyter Notebook is launched (no change). However a warning message is printed pointing to https://github.com/jupyter/notebook#notice.
- **With `JUPYTER_ENABLE_LAB`**: Jupyter Lab is launched (no change).

I've written a test that checks this behavior.

Best