### PR TITLE
Fixes #1215: remove the workaround

### DIFF
--- a/base-notebook/Dockerfile
+++ b/base-notebook/Dockerfile
@@ -131,8 +131,6 @@ RUN wget --quiet "https://github.com/conda-forge/miniforge/releases/download/${m
 # Do all this in a single RUN command to avoid duplicating all of the
 # files across image layers when the permissions change
 RUN conda install --quiet --yes \
-    # FIXME: Workaround to fix #1215, to be removed once fixed in upstream
-    'jedi=0.17.2' \
     'notebook=6.2.0' \
     'jupyterhub=1.3.0' \
     'jupyterlab=3.0.5' && \


### PR DESCRIPTION
The ipython package dependencies has been fixed in conda-forge see https://github.com/ipython/ipython/issues/12740#issuecomment-768898772. So it's no longer necessary to pin jedi here, as it is managed by the upstream dependency and it leads to the same result install jedi `0.17.2` instead of `0.18.0`.

Best