### PR TITLE
Add openssh-client (needed for git-over-ssh)

### DIFF
--- a/minimal-notebook/Dockerfile
+++ b/minimal-notebook/Dockerfile
@@ -19,6 +19,7 @@ RUN apt-get update --yes && \
     libxrender1 \
     lmodern \
     netcat \
+    openssh-client \
     # ---- nbconvert dependencies ----
     texlive-xetex \
     texlive-fonts-recommended \


### PR DESCRIPTION
As discussed in https://github.com/jupyter/docker-stacks/issues/1372, this PR adds `openssh-client` to the list of packages installed in the `minimal-notebook`. - It's needed for the git-over-ssh support.

Closes #1372 