### PR TITLE
Install tini from the ubuntu package

### DIFF
--- a/base-notebook/Dockerfile
+++ b/base-notebook/Dockerfile
@@ -46,6 +46,7 @@ ARG miniforge_checksum="d4065b376f81b83cfef0c7316f97bb83337e4ae27eb988828363a578
 ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get -q update && \
     apt-get install -yq --no-install-recommends \
+    tini \
     wget \
     ca-certificates \
     sudo \
@@ -115,10 +116,8 @@ RUN wget --quiet "https://github.com/conda-forge/miniforge/releases/download/${m
     conda list python | grep '^python ' | tr -s ' ' | cut -d '.' -f 1,2 | sed 's/$/.*/' >> $CONDA_DIR/conda-meta/pinned && \
     conda install --quiet --yes \
     "conda=${CONDA_VERSION}" \
-    'pip' \
-    'tini=0.18.0' && \
+    'pip' && \
     conda update --all --quiet --yes && \
-    conda list tini | grep tini | tr -s ' ' | cut -d ' ' -f 1,2 >> $CONDA_DIR/conda-meta/pinned && \
     conda clean --all -f -y && \
     rm -rf /home/$NB_USER/.cache/yarn && \
     fix-permissions $CONDA_DIR && \

--- a/docs/using/selecting.md
+++ b/docs/using/selecting.md
@@ -238,7 +238,7 @@ core images and link them below.
   **nvidia/cuda** base image, the well-maintained **docker-stacks** that is integrated as submodule
   and GPU-able libraries like **Tensorflow**, **Keras** and **PyTorch** on top of it.
 
-- [PRP GPU Jupyter repo](https://gitlab.nautilus.optiputer.net/prp/jupyter-stack/-/tree/prp) and [Registry](https://gitlab.nautilus.optiputer.net/prp/jupyter-stack/container_registry): PRP (Pacific Research Platform) maintained registry for jupyter stack based on NVIDIA CUDA-enabled image. Added the PRP image with Pytorch and some other python packages, and GUI Desktop notebook based on https://github.com/jupyterhub/jupyter-remote-desktop-proxy.
+- [PRP GPU Jupyter repo](https://gitlab.nautilus.optiputer.net/prp/jupyter-stack/-/tree/prp) and [Registry](https://gitlab.nautilus.optiputer.net/prp/jupyter-stack/container_registry): PRP (Pacific Research Platform) maintained registry for jupyter stack based on NVIDIA CUDA-enabled image. Added the PRP image with Pytorch and some other python packages, and GUI Desktop notebook based on <https://github.com/jupyterhub/jupyter-remote-desktop-proxy>.
 
 - [cgspatial-notebook](https://github.com/SCiO-systems/cgspatial-notebook) is a community Jupyter
   Docker Stack image. The image includes major geospatial Python & R libraries on top of the


### PR DESCRIPTION
Hello,

According to @lima4658 suggestion in #1306, `tini` is now installed from the ubuntu package.
The installation is cleaner because we can remove the corresponding pin of the conda package.

Also added a test to check that `tini` is used as the `PID` 1 when launching the `base-notebook` container.

Best