### PR TITLE
Fix autocompletion issue #1215

### DIFF
--- a/base-notebook/Dockerfile
+++ b/base-notebook/Dockerfile
@@ -26,7 +26,7 @@ USER root
 # Conda version
 ARG conda_version="4.9.2"
 # Miniforge installer patch version
-ARG miniforge_patch_number="0"
+ARG miniforge_patch_number="5"
 # Miniforge installer architecture
 ARG miniforge_arch="x86_64"
 # Python implementation to use 
@@ -38,7 +38,7 @@ ARG miniforge_version="${conda_version}-${miniforge_patch_number}"
 # Miniforge installer
 ARG miniforge_installer="${miniforge_python}-${miniforge_version}-Linux-${miniforge_arch}.sh"
 # Miniforge checksum
-ARG miniforge_checksum="6321775eb2c02d7f51d3a9004ce0be839099f126f4099c781531428536669560"
+ARG miniforge_checksum="49dddb3998550e40adc904dae55b0a2aeeb0bd9fc4306869cc4a600ec4b8b47c"
 
 # Install all OS dependencies for notebook server that starts but lacks all
 # features (e.g., download as all possible file formats)
@@ -131,7 +131,9 @@ RUN wget --quiet "https://github.com/conda-forge/miniforge/releases/download/${m
 # Do all this in a single RUN command to avoid duplicating all of the
 # files across image layers when the permissions change
 RUN conda install --quiet --yes \
-    'notebook=6.1.6' \
+    # FIXME: Workaround to fix #1215, to be removed once fixed in upstream
+    'jedi=0.17.2' \
+    'notebook=6.2.0' \
     'jupyterhub=1.3.0' \
     'jupyterlab=2.2.9' && \
     conda clean --all -f -y && \


### PR DESCRIPTION
Hello,

This is a workaround to fix #1215. I've also bumped some dependencies in `base-notebook`.
This will have to be removed once fixed on upstream.

_Note: I've noticed in the previous build that iPython was downgraded to `7.18.1`, maybe a consequence of pinning jedi to `<1.18`._