### PR TITLE
Add copy button to the docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -31,7 +31,8 @@ needs_sphinx = '2.1'
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
-    'myst_parser'
+    'myst_parser',
+    'sphinx_copybutton'
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,6 +5,7 @@ pre-commit
 pytest
 requests
 sphinx>=2.1
+sphinx-copybutton
 sphinx-intl
 tabulate
 transifex-client


### PR DESCRIPTION
This adds small copy button to all the code blocks.
I think it's quite nice and helpful (especially when copying one-liners)