### PR TITLE
Add MySQL connector jar to pyspark Dockerfile to be able to connect to host MySQL instance

### DIFF
--- a/pyspark-notebook/Dockerfile
+++ b/pyspark-notebook/Dockerfile
@@ -17,6 +17,7 @@ ARG spark_version="3.1.1"
 ARG hadoop_version="3.2"
 ARG spark_checksum="E90B31E58F6D95A42900BA4D288261D71F6C19FA39C1CB71862B792D1B5564941A320227F6AB0E09D946F16B8C1969ED2DEA2A369EC8F9D2D7099189234DE1BE"
 ARG openjdk_version="11"
+ARG mysql_connector_version="8.0.23"
 
 ENV APACHE_SPARK_VERSION="${spark_version}" \
     HADOOP_VERSION="${hadoop_version}"
@@ -54,6 +55,9 @@ RUN ln -s "spark-${APACHE_SPARK_VERSION}-bin-hadoop${HADOOP_VERSION}" spark && \
 RUN cp -p "$SPARK_HOME/conf/spark-defaults.conf.template" "$SPARK_HOME/conf/spark-defaults.conf" && \
     echo 'spark.driver.extraJavaOptions="-Dio.netty.tryReflectionSetAccessible=true"' >> $SPARK_HOME/conf/spark-defaults.conf && \
     echo 'spark.executor.extraJavaOptions="-Dio.netty.tryReflectionSetAccessible=true"' >> $SPARK_HOME/conf/spark-defaults.conf
+
+# Add MySQL connector
+RUN wget -q https://repo1.maven.org/maven2/mysql/mysql-connector-java/${mysql_connector_version}/mysql-connector-java-${mysql_connector_version}.jar -P /usr/local/spark/jars/
 
 USER $NB_UID
 


### PR DESCRIPTION
# Description

I want to be able to connect pyspark to the host instance of MySQL without having to mount a mysql-connector jar on container start

# Steps to Reproduce

1. Create a `SparkSession`

```python
from pyspark.sql import SparkSession

spark = SparkSession\
    .builder\
    .appName("Test App")\
    .getOrCreate()
```
2. Attempt to connect to your host machine's MySQL instance

```python
actor_frame = spark.read.format("jdbc") \
    .option("url", "jdbc:mysql://host.docker.internal:3306/sakila") \
    .option("driver", "com.mysql.cj.jdbc.Driver") \
    .option("dbtable", "actor") \ # actor is a table name
    .option("user", "root") \ # mysql username here
    .option("password", "") \ # mysql password here
    .load()
```

3. Attempt to load the frame created from step 2

```python
actor_frame.show()
```

# Screenshots

Error
<img width="1015" alt="Screen Shot 2021-03-20 at 11 41 42 AM" src="https://user-images.githubusercontent.com/1951558/111883015-f46e9980-8975-11eb-90a4-d4db7a9e2df4.png">

Success
<img width="550" alt="Screen Shot 2021-03-20 at 11 53 16 AM" src="https://user-images.githubusercontent.com/1951558/111883025-05b7a600-8976-11eb-80c2-b53143f53efb.png">
