### PR TITLE
Update tags in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ This change is tracked in the issue [#1217](https://github.com/jupyter/docker-st
 
 You can try a
 [relatively recent build of the jupyter/base-notebook image on mybinder.org](https://mybinder.org/v2/gh/jupyter/docker-stacks/master?filepath=README.ipynb)
-by simply clicking the preceding link. The image used in binder was last updated on 19 Jan 2021.
+by simply clicking the preceding link. The image used in binder was last updated on 22 May 2021.
 Otherwise, the two examples below may help you get started if
 you [have Docker installed](https://docs.docker.com/install/) know
 [which Docker image](https://jupyter-docker-stacks.readthedocs.io/en/latest/using/selecting.html) you
@@ -53,7 +53,7 @@ want to use, and want to launch a single Jupyter Notebook server in a container.
 The [User Guide on ReadTheDocs](https://jupyter-docker-stacks.readthedocs.io/) describes additional
 uses and features in detail.
 
-**Example 1:** This command pulls the `jupyter/scipy-notebook` image tagged `17aba6048f44` from
+**Example 1:** This command pulls the `jupyter/scipy-notebook` image tagged `33add21fab64` from
 Docker Hub if it is not already present on the local host. It then starts a container running a
 Jupyter Notebook server and exposes the server on host port 8888. The server logs appear in the
 terminal. Visiting `http://<hostname>:8888/?token=<token>` in a browser loads the Jupyter Notebook
@@ -61,16 +61,16 @@ dashboard page, where `hostname` is the name of the computer running docker and 
 secret token printed in the console. The container remains intact for restart after the notebook
 server exits.
 
-    docker run -p 8888:8888 jupyter/scipy-notebook:17aba6048f44
+    docker run -p 8888:8888 jupyter/scipy-notebook:33add21fab64
 
 **Example 2:** This command performs the same operations as **Example 1**, but it exposes the server
 on host port 10000 instead of port 8888. Visiting `http://<hostname>:10000/?token=<token>` in a
 browser loads JupyterLab, where `hostname` is the name of the computer running docker and `token` is
 the secret token printed in the console.::
 
-    docker run -p 10000:8888 jupyter/scipy-notebook:17aba6048f44
+    docker run -p 10000:8888 jupyter/scipy-notebook:33add21fab64
 
-**Example 3:** This command pulls the `jupyter/datascience-notebook` image tagged `9b06df75e445`
+**Example 3:** This command pulls the `jupyter/datascience-notebook` image tagged `33add21fab64`
 from Docker Hub if it is not already present on the local host. It then starts an _ephemeral_
 container running a Jupyter Notebook server and exposes the server on host port 10000. The command
 mounts the current working directory on the host as `/home/jovyan/work` in the container. The server
@@ -79,7 +79,7 @@ JupyterLab, where `hostname` is the name of the computer running docker and `tok
 token printed in the console. Docker destroys the container after notebook server exit, but any
 files written to `~/work` in the container remain intact on the host.
 
-    docker run --rm -p 10000:8888 -e JUPYTER_ENABLE_LAB=yes -v "$PWD":/home/jovyan/work jupyter/datascience-notebook:9b06df75e445
+    docker run --rm -p 10000:8888 -e JUPYTER_ENABLE_LAB=yes -v "$PWD":/home/jovyan/work jupyter/datascience-notebook:33add21fab64
 
 ## Contributing
 

--- a/binder/Dockerfile
+++ b/binder/Dockerfile
@@ -2,11 +2,11 @@
 # Distributed under the terms of the Modified BSD License.
 
 # https://hub.docker.com/r/jupyter/base-notebook/tags
-ARG BASE_CONTAINER=jupyter/base-notebook:aec555e49be6
+ARG BASE_CONTAINER=jupyter/base-notebook:33add21fab64
 FROM $BASE_CONTAINER
 
 LABEL maintainer="Jupyter Project <jupyter@googlegroups.com>"
-ENV TAG="aec555e49be6"
+ENV TAG="33add21fab64"
 
 WORKDIR $HOME
 COPY binder/README.ipynb .

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -14,17 +14,17 @@ You can try a `recent build of the jupyter/base-notebook image on mybinder.org <
 
 The other pages in this documentation describe additional uses and features in detail.
 
-**Example 1:** This command pulls the ``jupyter/scipy-notebook`` image tagged ``17aba6048f44`` from Docker Hub if it is not already present on the local host. It then starts a container running a Jupyter Notebook server and exposes the server on host port 8888. The server logs appear in the terminal. Visiting ``http://<hostname>:8888/?token=<token>`` in a browser loads the Jupyter Notebook dashboard page, where ``hostname`` is the name of the computer running docker and ``token`` is the secret token printed in the console. The container remains intact for restart after the notebook server exits.::
+**Example 1:** This command pulls the ``jupyter/scipy-notebook`` image tagged ``33add21fab64`` from Docker Hub if it is not already present on the local host. It then starts a container running a Jupyter Notebook server and exposes the server on host port 8888. The server logs appear in the terminal. Visiting ``http://<hostname>:8888/?token=<token>`` in a browser loads the Jupyter Notebook dashboard page, where ``hostname`` is the name of the computer running docker and ``token`` is the secret token printed in the console. The container remains intact for restart after the notebook server exits.::
 
-    docker run -p 8888:8888 jupyter/scipy-notebook:17aba6048f44
+    docker run -p 8888:8888 jupyter/scipy-notebook:33add21fab64
 
 **Example 2:** This command performs the same operations as **Example 1**, but it exposes the server on host port 10000 instead of port 8888. Visiting ``http://<hostname>:10000/?token=<token>`` in a browser loads JupyterLab, where ``hostname`` is the name of the computer running docker and ``token`` is the secret token printed in the console.::
 
-    docker run -p 10000:8888 jupyter/scipy-notebook:17aba6048f44
+    docker run -p 10000:8888 jupyter/scipy-notebook:33add21fab64
 
-**Example 3:** This command pulls the ``jupyter/datascience-notebook`` image tagged ``9b06df75e445`` from Docker Hub if it is not already present on the local host. It then starts an *ephemeral* container running a Jupyter Notebook server and exposes the server on host port 10000. The command mounts the current working directory on the host as ``/home/jovyan/work`` in the container. The server logs appear in the terminal. Visiting ``http://<hostname>:10000/?token=<token>`` in a browser loads JupyterLab, where ``hostname`` is the name of the computer running docker and ``token`` is the secret token printed in the console. Docker destroys the container after notebook server exit, but any files written to ``~/work`` in the container remain intact on the host.::
+**Example 3:** This command pulls the ``jupyter/datascience-notebook`` image tagged ``33add21fab64`` from Docker Hub if it is not already present on the local host. It then starts an *ephemeral* container running a Jupyter Notebook server and exposes the server on host port 10000. The command mounts the current working directory on the host as ``/home/jovyan/work`` in the container. The server logs appear in the terminal. Visiting ``http://<hostname>:10000/?token=<token>`` in a browser loads JupyterLab, where ``hostname`` is the name of the computer running docker and ``token`` is the secret token printed in the console. Docker destroys the container after notebook server exit, but any files written to ``~/work`` in the container remain intact on the host.::
 
-    docker run --rm -p 10000:8888 -e JUPYTER_ENABLE_LAB=yes -v "$PWD":/home/jovyan/work jupyter/datascience-notebook:9b06df75e445
+    docker run --rm -p 10000:8888 -e JUPYTER_ENABLE_LAB=yes -v "$PWD":/home/jovyan/work jupyter/datascience-notebook:33add21fab64
 
 Table of Contents
 -----------------

--- a/docs/using/recipes.md
+++ b/docs/using/recipes.md
@@ -30,7 +30,7 @@ Create a new Dockerfile like the one shown below.
 
 ```dockerfile
 # Start from a core stack version
-FROM jupyter/datascience-notebook:9f9e5ca8fe5a
+FROM jupyter/datascience-notebook:33add21fab64
 # Install in the default python3 environment
 RUN pip install 'ggplot==0.6.8'
 ```
@@ -46,7 +46,7 @@ packages desired. Next, create a new Dockerfile like the one shown below.
 
 ```dockerfile
 # Start from a core stack version
-FROM jupyter/datascience-notebook:9f9e5ca8fe5a
+FROM jupyter/datascience-notebook:33add21fab64
 # Install from requirements.txt file
 COPY --chown=${NB_UID}:${NB_GID} requirements.txt /tmp/
 RUN pip install --requirement /tmp/requirements.txt && \
@@ -58,7 +58,7 @@ For conda, the Dockerfile is similar:
 
 ```dockerfile
 # Start from a core stack version
-FROM jupyter/datascience-notebook:9f9e5ca8fe5a
+FROM jupyter/datascience-notebook:33add21fab64
 # Install from requirements.txt file
 COPY --chown=${NB_UID}:${NB_GID} requirements.txt /tmp/
 RUN conda install --yes --file /tmp/requirements.txt && \
@@ -312,7 +312,7 @@ To use a specific version of JupyterHub, the version of `jupyterhub` in your ima
 version in the Hub itself.
 
 ```dockerfile
-FROM jupyter/base-notebook:5ded1de07260
+FROM jupyter/base-notebook:33add21fab64
 RUN pip install jupyterhub==0.8.0b1
 ```
 
@@ -478,13 +478,13 @@ convenient to launch the server without a password or token. In this case, you s
 For jupyterlab:
 
 ```bash
-docker run jupyter/base-notebook:6d2a05346196 start.sh jupyter lab --LabApp.token=''
+docker run jupyter/base-notebook:33add21fab64 start.sh jupyter lab --LabApp.token=''
 ```
 
 For jupyter classic:
 
 ```bash
-docker run jupyter/base-notebook:6d2a05346196 start.sh jupyter notebook --NotebookApp.token=''
+docker run jupyter/base-notebook:33add21fab64 start.sh jupyter notebook --NotebookApp.token=''
 ```
 
 ## Enable nbextension spellchecker for markdown (or any other nbextension)

--- a/docs/using/running.md
+++ b/docs/using/running.md
@@ -11,10 +11,10 @@ This section provides details about the second.
 
 You can launch a local Docker container from the Jupyter Docker Stacks using the [Docker command line interface](https://docs.docker.com/engine/reference/commandline/cli/). There are numerous ways to configure containers using the CLI. The following are some common patterns.
 
-**Example 1** This command pulls the `jupyter/scipy-notebook` image tagged `2c80cf3537ca` from Docker Hub if it is not already present on the local host. It then starts a container running a Jupyter Notebook server and exposes the server on host port 8888. The server logs appear in the terminal and include a URL to the notebook server.
+**Example 1** This command pulls the `jupyter/scipy-notebook` image tagged `33add21fab64` from Docker Hub if it is not already present on the local host. It then starts a container running a Jupyter Notebook server and exposes the server on host port 8888. The server logs appear in the terminal and include a URL to the notebook server.
 
 ```bash
-$ docker run -p 8888:8888 jupyter/scipy-notebook:2c80cf3537ca
+$ docker run -p 8888:8888 jupyter/scipy-notebook:33add21fab64
 
 Executing the command: jupyter notebook
 [I 15:33:00.567 NotebookApp] Writing notebook server cookie secret to /home/jovyan/.local/share/jupyter/runtime/notebook_cookie_secret
@@ -52,10 +52,10 @@ $ docker rm d67fe77f1a84
 d67fe77f1a84
 ```
 
-**Example 2** This command pulls the `jupyter/r-notebook` image tagged `e5c5a7d3e52d` from Docker Hub if it is not already present on the local host. It then starts a container running a Jupyter Notebook server and exposes the server on host port 10000. The server logs appear in the terminal and include a URL to the notebook server, but with the internal container port (8888) instead of the the correct host port (10000).
+**Example 2** This command pulls the `jupyter/r-notebook` image tagged `33add21fab64` from Docker Hub if it is not already present on the local host. It then starts a container running a Jupyter Notebook server and exposes the server on host port 10000. The server logs appear in the terminal and include a URL to the notebook server, but with the internal container port (8888) instead of the the correct host port (10000).
 
 ```bash
-$ docker run --rm -p 10000:8888 -v "$PWD":/home/jovyan/work jupyter/r-notebook:e5c5a7d3e52d
+$ docker run --rm -p 10000:8888 -v "$PWD":/home/jovyan/work jupyter/r-notebook:33add21fab64
 
 Executing the command: jupyter notebook
 [I 19:31:09.573 NotebookApp] Writing notebook server cookie secret to /home/jovyan/.local/share/jupyter/runtime/notebook_cookie_secret

--- a/docs/using/selecting.md
+++ b/docs/using/selecting.md
@@ -184,13 +184,13 @@ The `latest` tag in each Docker Hub repository tracks the master branch `HEAD` r
 
 Every image on Docker Hub also receives a 12-character tag which corresponds with the git commit SHA
 that triggered the image build. You can inspect the state of the `jupyter/docker-stacks` repository
-for that commit to review the definition of the image (e.g., images with tag 7c45ec67c8e7 were built
+for that commit to review the definition of the image (e.g., images with tag `33add21fab64` were built
 from
-[https://github.com/jupyter/docker-stacks/tree/7c45ec67c8e7](https://github.com/jupyter/docker-stacks/tree/7c45ec67c8e7)).
+<https://github.com/jupyter/docker-stacks/tree/33add21fab64>.
 
 You must refer to git-SHA image tags when stability and reproducibility are important in your work.
-(e.g. `FROM jupyter/scipy-notebook:7c45ec67c8e7`,
-`docker run -it --rm jupyter/scipy-notebook:7c45ec67c8e7`). You should only use `latest` when a
+(e.g. `FROM jupyter/scipy-notebook:33add21fab64`,
+`docker run -it --rm jupyter/scipy-notebook:33add21fab64`). You should only use `latest` when a
 one-off container instance is acceptable (e.g., you want to briefly try a new library in a
 notebook).
 

--- a/examples/docker-compose/README.md
+++ b/examples/docker-compose/README.md
@@ -41,7 +41,7 @@ notebook/down.sh
 You can customize the docker-stack notebook image to deploy by modifying the `notebook/Dockerfile`. For example, you can build and deploy a `jupyter/all-spark-notebook` by modifying the Dockerfile like so:
 
 ```dockerfile
-FROM jupyter/all-spark-notebook:55d5ca6be183
+FROM jupyter/all-spark-notebook:33add21fab64
 ...
 ```
 

--- a/examples/docker-compose/notebook/Dockerfile
+++ b/examples/docker-compose/notebook/Dockerfile
@@ -2,7 +2,7 @@
 # Distributed under the terms of the Modified BSD License.
 
 # Pick your favorite docker-stacks image
-FROM jupyter/minimal-notebook:55d5ca6be183
+FROM jupyter/minimal-notebook:33add21fab64
 
 USER root
 

--- a/examples/make-deploy/Dockerfile
+++ b/examples/make-deploy/Dockerfile
@@ -2,7 +2,7 @@
 # Distributed under the terms of the Modified BSD License.
 
 # Pick your favorite docker-stacks image
-FROM jupyter/minimal-notebook:2d125a7161b5
+FROM jupyter/minimal-notebook:33add21fab64
 
 USER root
 


### PR DESCRIPTION
I tried to find all the places where we have fixed tags.
And updated to tag `33add21fab64`, which was built an hour ago.
So, users will run the latest (and greatest) image when following our documentation.
It should also make maintenance easier - next time one grep + replace should be enough (right now there are about 10 different tags across all the docs).