### PR TITLE
Use hadolint from pre-commit

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -42,9 +42,7 @@ jobs:
       - name: Install Dev Dependencies
         run: |
           python -m pip install --upgrade pip
-          make -C main dev-env hadolint-install
-      - name: Lint Dockerfiles
-        run: make -C main hadolint-all
+          make -C main dev-env
       - name: Run pre-commit hooks
         run: make -C main pre-commit-all
       - name: Build Docker Images

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,11 +6,11 @@ repos:
       - id: check-yaml
         files: .*\.(yaml|yml)$
   - repo: https://github.com/hadolint/hadolint.git
-    rev: v2.1.0
+    rev: v2.3.0
     hooks:
       - id: hadolint-docker
         # FIXME: remove after https://github.com/hadolint/hadolint/issues/628 is resolved
-        entry: hadolint/hadolint:v2.1.0 hadolint
+        entry: hadolint/hadolint:v2.3.0 hadolint
         exclude: Dockerfile.ppc64le|Dockerfile.ppc64le.patch
   - repo: https://github.com/adrienverge/yamllint.git
     rev: v1.26.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,9 +6,11 @@ repos:
       - id: check-yaml
         files: .*\.(yaml|yml)$
   - repo: https://github.com/hadolint/hadolint.git
-    rev: v2.3.0
+    rev: v2.1.0
     hooks:
       - id: hadolint-docker
+        # FIXME: remove after https://github.com/hadolint/hadolint/issues/628 is resolved
+        entry: hadolint/hadolint:v2.1.0 hadolint
         exclude: Dockerfile.ppc64le|Dockerfile.ppc64le.patch
   - repo: https://github.com/adrienverge/yamllint.git
     rev: v1.26.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,6 +5,11 @@ repos:
     hooks:
       - id: check-yaml
         files: .*\.(yaml|yml)$
+  - repo: https://github.com/hadolint/hadolint.git
+    rev: v2.3.0
+    hooks:
+      - id: hadolint-docker
+        exclude: Dockerfile.ppc64le|Dockerfile.ppc64le.patch
   - repo: https://github.com/adrienverge/yamllint.git
     rev: v1.26.1
     hooks:

--- a/Makefile
+++ b/Makefile
@@ -23,10 +23,6 @@ endif
 
 ALL_IMAGES:=$(ALL_STACKS)
 
-# Dockerfile Linter
-HADOLINT="${HOME}/hadolint"
-HADOLINT_VERSION="v2.1.0"
-
 # Enable BuildKit for Docker build
 export DOCKER_BUILDKIT:=1
 
@@ -118,23 +114,6 @@ img-rm:  ## remove jupyter images
 img-rm-dang: ## remove dangling images (tagged None)
 	@echo "Removing dangling images ..."
 	-docker rmi --force $(shell docker images -f "dangling=true" -q) 2> /dev/null
-
-hadolint/%: ARGS?=
-hadolint/%: ## lint the dockerfile(s) for a stack
-	@echo "Linting Dockerfiles in $(notdir $@)..."
-	@git ls-files --exclude='Dockerfile*' --ignored $(notdir $@) | grep -v ppc64 | xargs -L 1 $(HADOLINT) $(ARGS)
-	@echo "Linting done!"
-
-hadolint-all: $(foreach I,$(ALL_IMAGES),hadolint/$(I) ) ## lint all stacks
-
-hadolint-build-test-all: $(foreach I,$(ALL_IMAGES),hadolint/$(I) arch_patch/$(I) build/$(I) test/$(I) ) ## lint, build and test all stacks
-
-hadolint-install: ## install hadolint
-	@echo "Installing hadolint at $(HADOLINT) ..."
-	@curl -sL -o $(HADOLINT) "https://github.com/hadolint/hadolint/releases/download/$(HADOLINT_VERSION)/hadolint-$(shell uname -s)-$(shell uname -m)"
-	@chmod 700 $(HADOLINT)
-	@echo "Installation done!"
-	@$(HADOLINT) --version
 
 pre-commit-all: ## run pre-commit hook on all files
 	@pre-commit run --all-files

--- a/binder/Dockerfile
+++ b/binder/Dockerfile
@@ -8,6 +8,7 @@ FROM $BASE_CONTAINER
 LABEL maintainer="Jupyter Project <jupyter@googlegroups.com>"
 ENV TAG="aec555e49be6"
 
+WORKDIR $HOME
 COPY binder/README.ipynb .
 
 # Fix permissions on README.ipynb as root

--- a/docs/contributing/lint.md
+++ b/docs/contributing/lint.md
@@ -29,6 +29,8 @@ $ make pre-commit-install
 Now pre-commit (and so configured hooks) will run automatically on `git commit` on each changed file.
 However it is also possible to trigger it against all files.
 
+- Note: Hadolint pre-commit uses docker to run, so docker should be running while running this command.
+
 ```sh
 $ make pre-commit-all
 ```
@@ -37,57 +39,10 @@ $ make pre-commit-all
 
 To comply with [Docker best practices][dbp], we are using the [Hadolint][hadolint] tool to analyse each `Dockerfile` .
 
-### Installation
-
-There is a specific `make` target to install the linter.
-By default `hadolint` will be installed in `${HOME}/hadolint`.
-
-```bash
-$ make hadolint-install
-
-# Installing hadolint at /Users/romain/hadolint ...
-# Installation done!
-# Haskell Dockerfile Linter v1.17.6-0-gc918759
-```
-
-### Linting
-
-#### Per Stack
-
-The linter can be run per stack.
-
-```bash
-$ make hadolint/scipy-notebook
-
-# Linting Dockerfiles in scipy-notebook...
-# scipy-notebook/Dockerfile:4 DL3006 Always tag the version of an image explicitly
-# scipy-notebook/Dockerfile:11 DL3008 Pin versions in apt get install. Instead of `apt-get install <package>` use `apt-get install <package>=<version>`
-# scipy-notebook/Dockerfile:18 SC2086 Double quote to prevent globbing and word splitting.
-# scipy-notebook/Dockerfile:68 SC2086 Double quote to prevent globbing and word splitting.
-# scipy-notebook/Dockerfile:68 DL3003 Use WORKDIR to switch to a directory
-# scipy-notebook/Dockerfile:79 SC2086 Double quote to prevent globbing and word splitting.
-# make: *** [lint/scipy-notebook] Error 1
-```
-
-Optionally you can pass arguments to the hadolint.
-
-```bash
-# Use a different export format
-$ make hadolint/scipy-notebook ARGS="--format codeclimate"
-```
-
-#### All the Stacks
-
-The linter can be run against all the stacks.
-
-```bash
-$ make hadolint-all
-```
-
 ### Ignoring Rules
 
 Sometimes it is necessary to ignore [some rules][rules].
-The following rules are ignored by default and sor for all images in the `.hadolint.yaml` file.
+The following rules are ignored by default for all images in the `.hadolint.yaml` file.
 
 - [`DL3006`][DL3006]: We use a specific policy to manage image tags.
   - `base-notebook` `FROM` clause is fixed but based on an argument (`ARG`).
@@ -99,7 +54,6 @@ For other rules, the preferred way to do it is to flag ignored rules in the `Doc
 > It is also possible to ignore rules by using a special comment directly above the Dockerfile instruction you want to make an exception for. Ignore rule comments look like `# hadolint ignore=DL3001,SC1081`. For example:
 
 ```dockerfile
-
 FROM ubuntu
 
 # hadolint ignore=DL3003,SC1035


### PR DESCRIPTION
Thanks to https://github.com/hadolint/hadolint/pull/523 we can use hadolint directly in `pre-commit`.

Downsides:
- being able to run hadolint on a specific image with `make` command. But it is actually still possible to run it via `pre-commit --run` flags.
- need to be running docker to run hadolint. But this project uses docker for basically everything, so this should not be a problem.

Upsides:
- 21 deletions in Makefile
- approximately 50 deletions in docs
- The setup is easier because there are no specific things for hadolint
- No hadolint binary in HOME (I didn't like this on my mac)
- Pre-commit hooks versions could be updated automatically (I will try to do it later)
