### PR TITLE
Use docker/login-action instead of manual docker login

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -55,9 +55,10 @@ jobs:
         run: make -C main hook-all
       - name: Login to Docker Hub
         if: github.ref == 'refs/heads/master'
-        run: >
-          echo '${{secrets.DOCKERHUB_PASSWORD}}' | docker login --username
-          '${{secrets.DOCKERHUB_USERNAME}}' --password-stdin
+        uses: docker/login-action@v1
+        with:
+          username: ${{secrets.DOCKERHUB_USERNAME}}
+          password: ${{secrets.DOCKERHUB_PASSWORD}}
       - name: Push Images to DockerHub
         if: github.ref == 'refs/heads/master'
         run: make -C main push-all


### PR DESCRIPTION
This is more idiomatic on GitHub, doesn't create a warning, supports plenty of registries (https://github.com/marketplace/actions/docker-login) and does automatic logout in the end of the job.