### PR TITLE
Remove build-essential install

### DIFF
--- a/minimal-notebook/Dockerfile
+++ b/minimal-notebook/Dockerfile
@@ -10,7 +10,6 @@ USER root
 # Install all OS dependencies for fully functional notebook server
 RUN apt-get update --yes && \
     apt-get install --yes --no-install-recommends \
-    build-essential \
     vim-tiny \
     git \
     inkscape \


### PR DESCRIPTION
### PR description by @consideRatio

The `build-essentials` package was not a dependency to install other packages in the images of this repo, and it increased the minimal-notebook image size from 1.37GB to 1.55GB for example.

With the motivation that it is probably only relevant for users that depend on this image as a base image from other Dockerfiles where it is easy to install an additional `apt` package, this PR propose it is deleted. If this caused a breaking change for you, and you were using the image directly without using this image as a base image (via a `FROM` statement in a Dockerfile), please open an issue and describe that use case!