### PR TITLE
Install mamba in base-notebook

### DIFF
--- a/base-notebook/Dockerfile
+++ b/base-notebook/Dockerfile
@@ -26,24 +26,24 @@ USER root
 # Conda version
 ARG conda_version="4.9.2"
 # Miniforge installer patch version
-ARG miniforge_patch_number="5"
+ARG miniforge_patch_number="7"
 # Miniforge installer architecture
 ARG miniforge_arch="x86_64"
 # Python implementation to use 
 # can be either Miniforge3 to use Python or Miniforge-pypy3 to use PyPy
-ARG miniforge_python="Miniforge3"
+ARG miniforge_python="Mambaforge"
 
 # Miniforge archive to install
 ARG miniforge_version="${conda_version}-${miniforge_patch_number}"
 # Miniforge installer
 ARG miniforge_installer="${miniforge_python}-${miniforge_version}-Linux-${miniforge_arch}.sh"
 # Miniforge checksum
-ARG miniforge_checksum="49dddb3998550e40adc904dae55b0a2aeeb0bd9fc4306869cc4a600ec4b8b47c"
+ARG miniforge_checksum="5a827a62d98ba2217796a9dc7673380257ed7c161017565fba8ce785fb21a599"
 
 # Install all OS dependencies for notebook server that starts but lacks all
 # features (e.g., download as all possible file formats)
 ENV DEBIAN_FRONTEND noninteractive
-RUN apt-get update \
+RUN apt-get -q update \
  && apt-get install -yq --no-install-recommends \
     wget \
     ca-certificates \
@@ -102,7 +102,7 @@ RUN mkdir "/home/$NB_USER/work" && \
 # Install conda as jovyan and check the sha256 sum provided on the download site
 WORKDIR /tmp
 
-# Prerequisites installation: conda, pip, tini
+# Prerequisites installation: conda, mamba, pip, tini
 RUN wget --quiet "https://github.com/conda-forge/miniforge/releases/download/${miniforge_version}/${miniforge_installer}" && \
     echo "${miniforge_checksum} *${miniforge_installer}" | sha256sum --check && \
     /bin/bash "${miniforge_installer}" -f -b -p $CONDA_DIR && \

--- a/base-notebook/Dockerfile
+++ b/base-notebook/Dockerfile
@@ -29,8 +29,9 @@ ARG conda_version="4.9.2"
 ARG miniforge_patch_number="7"
 # Miniforge installer architecture
 ARG miniforge_arch="x86_64"
-# Python implementation to use 
-# can be either Miniforge3 to use Python or Miniforge-pypy3 to use PyPy
+# Package Manager and Python implementation to use (https://github.com/conda-forge/miniforge)
+# - conda only: either Miniforge3 to use Python or Miniforge-pypy3 to use PyPy
+# - conda + mamba: either Mambaforge to use Python or Mambaforge-pypy3 to use PyPy
 ARG miniforge_python="Mambaforge"
 
 # Miniforge archive to install

--- a/base-notebook/test/test_package_managers.py
+++ b/base-notebook/test/test_package_managers.py
@@ -1,0 +1,24 @@
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+
+import logging
+import pytest
+
+LOGGER = logging.getLogger(__name__)
+
+
+@pytest.mark.parametrize(
+    "package_manager, cmd", [("apt", "--version"), ("conda", "--version"), ("mamba", "--version"), ("npm", "--version")]
+)
+def test_package_manager(container, package_manager, cmd):
+    """Test the notebook start-notebook script"""
+    LOGGER.info(
+        f"Test that the package manager {package_manager} is working properly ..."
+    )
+    c = container.run(
+        tty=True, command=["start.sh", "bash", "-c", f"{package_manager} {cmd}"]
+    )
+    rv = c.wait(timeout=5)
+    logs = c.logs(stdout=True).decode("utf-8")
+    assert rv == 0 or rv["StatusCode"] == 0, f"Package manager {package_manager} not working"
+    LOGGER.debug(logs)

--- a/base-notebook/test/test_package_managers.py
+++ b/base-notebook/test/test_package_managers.py
@@ -14,6 +14,7 @@ LOGGER = logging.getLogger(__name__)
         ("conda", "--version"),
         ("mamba", "--version"),
         ("npm", "--version"),
+        ("pip", "--version"),
     ],
 )
 def test_package_manager(container, package_manager, cmd):

--- a/base-notebook/test/test_package_managers.py
+++ b/base-notebook/test/test_package_managers.py
@@ -8,7 +8,13 @@ LOGGER = logging.getLogger(__name__)
 
 
 @pytest.mark.parametrize(
-    "package_manager, cmd", [("apt", "--version"), ("conda", "--version"), ("mamba", "--version"), ("npm", "--version")]
+    "package_manager, cmd",
+    [
+        ("apt", "--version"),
+        ("conda", "--version"),
+        ("mamba", "--version"),
+        ("npm", "--version"),
+    ],
 )
 def test_package_manager(container, package_manager, cmd):
     """Test the notebook start-notebook script"""
@@ -20,5 +26,7 @@ def test_package_manager(container, package_manager, cmd):
     )
     rv = c.wait(timeout=5)
     logs = c.logs(stdout=True).decode("utf-8")
-    assert rv == 0 or rv["StatusCode"] == 0, f"Package manager {package_manager} not working"
+    assert (
+        rv == 0 or rv["StatusCode"] == 0
+    ), f"Package manager {package_manager} not working"
     LOGGER.debug(logs)

--- a/docs/using/common.md
+++ b/docs/using/common.md
@@ -105,12 +105,13 @@ You can bypass the provided scripts and specify an arbitrary start command. If y
 
 The default Python 3.x [Conda environment](http://conda.pydata.org/docs/using/envs.html) resides in `/opt/conda`. The `/opt/conda/bin` directory is part of the default `jovyan` user's `$PATH`. That directory is also whitelisted for use in `sudo` commands by the `start.sh` script.
 
-The `jovyan` user has full read/write access to the `/opt/conda` directory. You can use either `conda` or `pip` to install new packages without any additional permissions.
+The `jovyan` user has full read/write access to the `/opt/conda` directory. You can use either `conda`, `mamba` or `pip` to install new packages without any additional permissions.
 
 ```bash
 # install a package into the default (python 3.x) environment
 pip install some-package
 conda install some-package
+mamba install some-package
 ```
 
 ### Using alternative channels

--- a/docs/using/selecting.md
+++ b/docs/using/selecting.md
@@ -28,7 +28,9 @@ and versioning strategy.
 [options common across all core stacks](common.md). It is the basis for all other stacks.
 
 - Minimally-functional Jupyter Notebook server (e.g., no LaTeX support for saving notebooks as PDFs)
-- [Miniforge](https://github.com/conda-forge/miniforge) Python 3.x in `/opt/conda`
+- [Miniforge](https://github.com/conda-forge/miniforge) Python 3.x in `/opt/conda` with two package managers
+  - [conda](https://github.com/conda/conda): "cross-platform, language-agnostic binary package manager".
+  - [mamba](https://github.com/mamba-org/mamba): "reimplementation of the conda package manager in C++".
 - No preinstalled scientific computing packages
 - Unprivileged user `jovyan` (`uid=1000`, configurable, see options) in group `users` (`gid=100`)
   with ownership over the `/home/jovyan` and `/opt/conda` paths


### PR DESCRIPTION
Hello,

This PR replaces #1213 and resolves #1210: installation of [Mamba][1] in `base-notebook`.
This time Mamba is only installed and not used to install packages of the stack, so it will be available to end users as a _faster_ alternative to Conda if they want to install their own packages. It seems to be a feature required by several users.

- Installation: I have used a flavor of the [Miniforge][2] installer shipping `mamba` by default.
- Docs: Updated, maybe I missed some.
- Test: Added generic test `test_package_managers.py` for all package managers including `mamba`.
- Size: +23MB penalty on all images
```bash
REPOSITORY              TAG               IMAGE ID       CREATED          SIZE
jupyter/base-notebook   latest            bdb5390b61b5   24 minutes ago   704MB
jupyter/base-notebook   <none>            d5b486f8e692   2 days ago       681MB
```
- Mamba versioning: I wondered how to manage this point, I've chosen for now the simplest way
  - I have not coded something complex to manage Mamba version (pin, default vs. defined version). 
  - It will be automatically updated to the latest version because of the following line
https://github.com/jupyter/docker-stacks/blob/67b8fb91f950d0099b179f27b7c6eeccb3179a9f/base-notebook/Dockerfile#L120

Best

[1]: https://github.com/mamba-org/mamba
[2]: https://github.com/conda-forge/miniforge