### PR TITLE
Fix: Move comment to uncomment packages installation after r-e1071

### DIFF
--- a/datascience-notebook/Dockerfile
+++ b/datascience-notebook/Dockerfile
@@ -64,7 +64,8 @@ RUN mamba install --quiet --yes \
     'r-caret' \
     'r-crayon' \
     'r-devtools' \
-    'r-e1071'  # dependency of the caret R package \
+    # r-e1071: dependency of the caret R package
+    'r-e1071' \
     'r-forecast' \
     'r-hexbin' \
     'r-htmltools' \

--- a/r-notebook/Dockerfile
+++ b/r-notebook/Dockerfile
@@ -30,7 +30,8 @@ RUN mamba install --quiet --yes \
     'r-caret' \
     'r-crayon' \
     'r-devtools' \
-    'r-e1071'  # dependency of the caret R package \
+    # r-e1071: dependency of the caret R package
+    'r-e1071' \
     'r-forecast' \
     'r-hexbin' \
     'r-htmltools' \


### PR DESCRIPTION
Hi,

This PR fix #1450.

The packages following the comment after "r-e1071" are not installed be
To keep the comment I moved it to the line just above.

Regards,