### PR TITLE
JupyterLab 3.0 and other updates

### DIFF
--- a/base-notebook/Dockerfile
+++ b/base-notebook/Dockerfile
@@ -4,7 +4,7 @@
 # Ubuntu 20.04 (focal)
 # https://hub.docker.com/_/ubuntu/?tab=tags&name=focal
 # OS/ARCH: linux/amd64
-ARG ROOT_CONTAINER=ubuntu:focal-20201106@sha256:4e4bc990609ed865e07afc8427c30ffdddca5153fd4e82c20d8f0783a291e241
+ARG ROOT_CONTAINER=ubuntu:focal-20210119@sha256:3093096ee188f8ff4531949b8f6115af4747ec1c58858c091c8cb4579c39cc4e
 
 ARG BASE_CONTAINER=$ROOT_CONTAINER
 FROM $BASE_CONTAINER
@@ -135,7 +135,7 @@ RUN conda install --quiet --yes \
     'jedi=0.17.2' \
     'notebook=6.2.0' \
     'jupyterhub=1.3.0' \
-    'jupyterlab=2.2.9' && \
+    'jupyterlab=3.0.5' && \
     conda clean --all -f -y && \
     npm cache clean --force && \
     jupyter notebook --generate-config && \

--- a/datascience-notebook/Dockerfile
+++ b/datascience-notebook/Dockerfile
@@ -74,7 +74,7 @@ RUN conda install --quiet --yes \
     'r-rsqlite=2.2*' \
     'r-shiny=1.5*' \
     'r-tidyverse=1.3*' \
-    'rpy2=3.3*' && \
+    'rpy2=3.4*' && \
     conda clean --all -f -y && \
     fix-permissions "${CONDA_DIR}" && \
     fix-permissions "/home/${NB_USER}"

--- a/r-notebook/Dockerfile
+++ b/r-notebook/Dockerfile
@@ -46,7 +46,8 @@ RUN conda install --quiet --yes \
     'r-tidymodels=0.1*' \
     && \
     conda clean --all -f -y && \
-    fix-permissions "${CONDA_DIR}"
+    fix-permissions "${CONDA_DIR}" && \
+    fix-permissions "/home/${NB_USER}"
 
 # Install e1071 R package (dependency of the caret R package)
 RUN conda install --quiet --yes r-e1071

--- a/scipy-notebook/Dockerfile
+++ b/scipy-notebook/Dockerfile
@@ -22,43 +22,29 @@ RUN conda install --quiet --yes \
     'bottleneck=1.3.*' \
     'cloudpickle=1.6.*' \
     'cython=0.29.*' \
-    'dask=2020.12.*' \
+    'dask=2021.1.*' \
     'dill=0.3.*' \
     'h5py=3.1.*' \
     'ipywidgets=7.6.*' \
-    'ipympl=0.5.*'\
+    'ipympl=0.6.*'\
     'matplotlib-base=3.3.*' \
     'numba=0.52.*' \
     'numexpr=2.7.*' \
-    'pandas=1.1.*' \
+    'pandas=1.2.*' \
     'patsy=0.5.*' \
     'protobuf=3.14.*' \
     'pytables=3.6.*' \
     'scikit-image=0.18.*' \
     'scikit-learn=0.24.*' \
-    'scipy=1.5.*' \
+    'scipy=1.6.*' \
     'seaborn=0.11.*' \
     'sqlalchemy=1.3.*' \
     'statsmodels=0.12.*' \
     'sympy=1.7.*' \
     'vincent=0.4.*' \
     'widgetsnbextension=3.5.*'\
-    'xlrd=1.2.*' \
-    && \
+    'xlrd=2.0.*' && \
     conda clean --all -f -y && \
-    # Activate ipywidgets extension in the environment that runs the notebook server
-    jupyter nbextension enable --py widgetsnbextension --sys-prefix && \
-    # Also activate ipywidgets extension for JupyterLab
-    # Check this URL for most recent compatibilities
-    # https://github.com/jupyter-widgets/ipywidgets/tree/master/packages/jupyterlab-manager
-    jupyter labextension install @jupyter-widgets/jupyterlab-manager@^2.0.0 --no-build && \
-    jupyter labextension install @bokeh/jupyter_bokeh@^2.0.0 --no-build && \
-    jupyter labextension install jupyter-matplotlib@^0.7.2 --no-build && \
-    jupyter lab build -y && \
-    jupyter lab clean -y && \
-    npm cache clean --force && \
-    rm -rf "/home/${NB_USER}/.cache/yarn" && \
-    rm -rf "/home/${NB_USER}/.node-gyp" && \
     fix-permissions "${CONDA_DIR}" && \
     fix-permissions "/home/${NB_USER}"
 

--- a/scipy-notebook/test/test_extensions.py
+++ b/scipy-notebook/test/test_extensions.py
@@ -7,6 +7,7 @@ import pytest
 LOGGER = logging.getLogger(__name__)
 
 
+@pytest.mark.skip(reason="Not yet compliant with JupyterLab 3")
 @pytest.mark.parametrize(
     "extension",
     [
@@ -16,7 +17,13 @@ LOGGER = logging.getLogger(__name__)
     ],
 )
 def test_check_extension(container, extension):
-    """Basic check of each extension"""
+    """Basic check of each extension
+
+    The list of extensions can be obtained through this command
+
+    $ jupyter labextension list
+
+    """
     LOGGER.info(f"Checking the extension: {extension} ...")
     c = container.run(
         tty=True, command=["start.sh", "jupyter", "labextension", "check", extension]

--- a/tensorflow-notebook/Dockerfile
+++ b/tensorflow-notebook/Dockerfile
@@ -7,6 +7,6 @@ LABEL maintainer="Jupyter Project <jupyter@googlegroups.com>"
 
 # Install Tensorflow
 RUN pip install --quiet --no-cache-dir \
-    'tensorflow==2.4.0' && \
+    'tensorflow==2.4.1' && \
     fix-permissions "${CONDA_DIR}" && \
     fix-permissions "/home/${NB_USER}"


### PR DESCRIPTION
Upgrade to JupyterLab `3.0.x` as described in #1207 and other upgrades.

- `base-notebook`
  - `Changed`: Bump ubuntu
  - `Changed`: Bump `jupyterlab` -> Fixes #1207 and fixes #1167
- `scipy-notebook`
  - `Changed`: Bump `dask`
  - `Changed`: Bump `ipympl`
  - `Changed`: Bump `pandas`
  - `Changed`: Bump `scipy`
  - `Removed`: Jupyter Extension management through `npm` and `jupyter labextension`.
    It is not necessary anymore, and I have checked that both `ipywidgets` and `matplotlib` are working with JupyterLab and Jupyter. It speeds up the build time.
  - `Removed`: Skip extension test, see limitations below for detail
- `datascience-notebook`
  - `Changed`: Bump `rpy2`
- `tensorflow-notebook`
  - `Changed`: Bump `tensorflow`

Even with the limitations (Bokeh extension is the only regression) listed below, I think it is reasonable to merge it.

## Limitations

### Bokeh extension not available

Bokeh extension is not ready for JupyterLab `3.0.x` see https://github.com/bokeh/bokeh/issues/10569.

### Check extension

`jupyter labextension check` seems to not work anymore. We should create an issue in the upstream repo.

```bash
# Installation don't need to use node now
conda install --quiet --yes 'ipywidgets=7.6.*'

# Preparing transaction: ...working... done
# Verifying transaction: ...working... done
# Executing transaction: ...working... Enabling notebook extension jupyter-js-widgets/extension...
      - Validating: OK
      
# List extensions, everything is OK
jupyter labextension list

# JupyterLab v3.0.5
# /opt/conda/share/jupyter/labextensions
#        @jupyter-widgets/jupyterlab-manager v3.0.0 enabled OK (python, jupyterlab_widgets)

# However, the check does not work
jupyter labextension check @jupyter-widgets/jupyterlab-manager

# @jupyter-widgets/jupyterlab-manager: X
```

### Warning at start

There is a warning at the start that seems related to this configuration `c.ServerApp.open_browser = False` in `jupyter_server_config.py`, see https://github.com/jupyterlab/jupyterlab/issues/9360

```bash
# [W 2021-01-22 08:14:06.693 ServerApp] No web browser found: could not locate runnable browser.
```