### PR TITLE
Update image used in binder

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,9 @@ This change is tracked in the issue [#1217](https://github.com/jupyter/docker-st
 ## Quick Start
 
 You can try a
-[recent build of the jupyter/base-notebook image on mybinder.org](https://mybinder.org/v2/gh/jupyter/docker-stacks/master?filepath=README.ipynb)
-by simply clicking the preceding link. Otherwise, the two examples below may help you get started if
+[relatively recent build of the jupyter/base-notebook image on mybinder.org](https://mybinder.org/v2/gh/jupyter/docker-stacks/master?filepath=README.ipynb)
+by simply clicking the preceding link. The image used in binder was last updated on 19 Jan 2021.
+Otherwise, the two examples below may help you get started if
 you [have Docker installed](https://docs.docker.com/install/) know
 [which Docker image](http://jupyter-docker-stacks.readthedocs.io/en/latest/using/selecting.html) you
 want to use, and want to launch a single Jupyter Notebook server in a container.

--- a/binder/Dockerfile
+++ b/binder/Dockerfile
@@ -1,5 +1,5 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
-FROM jupyter/base-notebook:17aba6048f44
-ENV TAG="17aba6048f44"
+FROM jupyter/base-notebook:f0cd87ab1979
+ENV TAG="f0cd87ab1979"
 COPY binder/README.ipynb .

--- a/binder/Dockerfile
+++ b/binder/Dockerfile
@@ -1,5 +1,5 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
-FROM jupyter/base-notebook:7fb3bffa2e73
-ENV TAG="7fb3bffa2e73"
+FROM jupyter/base-notebook:aec555e49be6
+ENV TAG="aec555e49be6"
 COPY binder/README.ipynb .

--- a/binder/Dockerfile
+++ b/binder/Dockerfile
@@ -1,5 +1,5 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
-FROM jupyter/base-notebook:f0cd87ab1979
-ENV TAG="f0cd87ab1979"
+FROM jupyter/base-notebook:7fb3bffa2e73
+ENV TAG="7fb3bffa2e73"
 COPY binder/README.ipynb .


### PR DESCRIPTION
Fix #1219

The link to check that everything works:
https://mybinder.org/v2/gh/mathbunnyru/docker-stacks/master?filepath=README.ipynb

(The only change in the link is using `mathbunnyru` instead of `jupyter`, I committed directly to master)