### PR TITLE
update r-rmarkdown to 2.7*

### DIFF
--- a/datascience-notebook/Dockerfile
+++ b/datascience-notebook/Dockerfile
@@ -70,7 +70,7 @@ RUN conda install --quiet --yes \
     'r-nycflights13=1.0*' \
     'r-randomforest=4.6*' \
     'r-rcurl=1.98*' \
-    'r-rmarkdown=2.6*' \
+    'r-rmarkdown=2.7*' \
     'r-rsqlite=2.2*' \
     'r-shiny=1.6*' \
     'r-tidyverse=1.3*' \

--- a/r-notebook/Dockerfile
+++ b/r-notebook/Dockerfile
@@ -37,7 +37,7 @@ RUN conda install --quiet --yes \
     'r-nycflights13=1.0*' \
     'r-randomforest=4.6*' \
     'r-rcurl=1.98*' \
-    'r-rmarkdown=2.6*' \
+    'r-rmarkdown=2.7*' \
     'r-rodbc=1.3*' \
     'r-rsqlite=2.2*' \
     'r-shiny=1.6*' \


### PR DESCRIPTION
Title says it all readlly. I  was updating the images I built for Kubeflow and saw that  r-rmarkdown 2.7 was released 5 days ago. Thought the jupyter docker-stacks could also use the update. 