### PR TITLE
Update JupyterHub to 1.4.1 and JupyterLab to 3.0.15

### DIFF
--- a/base-notebook/Dockerfile
+++ b/base-notebook/Dockerfile
@@ -133,7 +133,7 @@ RUN wget --quiet "https://github.com/conda-forge/miniforge/releases/download/${m
 RUN conda install --quiet --yes \
     'notebook=6.3.0' \
     'jupyterhub=1.4.1' \
-    'jupyterlab=3.0.14' && \
+    'jupyterlab=3.0.15' && \
     conda clean --all -f -y && \
     npm cache clean --force && \
     jupyter notebook --generate-config && \

--- a/base-notebook/Dockerfile
+++ b/base-notebook/Dockerfile
@@ -132,7 +132,7 @@ RUN wget --quiet "https://github.com/conda-forge/miniforge/releases/download/${m
 # files across image layers when the permissions change
 RUN conda install --quiet --yes \
     'notebook=6.3.0' \
-    'jupyterhub=1.4.0' \
+    'jupyterhub=1.4.1' \
     'jupyterlab=3.0.14' && \
     conda clean --all -f -y && \
     npm cache clean --force && \


### PR DESCRIPTION
> JupyterHub 1.4 is a small release, with several enhancements, bug fixes, and new configuration options.

> 1.4.1 is a small bugfix release for 1.4.

[see JupyterHub changelog](https://jupyterhub.readthedocs.io/en/stable/changelog.html)

[see JupyterLab changlog](https://jupyterlab.readthedocs.io/en/stable/getting_started/changelog.html#v3-0-15)

I was not able to locally test due to [known issues](https://docs.docker.com/docker-for-mac/apple-silicon/#known-issues) with Docker on Apple silicon.