### PR TITLE
Pin docker version and move comment out of install

### DIFF
--- a/datascience-notebook/Dockerfile
+++ b/datascience-notebook/Dockerfile
@@ -59,12 +59,12 @@ RUN mkdir /etc/julia && \
 USER ${NB_UID}
 
 # R packages including IRKernel which gets installed globally.
+# r-e1071: dependency of the caret R package
 RUN mamba install --quiet --yes \
     'r-base' \
     'r-caret' \
     'r-crayon' \
     'r-devtools' \
-    # r-e1071: dependency of the caret R package
     'r-e1071' \
     'r-forecast' \
     'r-hexbin' \

--- a/r-notebook/Dockerfile
+++ b/r-notebook/Dockerfile
@@ -25,12 +25,12 @@ RUN ln -s /bin/tar /bin/gtar
 USER ${NB_UID}
 
 # R packages including IRKernel which gets installed globally.
+# r-e1071: dependency of the caret R package
 RUN mamba install --quiet --yes \
     'r-base' \
     'r-caret' \
     'r-crayon' \
     'r-devtools' \
-    # r-e1071: dependency of the caret R package
     'r-e1071' \
     'r-forecast' \
     'r-hexbin' \

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
-docker
+docker==5.0.0
 myst-parser
 packaging
 plumbum


### PR DESCRIPTION
As mentioned here: Latest release 5.0.1 container exec_run fails

https://github.com/docker/docker-py/issues/2885

We will have to pin the version until the upstream fixes the issue and then updates the package.