### PR TITLE
Install spark from archive.apache.org to be able to use old versions

### DIFF
--- a/docs/using/specifics.md
+++ b/docs/using/specifics.md
@@ -12,7 +12,7 @@ This page provides details about features specific to one or more images.
 
 You can build a `pyspark-notebook` image (and also the downstream `all-spark-notebook` image) with a different version of Spark by overriding the default value of the following arguments at build time.
 
-* Spark distribution is defined by the combination of the Spark and the Hadoop version and verified by the package checksum, see [Download Apache Spark](https://spark.apache.org/downloads.html) for more information.
+* Spark distribution is defined by the combination of the Spark and the Hadoop version and verified by the package checksum, see [Download Apache Spark](https://spark.apache.org/downloads.html) and the [archive repo](https://archive.apache.org/dist/spark/) for more information.
   * `spark_version`: The Spark version to install (`3.0.0`).
   * `hadoop_version`: The Hadoop version (`3.2`).
   * `spark_checksum`: The package checksum (`BFE4540...`).

--- a/docs/using/specifics.md
+++ b/docs/using/specifics.md
@@ -12,7 +12,7 @@ This page provides details about features specific to one or more images.
 
 You can build a `pyspark-notebook` image (and also the downstream `all-spark-notebook` image) with a different version of Spark by overriding the default value of the following arguments at build time.
 
-* Spark distribution is defined by the combination of the Spark and the Hadoop version and verified by the package checksum, see [Download Apache Spark](https://spark.apache.org/downloads.html) for more information. At this time the build will only work with the set of versions available on the Apache Spark download page, so it will not work with the archived versions.
+* Spark distribution is defined by the combination of the Spark and the Hadoop version and verified by the package checksum, see [Download Apache Spark](https://spark.apache.org/downloads.html) for more information.
   * `spark_version`: The Spark version to install (`3.0.0`).
   * `hadoop_version`: The Hadoop version (`3.2`).
   * `spark_checksum`: The package checksum (`BFE4540...`).

--- a/pyspark-notebook/Dockerfile
+++ b/pyspark-notebook/Dockerfile
@@ -29,10 +29,8 @@ RUN apt-get -y update && \
 
 # Spark installation
 WORKDIR /tmp
-# Using the preferred mirror to download Spark
 # hadolint ignore=SC2046
-RUN wget -q $(wget -qO- https://www.apache.org/dyn/closer.lua/spark/spark-${APACHE_SPARK_VERSION}/spark-${APACHE_SPARK_VERSION}-bin-hadoop${HADOOP_VERSION}.tgz\?as_json | \
-    python -c "import sys, json; content=json.load(sys.stdin); print(content['preferred']+content['path_info'])") && \
+RUN wget -q "https://archive.apache.org/dist/spark/spark-${APACHE_SPARK_VERSION}/spark-${APACHE_SPARK_VERSION}-bin-hadoop${HADOOP_VERSION}.tgz" && \
     echo "${spark_checksum} *spark-${APACHE_SPARK_VERSION}-bin-hadoop${HADOOP_VERSION}.tgz" | sha512sum -c - && \
     tar xzf "spark-${APACHE_SPARK_VERSION}-bin-hadoop${HADOOP_VERSION}.tgz" -C /usr/local --owner root --group root --no-same-owner && \
     rm "spark-${APACHE_SPARK_VERSION}-bin-hadoop${HADOOP_VERSION}.tgz"

--- a/pyspark-notebook/Dockerfile
+++ b/pyspark-notebook/Dockerfile
@@ -29,7 +29,6 @@ RUN apt-get -y update && \
 
 # Spark installation
 WORKDIR /tmp
-# hadolint ignore=SC2046
 RUN wget -q "https://archive.apache.org/dist/spark/spark-${APACHE_SPARK_VERSION}/spark-${APACHE_SPARK_VERSION}-bin-hadoop${HADOOP_VERSION}.tgz" && \
     echo "${spark_checksum} *spark-${APACHE_SPARK_VERSION}-bin-hadoop${HADOOP_VERSION}.tgz" | sha512sum -c - && \
     tar xzf "spark-${APACHE_SPARK_VERSION}-bin-hadoop${HADOOP_VERSION}.tgz" -C /usr/local --owner root --group root --no-same-owner && \


### PR DESCRIPTION
Fix: https://github.com/jupyter/docker-stacks/issues/1163

@romainx as you suggested, in your issue, we could use a spark archive to be able to build the old spark versions.

You said, that we will put pressure on a specific download site.
I think that's true, at the same time it's `https://spark.apache.org`.
The pressure we create is only a few builds per day (at max).
And I think there are not so many people, who rebuild our images from scratch (I think it's not needed in most cases).

I agree that this way is less clever than using the preferred site.
At the same time, it's much easier to use only one `wget` command.

If I'm right, we haven't tried `https://archive.apache.org` as a mirror so it might be reliable to use (I hope it is).

I think - let's give `archive` a try, if everything goes well for us (and users), we will get simpler dockerfile and ability to customize spark version.
If not, it should be easy to revert the commit.