### PR TITLE
Use python-version: 3.x in github actions

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Set Up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.8
+          python-version: 3.x
       - name: Install Dev Dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Set Up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.8
+          python-version: 3.x
       - name: Install Dev Dependencies
         run: |
           python -m pip install --upgrade pip


### PR DESCRIPTION
This is already used in sphinx, works fine.
And it will be easier to start using new features for the new code.

(Changing the python version here doesn't change the content of the docker image).