### PR TITLE
Run pre-commit in separate workflow

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -7,14 +7,17 @@ on:
       - "binder/**"
       - "docs/**"
       - "examples/**"
+      - ".pre-commit-config.yaml"
   push:
     branches:
       - master
+      - main
     paths-ignore:
       - "*.md"
       - "binder/**"
       - "docs/**"
       - "examples/**"
+      - ".pre-commit-config.yaml"
 
 jobs:
   build:
@@ -43,8 +46,6 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           make -C main dev-env
-      - name: Run pre-commit hooks
-        run: make -C main pre-commit-all
       - name: Build Docker Images
         run: make -C main build-test-all
         env:

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,0 +1,31 @@
+name: Run pre-commit hooks
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+      - main
+
+jobs:
+  build:
+    name: Run pre-commit hooks
+    runs-on: ubuntu-latest
+    if: >
+      !contains(github.event.head_commit.message, 'ci skip') &&
+      !contains(github.event.pull_request.title, 'ci skip')
+    steps:
+      - name: Clone Main Repo
+        uses: actions/checkout@v2
+        with:
+          path: main
+      - name: Set Up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+      - name: Install Dev Dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install --upgrade pre-commit
+      - name: Run pre-commit hooks
+        run: make -C main pre-commit-all


### PR DESCRIPTION
Several reasons for this change:
- PRs like this shouldn't trigger docker build. https://github.com/jupyter/docker-stacks/pull/1339
- A bit faster CI (1 minute)
- Unfortunately, we can't fully rely on pre-commit.ci, because we use Docker-based linter and docker is not available in pre-commit.ci