### PR TITLE
Add nteract front end

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,7 @@ in working on the project.
 ## Jupyter Notebook Deprecation Notice
 
 Following [Jupyter Notebook notice](https://github.com/jupyter/notebook#notice), we encourage users to transition to JupyterLab.
-This can be done by passing the environment variable `JUPYTER_ENABLE_LAB=yes` at container startup,
-more information is available in the [documentation](https://jupyter-docker-stacks.readthedocs.io/en/latest/using/common.html#docker-options).
+This can be done by passing the environment variable `JUPYTER_ENABLE_LAB=yes` at container startup. Alternatively, you may pass the environment variable `NTERACT=yes` to use the [nteract](https://blog.nteract.io/nteract-on-jupyter-53cc2c38290d) front end. More information is available in the [documentation](https://jupyter-docker-stacks.readthedocs.io/en/latest/using/common.html#docker-options).
 
 At some point, JupyterLab will become the default for all of the Jupyter Docker stack images, however a new environment variable will be introduced to switch back to Jupyter Notebook if needed.
 

--- a/base-notebook/Dockerfile
+++ b/base-notebook/Dockerfile
@@ -123,7 +123,7 @@ RUN wget --quiet "https://github.com/conda-forge/miniforge/releases/download/${m
     fix-permissions $CONDA_DIR && \
     fix-permissions /home/$NB_USER
 
-# Install Jupyter Notebook, Lab, and Hub
+# Install Jupyter Notebook, Lab, nteract, and Hub
 # Generate a notebook server config
 # Cleanup temporary files
 # Correct permissions
@@ -132,7 +132,8 @@ RUN wget --quiet "https://github.com/conda-forge/miniforge/releases/download/${m
 RUN conda install --quiet --yes \
     'notebook=6.3.0' \
     'jupyterhub=1.4.1' \
-    'jupyterlab=3.0.15' && \
+    'jupyterlab=3.0.15' \
+    'nteract_on_jupyter=2.1.3' && \
     conda clean --all -f -y && \
     npm cache clean --force && \
     jupyter notebook --generate-config && \

--- a/base-notebook/start-notebook.sh
+++ b/base-notebook/start-notebook.sh
@@ -15,6 +15,8 @@ if [[ -n "${JUPYTERHUB_API_TOKEN}" ]]; then
 elif [[ -n "${JUPYTER_ENABLE_LAB}" ]]; then
     # shellcheck disable=SC1091
     . /usr/local/bin/start.sh $wrapper jupyter lab "$@"
+elif [[ -n "${NTERACT}" ]]; then
+    . /usr/local/bin/start.sh $wrapper jupyter nteract "$@"
 else
     echo "WARN: Jupyter Notebook deprecation notice https://github.com/jupyter/docker-stacks#jupyter-notebook-deprecation-notice."
     # shellcheck disable=SC1091


### PR DESCRIPTION
Add an option to use the [nteract front end extension](https://blog.nteract.io/nteract-on-jupyter-53cc2c38290d) in docker-stacks containers. Additional conda forge package is 28MB. 

The nteract front end provides a graphically clean front end interface ideal for both focused development and tidy presentations.