### PR TITLE
Install mamba and use it to replace for install, list and clean

### DIFF
--- a/all-spark-notebook/Dockerfile
+++ b/all-spark-notebook/Dockerfile
@@ -22,20 +22,20 @@ RUN apt-get update && \
 USER $NB_UID
 
 # R packages
-RUN conda install --quiet --yes \
+RUN mamba install --quiet --yes \
     'r-base=4.0.3' \
     'r-ggplot2=3.3*' \
     'r-irkernel=1.1*' \
     'r-rcurl=1.98*' \
     'r-sparklyr=1.5*' \
     && \
-    conda clean --all -f -y && \
+    mamba clean --all -f -y && \
     fix-permissions "${CONDA_DIR}" && \
     fix-permissions "/home/${NB_USER}"
 
 # Spylon-kernel
-RUN conda install --quiet --yes 'spylon-kernel=0.4*' && \
-    conda clean --all -f -y && \
+RUN mamba install --quiet --yes 'spylon-kernel=0.4*' && \
+    mamba clean --all -f -y && \
     python -m spylon_kernel install --sys-prefix && \
     rm -rf "/home/${NB_USER}/.local" && \
     fix-permissions "${CONDA_DIR}" && \

--- a/base-notebook/Dockerfile
+++ b/base-notebook/Dockerfile
@@ -26,19 +26,19 @@ USER root
 # Conda version
 ARG conda_version="4.9.2"
 # Miniforge installer patch version
-ARG miniforge_patch_number="0"
+ARG miniforge_patch_number="5"
 # Miniforge installer architecture
 ARG miniforge_arch="x86_64"
 # Python implementation to use 
 # can be either Miniforge3 to use Python or Miniforge-pypy3 to use PyPy
-ARG miniforge_python="Miniforge3"
+ARG miniforge_python="Mambaforge"
 
 # Miniforge archive to install
 ARG miniforge_version="${conda_version}-${miniforge_patch_number}"
 # Miniforge installer
 ARG miniforge_installer="${miniforge_python}-${miniforge_version}-Linux-${miniforge_arch}.sh"
 # Miniforge checksum
-ARG miniforge_checksum="6321775eb2c02d7f51d3a9004ce0be839099f126f4099c781531428536669560"
+ARG miniforge_checksum="7f0ad0c2f367751f7878d25a7bc1b4aa48b8dcea864daf9bc09acb595102368b"
 
 # Install all OS dependencies for notebook server that starts but lacks all
 # features (e.g., download as all possible file formats)
@@ -111,15 +111,15 @@ RUN wget --quiet "https://github.com/conda-forge/miniforge/releases/download/${m
     echo "conda ${CONDA_VERSION}" >> $CONDA_DIR/conda-meta/pinned && \
     conda config --system --set auto_update_conda false && \
     conda config --system --set show_channel_urls true && \
-    if [ ! $PYTHON_VERSION = 'default' ]; then conda install --yes python=$PYTHON_VERSION; fi && \
-    conda list python | grep '^python ' | tr -s ' ' | cut -d '.' -f 1,2 | sed 's/$/.*/' >> $CONDA_DIR/conda-meta/pinned && \
-    conda install --quiet --yes \
+    if [ ! $PYTHON_VERSION = 'default' ]; then mamba install --yes python=$PYTHON_VERSION; fi && \
+    mamba list python | grep '^python ' | tr -s ' ' | cut -d '.' -f 1,2 | sed 's/$/.*/' >> $CONDA_DIR/conda-meta/pinned && \
+    mamba install --quiet --yes \
     "conda=${CONDA_VERSION}" \
     'pip' \
     'tini=0.18.0' && \
-    conda update --all --quiet --yes && \
-    conda list tini | grep tini | tr -s ' ' | cut -d ' ' -f 1,2 >> $CONDA_DIR/conda-meta/pinned && \
-    conda clean --all -f -y && \
+    mamba update --all --quiet --yes && \
+    mamba list tini | grep tini | tr -s ' ' | cut -d ' ' -f 1,2 >> $CONDA_DIR/conda-meta/pinned && \
+    mamba clean --all -f -y && \
     rm -rf /home/$NB_USER/.cache/yarn && \
     fix-permissions $CONDA_DIR && \
     fix-permissions /home/$NB_USER
@@ -130,11 +130,11 @@ RUN wget --quiet "https://github.com/conda-forge/miniforge/releases/download/${m
 # Correct permissions
 # Do all this in a single RUN command to avoid duplicating all of the
 # files across image layers when the permissions change
-RUN conda install --quiet --yes \
+RUN mamba install --quiet --yes \
     'notebook=6.1.6' \
     'jupyterhub=1.3.0' \
     'jupyterlab=2.2.9' && \
-    conda clean --all -f -y && \
+    mamba clean --all -f -y && \
     npm cache clean --force && \
     jupyter notebook --generate-config && \
     rm -rf $CONDA_DIR/share/jupyter/lab/staging && \

--- a/datascience-notebook/Dockerfile
+++ b/datascience-notebook/Dockerfile
@@ -57,7 +57,7 @@ RUN mkdir /etc/julia && \
 USER $NB_UID
 
 # R packages including IRKernel which gets installed globally.
-RUN conda install --quiet --yes \
+RUN mamba install --quiet --yes \
     'r-base=4.0.3'  \
     'r-caret=6.0*' \
     'r-crayon=1.3*' \
@@ -75,7 +75,7 @@ RUN conda install --quiet --yes \
     'r-shiny=1.5*' \
     'r-tidyverse=1.3*' \
     'rpy2=3.3*' && \
-    conda clean --all -f -y && \
+    mamba clean --all -f -y && \
     fix-permissions "${CONDA_DIR}" && \
     fix-permissions "/home/${NB_USER}"
 

--- a/pyspark-notebook/Dockerfile
+++ b/pyspark-notebook/Dockerfile
@@ -58,9 +58,9 @@ RUN cp -p "$SPARK_HOME/conf/spark-defaults.conf.template" "$SPARK_HOME/conf/spar
 USER $NB_UID
 
 # Install pyarrow
-RUN conda install --quiet --yes --satisfied-skip-solve \
+RUN mamba install --quiet --yes --satisfied-skip-solve \
     'pyarrow=2.0.*' && \
-    conda clean --all -f -y && \
+    mamba clean --all -f -y && \
     fix-permissions "${CONDA_DIR}" && \
     fix-permissions "/home/${NB_USER}"
 

--- a/r-notebook/Dockerfile
+++ b/r-notebook/Dockerfile
@@ -24,7 +24,7 @@ RUN ln -s /bin/tar /bin/gtar
 USER $NB_UID
 
 # R packages
-RUN conda install --quiet --yes \
+RUN mamba install --quiet --yes \
     'r-base=4.0.3' \
     'r-caret=6.*' \
     'r-crayon=1.3*' \
@@ -45,8 +45,8 @@ RUN conda install --quiet --yes \
     'unixodbc=2.3.*' \
     'r-tidymodels=0.1*' \
     && \
-    conda clean --all -f -y && \
+    mamba clean --all -f -y && \
     fix-permissions "${CONDA_DIR}"
 
 # Install e1071 R package (dependency of the caret R package)
-RUN conda install --quiet --yes r-e1071
+RUN mamba install --quiet --yes r-e1071

--- a/scipy-notebook/Dockerfile
+++ b/scipy-notebook/Dockerfile
@@ -15,7 +15,7 @@ RUN apt-get update && \
 USER $NB_UID
 
 # Install Python 3 packages
-RUN conda install --quiet --yes \
+RUN mamba install --quiet --yes \
     'beautifulsoup4=4.9.*' \
     'conda-forge::blas=*=openblas' \
     'bokeh=2.2.*' \
@@ -45,7 +45,7 @@ RUN conda install --quiet --yes \
     'widgetsnbextension=3.5.*'\
     'xlrd=1.2.*' \
     && \
-    conda clean --all -f -y && \
+    mamba clean --all -f -y && \
     # Activate ipywidgets extension in the environment that runs the notebook server
     jupyter nbextension enable --py widgetsnbextension --sys-prefix && \
     # Also activate ipywidgets extension for JupyterLab


### PR DESCRIPTION
First try to resolves #1210 

- Installation of [mamba][1] through the [Miniforge][2] installer -> efficient way to do it since already shipped in the installer 
- Use it in all `Dockerfile` to replace `conda` commands: `install`, `list` and `clean`.

> Currently, only install, create, list, search, run, info and clean are supported through mamba.

[1]: https://github.com/mamba-org/mamba
[2]: https://github.com/conda-forge/miniforge