### PR TITLE
ci: provide a git diff on pre-commit failures

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -116,7 +116,7 @@ img-rm-dang: ## remove dangling images (tagged None)
 	-docker rmi --force $(shell docker images -f "dangling=true" -q) 2> /dev/null
 
 pre-commit-all: ## run pre-commit hook on all files
-	@pre-commit run --all-files
+	@pre-commit run --all-files || (printf "\n\n\n" && git --no-pager diff --color=always)
 
 pre-commit-install: ## set up the git hook scripts
 	@pre-commit --version

--- a/docs/using/selecting.md
+++ b/docs/using/selecting.md
@@ -238,7 +238,7 @@ core images and link them below.
   **nvidia/cuda** base image, the well-maintained **docker-stacks** that is integrated as submodule
   and GPU-able libraries like **Tensorflow**, **Keras** and **PyTorch** on top of it.
 
-- [PRP GPU Jupyter repo](https://gitlab.nautilus.optiputer.net/prp/jupyter-stack/-/tree/prp) and [Registry](https://gitlab.nautilus.optiputer.net/prp/jupyter-stack/container_registry): PRP (Pacific Research Platform) maintained registry for jupyter stack based on NVIDIA CUDA-enabled image. Added the PRP image with Pytorch and some other python packages, and GUI Desktop notebook based on https://github.com/jupyterhub/jupyter-remote-desktop-proxy.
+- [PRP GPU Jupyter repo](https://gitlab.nautilus.optiputer.net/prp/jupyter-stack/-/tree/prp) and [Registry](https://gitlab.nautilus.optiputer.net/prp/jupyter-stack/container_registry): PRP (Pacific Research Platform) maintained registry for jupyter stack based on NVIDIA CUDA-enabled image. Added the PRP image with Pytorch and some other python packages, and GUI Desktop notebook based on <https://github.com/jupyterhub/jupyter-remote-desktop-proxy>.
 
 - [cgspatial-notebook](https://github.com/SCiO-systems/cgspatial-notebook) is a community Jupyter
   Docker Stack image. The image includes major geospatial Python & R libraries on top of the


### PR DESCRIPTION
This PR fixes a markdown formatting error and ensures that future errors caught by pre-commit will emit relevant information by showing a `git diff`.