### PR TITLE
Put quick start first in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,38 +10,6 @@
 Jupyter Docker Stacks are a set of ready-to-run [Docker images](https://hub.docker.com/u/jupyter)
 containing Jupyter applications and interactive computing tools.
 
-## Maintainer Help Wanted
-
-We value all positive contributions to the Docker stacks project, from
-[bug reports](https://jupyter-docker-stacks.readthedocs.io/en/latest/contributing/issues.html) to
-[pull requests](https://jupyter-docker-stacks.readthedocs.io/en/latest/contributing/packages.html)
-to
-[translations](https://jupyter-docker-stacks.readthedocs.io/en/latest/contributing/translations.html)
-to help answering questions. We'd also like to invite members of the community to help with two
-maintainer activities:
-
-- Issue triage: Reading and providing a first response to issues, labeling issues appropriately,
-  redirecting cross-project questions to Jupyter Discourse
-- Pull request reviews: Reading proposed documentation and code changes, working with the submitter
-  to improve the contribution, deciding if the contribution should take another form (e.g., a recipe
-  instead of a permanent change to the images)
-
-Anyone in the community can jump in and help with these activities at any time. We will happily
-grant additional permissions (e.g., ability to merge PRs) to anyone who shows an on-going interest
-in working on the project.
-
-## Jupyter Notebook Deprecation Notice
-
-Following [Jupyter Notebook notice](https://github.com/jupyter/notebook#notice), we encourage users to transition to JupyterLab.
-This can be done by passing the environment variable `JUPYTER_ENABLE_LAB=yes` at container startup,
-more information is available in the [documentation](https://jupyter-docker-stacks.readthedocs.io/en/latest/using/common.html#docker-options).
-
-At some point, JupyterLab will become the default for all of the Jupyter Docker stack images, however a new environment variable will be introduced to switch back to Jupyter Notebook if needed.
-
-After the change of default, and according to the Jupyter Notebook project status and its compatibility with JupyterLab, these Docker images may remove the classic Jupyter Notebook interface altogether in favor of another _classic-like_ UI built atop JupyterLab.
-
-This change is tracked in the issue [#1217](https://github.com/jupyter/docker-stacks/issues/1217), please check its content for more information.
-
 ## Quick Start
 
 You can try a
@@ -88,6 +56,38 @@ files written to `~/work` in the container remain intact on the host.
 Please see the [Contributor Guide on ReadTheDocs](https://jupyter-docker-stacks.readthedocs.io/) for
 information about how to contribute package updates, recipes, features, tests, and community
 maintained stacks.
+
+## Maintainer Help Wanted
+
+We value all positive contributions to the Docker stacks project, from
+[bug reports](https://jupyter-docker-stacks.readthedocs.io/en/latest/contributing/issues.html) to
+[pull requests](https://jupyter-docker-stacks.readthedocs.io/en/latest/contributing/packages.html)
+to
+[translations](https://jupyter-docker-stacks.readthedocs.io/en/latest/contributing/translations.html)
+to help answering questions. We'd also like to invite members of the community to help with two
+maintainer activities:
+
+- Issue triage: Reading and providing a first response to issues, labeling issues appropriately,
+  redirecting cross-project questions to Jupyter Discourse
+- Pull request reviews: Reading proposed documentation and code changes, working with the submitter
+  to improve the contribution, deciding if the contribution should take another form (e.g., a recipe
+  instead of a permanent change to the images)
+
+Anyone in the community can jump in and help with these activities at any time. We will happily
+grant additional permissions (e.g., ability to merge PRs) to anyone who shows an on-going interest
+in working on the project.
+
+## Jupyter Notebook Deprecation Notice
+
+Following [Jupyter Notebook notice](https://github.com/jupyter/notebook#notice), we encourage users to transition to JupyterLab.
+This can be done by passing the environment variable `JUPYTER_ENABLE_LAB=yes` at container startup,
+more information is available in the [documentation](https://jupyter-docker-stacks.readthedocs.io/en/latest/using/common.html#docker-options).
+
+At some point, JupyterLab will become the default for all of the Jupyter Docker stack images, however a new environment variable will be introduced to switch back to Jupyter Notebook if needed.
+
+After the change of default, and according to the Jupyter Notebook project status and its compatibility with JupyterLab, these Docker images may remove the classic Jupyter Notebook interface altogether in favor of another _classic-like_ UI built atop JupyterLab.
+
+This change is tracked in the issue [#1217](https://github.com/jupyter/docker-stacks/issues/1217), please check its content for more information.
 
 ## Alternatives
 


### PR DESCRIPTION
Just a small rearrange of sections - I want the users to see the quick start first and only then info about maintainers and jupyter notebook.