### PR TITLE
Update dask-labextension recipe for JupyterLab 3

### DIFF
--- a/docs/using/recipes.md
+++ b/docs/using/recipes.md
@@ -156,9 +156,7 @@ Run jupyterlab using a command such as
 FROM jupyter/scipy-notebook:latest
 
 # Install the Dask dashboard
-RUN pip install dask_labextension ; \
-    jupyter labextension install -y --clean \
-    dask-labextension
+RUN pip install dask-labextension
 
 # Dask Scheduler & Bokeh ports
 EXPOSE 8787


### PR DESCRIPTION
Following https://github.com/jupyter/docker-stacks/pull/1222 the `jupyter/scipy-notebook:latest` image now uses JupyterLab 3. This allows us to [streamline the installation process](https://github.com/dask/dask-labextension#jupyterlab-30-or-greater) in the Dask JupyterLab extension recipe.