### PR TITLE
Also copy hidden files/directories

### DIFF
--- a/base-notebook/start.sh
+++ b/base-notebook/start.sh
@@ -55,7 +55,7 @@ if [ "$(id -u)" == 0 ] ; then
         if [[ ! -e "/home/${NB_USER}" ]]; then
             echo "Copying home dir to /home/${NB_USER}"
             mkdir "/home/${NB_USER}"
-            cp -R /home/jovyan "/home/${NB_USER}" || ln -s /home/jovyan "/home/${NB_USER}"
+            cp -a /home/jovyan/. "/home/${NB_USER}/" || ln -s /home/jovyan "/home/${NB_USER}"
         fi
         # if workdir is in /home/jovyan, cd to /home/${NB_USER}
         if [[ "${PWD}/" == "/home/jovyan/"* ]]; then


### PR DESCRIPTION
`cp -R` does not copy hidden files/directories, causing issues (cfr #1465) .

Using `-a` instead of `-R` makes `cp` work more closely as `rsync -avx` (which the `cp -R` replaced in 0dbce4526e165ce716e4ca41a7384e8dce0bfd0b) . This solves the problem that `CHOWN_HOME` was required to change file permissions from root  to the local user. Setting the `CHOWN_HOME` environment variable to 'yes' in our JupyterHub deployment caused issues like:

> chown: cannot access '/home/custom-username': No such file or directory

when older images were started

Added by @mathbunnyru 
Fix: https://github.com/jupyter/docker-stacks/issues/1465