### PR TITLE
Push all tags in docker push command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -154,7 +154,7 @@ pull/%: ## pull a jupyter image
 
 push/%: DARGS?=
 push/%: ## push all tags for a jupyter image
-	docker push $(DARGS) $(OWNER)/$(notdir $@)
+	docker push --all-tags $(DARGS) $(OWNER)/$(notdir $@)
 
 push-all: $(foreach I,$(ALL_IMAGES),push/$(I) ) ## push all tagged images
 


### PR DESCRIPTION
Fix https://github.com/jupyter/docker-stacks/issues/1237

There was a change in 20.10.0 docker:
https://docs.docker.com/engine/release-notes/#20100

`Add -a/--all-tags to docker push docker/cli#2220`

So, only the latest version is now pushed by default.
Since we don't fix the docker version and always use the latest one, it affected our setup.