### PR TITLE
Use stefanzweifel/git-auto-commit-action to push to github

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -59,7 +59,7 @@ jobs:
         if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main'
         uses: stefanzweifel/git-auto-commit-action@v4
         with:
-          commit_message: "[ci skip] Automated publish for $GITHUB_SHA"
+          commit_message: "[ci skip] Automated publish for ${{github.sha}}"
           repository: ../wiki
       - name: Login to Docker Hub
         if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main'

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -60,7 +60,7 @@ jobs:
         uses: stefanzweifel/git-auto-commit-action@v4
         with:
           commit_message: "[ci skip] Automated publish for ${{github.sha}}"
-          repository: ../wiki
+          repository: wiki/
       - name: Login to Docker Hub
         if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main'
         uses: docker/login-action@v1

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -57,7 +57,7 @@ jobs:
         run: make -C main hook-all
       - name: Push Wiki to GitHub
         if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main'
-        uses: stefanzweifel/git-auto-commit-action@ 5dd17c3b53a58c1cb5eaab903826abe94765ccd6 # dependabot updates to latest release
+        uses: stefanzweifel/git-auto-commit-action@5dd17c3b53a58c1cb5eaab903826abe94765ccd6 # dependabot updates to latest release
         with:
           commit_message: "[ci skip] Automated publish for ${{github.sha}}"
           repository: wiki/

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -57,7 +57,7 @@ jobs:
         run: make -C main hook-all
       - name: Push Wiki to GitHub
         if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main'
-        uses: stefanzweifel/git-auto-commit-action@v4
+        uses: stefanzweifel/git-auto-commit-action@ 5dd17c3b53a58c1cb5eaab903826abe94765ccd6 # dependabot updates to latest release
         with:
           commit_message: "[ci skip] Automated publish for ${{github.sha}}"
           repository: wiki/

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -57,11 +57,10 @@ jobs:
         run: make -C main hook-all
       - name: Push Wiki to GitHub
         if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main'
-        # Pass GITHUB_REPOSITORY directly to avoid conflict with GitHub Actions built-in env var
-        run: make -C main git-commit GITHUB_REPOSITORY='${{github.repository}}.wiki'
-        env:
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-          LOCAL_PATH: ../wiki
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: "[ci skip] Automated publish for ${{ GITHUB_SHA }}"
+          repository: ../wiki
       - name: Login to Docker Hub
         if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main'
         uses: docker/login-action@v1

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -59,7 +59,7 @@ jobs:
         if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main'
         uses: stefanzweifel/git-auto-commit-action@v4
         with:
-          commit_message: "[ci skip] Automated publish for ${{ GITHUB_SHA }}"
+          commit_message: "[ci skip] Automated publish for $GITHUB_SHA"
           repository: ../wiki
       - name: Login to Docker Hub
         if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main'

--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -44,4 +44,4 @@ jobs:
         if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main'
         uses: stefanzweifel/git-auto-commit-action@v4
         with:
-          commit_message: "[ci skip] Automated publish for $GITHUB_SHA"
+          commit_message: "[ci skip] Automated publish for ${{github.sha}}"

--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -33,9 +33,6 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           make dev-env
-      - name: Echo sha
-        run: |
-          echo "SHA_TAG $GITHUB_SHA"
       - name: Build Documentation
         run: make docs
       - name: Extract Source Strings
@@ -43,8 +40,16 @@ jobs:
         run: |
           sphinx-build -M gettext ./ ./_build/
           sphinx-intl update -p ./_build/gettext -l en
+      - name: Get last commit hash
+        id: last-commit-hash
+        run: |
+          echo "::set-output name=hash::$(git rev-parse HEAD)"
+      - name: Echo sha
+        run: |
+          echo "SHA_TAG $GITHUB_SHA"
+          echo "Calculates SHA_TAG ${{steps.last-commit-hash.outputs.hash}}"
       - name: Push Strings to Master
         if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main'
         uses: stefanzweifel/git-auto-commit-action@v4
         with:
-          commit_message: "[ci skip] Automated publish for $GITHUB_SHA"
+          commit_message: "[ci skip] Automated publish for ${{steps.last-commit-hash.outputs.hash}}"

--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -40,16 +40,8 @@ jobs:
         run: |
           sphinx-build -M gettext ./ ./_build/
           sphinx-intl update -p ./_build/gettext -l en
-      - name: Get last commit hash
-        id: last-commit-hash
-        run: |
-          echo "::set-output name=hash::$(git rev-parse HEAD)"
-      - name: Echo sha
-        run: |
-          echo "SHA_TAG $GITHUB_SHA"
-          echo "Calculates SHA_TAG ${{steps.last-commit-hash.outputs.hash}}"
       - name: Push Strings to Master
         if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main'
         uses: stefanzweifel/git-auto-commit-action@v4
         with:
-          commit_message: "[ci skip] Automated publish for ${{steps.last-commit-hash.outputs.hash}}"
+          commit_message: "[ci skip] Automated publish for $GITHUB_SHA"

--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -44,4 +44,4 @@ jobs:
         if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main'
         uses: stefanzweifel/git-auto-commit-action@v4
         with:
-          commit_message: "[ci skip] Automated publish for ${{ GITHUB_SHA }}"
+          commit_message: "[ci skip] Automated publish for $GITHUB_SHA"

--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -42,6 +42,6 @@ jobs:
           sphinx-intl update -p ./_build/gettext -l en
       - name: Push Strings to Master
         if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main'
-        uses: stefanzweifel/git-auto-commit-action@v4
+        uses: stefanzweifel/git-auto-commit-action@ 5dd17c3b53a58c1cb5eaab903826abe94765ccd6 # dependabot updates to latest release
         with:
           commit_message: "[ci skip] Automated publish for ${{github.sha}}"

--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -42,6 +42,6 @@ jobs:
           sphinx-intl update -p ./_build/gettext -l en
       - name: Push Strings to Master
         if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main'
-        uses: stefanzweifel/git-auto-commit-action@ 5dd17c3b53a58c1cb5eaab903826abe94765ccd6 # dependabot updates to latest release
+        uses: stefanzweifel/git-auto-commit-action@5dd17c3b53a58c1cb5eaab903826abe94765ccd6 # dependabot updates to latest release
         with:
           commit_message: "[ci skip] Automated publish for ${{github.sha}}"

--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -42,8 +42,6 @@ jobs:
           sphinx-intl update -p ./_build/gettext -l en
       - name: Push Strings to Master
         if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main'
-        run: make git-commit
-        env:
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-          GITHUB_REPOSITORY: ${{github.repository}}
-          LOCAL_PATH: ./docs/locale/en
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: "[ci skip] Automated publish for ${{ GITHUB_SHA }}"

--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -33,6 +33,9 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           make dev-env
+      - name: Echo sha
+        run: |
+          echo "SHA_TAG $GITHUB_SHA"
       - name: Build Documentation
         run: make docs
       - name: Extract Source Strings

--- a/Makefile
+++ b/Makefile
@@ -62,22 +62,6 @@ dev-env: ## install libraries required to build docs and run tests
 docs: ## build HTML documentation
 	sphinx-build docs/ docs/_build/
 
-git-commit: LOCAL_PATH?=.
-git-commit: GITHUB_SHA?=$(shell git rev-parse HEAD)
-git-commit: GITHUB_REPOSITORY?=jupyter/docker-stacks
-git-commit: GITHUB_TOKEN?=
-git-commit: ## commit outstading git changes and push to remote
-	@git config --global user.name "GitHub Actions"
-	@git config --global user.email "actions@users.noreply.github.com"
-
-	@echo "Publishing outstanding changes in $(LOCAL_PATH) to $(GITHUB_REPOSITORY)"
-	@cd $(LOCAL_PATH) && \
-		git remote add publisher https://$(GITHUB_TOKEN)@github.com/$(GITHUB_REPOSITORY).git && \
-		git checkout master && \
-		git add -A -- . && \
-		git commit -m "[ci skip] Automated publish for $(GITHUB_SHA)" || exit 0
-	@cd $(LOCAL_PATH) && git push -u publisher master
-
 hook/%: WIKI_PATH?=../wiki
 hook/%: ## run post-build hooks for an image
 	python3 -m tagging.tag_image --short-image-name "$(notdir $@)" --owner "$(OWNER)" && \


### PR DESCRIPTION
Github Actions are awesome.
Having many lines in Makefile is not.

After this change Makefile is always simply running a command or two, without any logic.
Also, the amount of code is reduced and there are not workarounds for wiki repo and env variables.

Funny thing that we can remove the check for `[ci skip]` in workflows because automatically created commits by default do not triggers workflows.
But, I think it's nice to be able to push something to master and not trigger builds, so I didn't remove `ci skip` condition.