### PR TITLE
Improve binder image

### DIFF
--- a/binder/Dockerfile
+++ b/binder/Dockerfile
@@ -1,5 +1,12 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
-FROM jupyter/base-notebook:aec555e49be6
+
+# https://hub.docker.com/r/jupyter/base-notebook/tags
+ARG BASE_CONTAINER=jupyter/base-notebook:aec555e49be6
+FROM $BASE_CONTAINER
+
+LABEL maintainer="Jupyter Project <jupyter@googlegroups.com>"
+
 ENV TAG="aec555e49be6"
 COPY binder/README.ipynb .
+RUN fix-permissions README.ipynb

--- a/binder/Dockerfile
+++ b/binder/Dockerfile
@@ -6,7 +6,16 @@ ARG BASE_CONTAINER=jupyter/base-notebook:aec555e49be6
 FROM $BASE_CONTAINER
 
 LABEL maintainer="Jupyter Project <jupyter@googlegroups.com>"
-
 ENV TAG="aec555e49be6"
+
 COPY binder/README.ipynb .
+
+# Fix permissions on README.ipynb as root
+USER root
+
 RUN fix-permissions README.ipynb
+
+# Switch back to jovyan to avoid accidental container runs as root
+USER $NB_UID
+
+WORKDIR $HOME


### PR DESCRIPTION
Main change is to make `README.ipynb` writeable.
Other changes are made to make this Dockerfile look similar to all the other notebook Dockerfiles we have.

Link to check the change:
https://mybinder.org/v2/gh/mathbunnyru/docker-stacks/asalikhov/improve_binder?filepath=README.ipynb
(Note: `mathbunnyru` (my fork) and branch name `asalikhov/improve_binder`)