### PR TITLE
Explicitly ask for the latest buildx version

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -40,6 +40,8 @@ jobs:
 
       - name: Set up Docker Buildx (for multi-arch builds)
         uses: docker/setup-buildx-action@0d135e0c2fc0dba0729c1a47ecfcf5a3c7f8579e # dependabot updates to latest release
+        with:
+          version: latest
 
       - name: Clone Main Repo
         uses: actions/checkout@v2


### PR DESCRIPTION
This is a followup to complement#1399 and #1408 about things that wasn't tested as it was part of the steps to push to the official registry.

`docker buildx build --push` resulted in 401 Unauthorized while `docker push` didn't. I think the reason is that there is a bug in buildx 0.5.1 that is patched in 0.6.0 that was released an hour ago.

To make it available, I explicitly declare that I want to use the latest version of buildx to make it download and install it.