### PR TITLE
Clone wiki only for steps which need it

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -33,11 +33,6 @@ jobs:
         uses: actions/checkout@v2
         with:
           path: main
-      - name: Clone Wiki
-        uses: actions/checkout@v2
-        with:
-          repository: ${{github.repository}}.wiki
-          path: wiki
       - name: Set Up Python
         uses: actions/setup-python@v2
         with:
@@ -51,8 +46,20 @@ jobs:
         env:
           # Full logs for CI build
           BUILDKIT_PROGRESS: plain
+      - name: Clone Wiki
+        uses: actions/checkout@v2
+        with:
+          repository: ${{github.repository}}.wiki
+          path: wiki
       - name: Run Post-Build Hooks
         run: make -C main hook-all
+      - name: Push Wiki to GitHub
+        if: github.ref == 'refs/heads/master'
+        # Pass GITHUB_REPOSITORY directly to avoid conflict with GitHub Actions built-in env var
+        run: make -C main git-commit GITHUB_REPOSITORY='${{github.repository}}.wiki'
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          LOCAL_PATH: ../wiki
       - name: Login to Docker Hub
         if: github.ref == 'refs/heads/master'
         run: >
@@ -61,10 +68,3 @@ jobs:
       - name: Push Images to DockerHub
         if: github.ref == 'refs/heads/master'
         run: make -C main push-all
-      - name: Push Wiki to GitHub
-        if: github.ref == 'refs/heads/master'
-        # Pass GITHUB_REPOSITORY directly to avoid conflict with GitHub Actions built-in env var
-        run: make -C main git-commit GITHUB_REPOSITORY='${{github.repository}}.wiki'
-        env:
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-          LOCAL_PATH: ../wiki


### PR DESCRIPTION
This change is to address the situation in https://github.com/jupyter/docker-stacks/pull/1341 (also happened with me once).

Now we can't merge to the master if there is something in the master which is not yet built.
This will cause errors.
The reason for that is that in the docker builds we clone the wiki in the beginning, and at the end of the build update the wiki.
And in between, we build the images (it's a long step that takes more than 30 minutes now).
And then there will be two commits in the docs which change the docs in a different way.
So, the second build will not update wiki (manifests).
And so the CI will fail.

This commit uses wiki only for a minute:
- clone wiki (seconds)
- hook everything (1min15s)
- push wiki if it's master (seconds)

This way we lock the wiki only for a minute, so we have much more chances with the situation like I described.