### PR TITLE
Add test for copying of hidden folder

### DIFF
--- a/base-notebook/test/test_container_options.py
+++ b/base-notebook/test/test_container_options.py
@@ -95,7 +95,15 @@ def test_nb_user_change(container):
         output == expected_output
     ), f"Bad owner for the {nb_user} home folder {output}, expected {expected_output}"
 
-
+    LOGGER.info(f"Checking if home folder of {nb_user} contains the hidden '.jupyter' folder with appropriate permissions ...")
+    command = f'stat -c "%F %U %G" /home/{nb_user}/.jupyter'
+    expected_output = f"directory {nb_user} users"
+    cmd = running_container.exec_run(command, workdir=f"/home/{nb_user}")
+    output = cmd.output.decode("utf-8").strip("\n")
+    assert (
+        output == expected_output
+    ), f"Hidden folder .jupyter was not copied properly to {nb_user} home folder. stat: {output}, expected {expected_output}"
+    
 def test_chown_extra(container):
     """Container should change the UID/GID of CHOWN_EXTRA."""
     c = container.run(

--- a/base-notebook/test/test_container_options.py
+++ b/base-notebook/test/test_container_options.py
@@ -95,7 +95,9 @@ def test_nb_user_change(container):
         output == expected_output
     ), f"Bad owner for the {nb_user} home folder {output}, expected {expected_output}"
 
-    LOGGER.info(f"Checking if home folder of {nb_user} contains the hidden '.jupyter' folder with appropriate permissions ...")
+    LOGGER.info(
+        f"Checking if home folder of {nb_user} contains the hidden '.jupyter' folder with appropriate permissions ..."
+    )
     command = f'stat -c "%F %U %G" /home/{nb_user}/.jupyter'
     expected_output = f"directory {nb_user} users"
     cmd = running_container.exec_run(command, workdir=f"/home/{nb_user}")
@@ -103,7 +105,8 @@ def test_nb_user_change(container):
     assert (
         output == expected_output
     ), f"Hidden folder .jupyter was not copied properly to {nb_user} home folder. stat: {output}, expected {expected_output}"
-    
+
+
 def test_chown_extra(container):
     """Container should change the UID/GID of CHOWN_EXTRA."""
     c = container.run(


### PR DESCRIPTION
Test if the hidden `.jupyter` folder is properly copied when the user is changed via `NB_USER` environment variable. This folder should exist as `jupyter notebook --generate-config` is executed to generate `/home/jovyan/.jupyter/jupyter_notebook_config.py` .

Test for fix #1466 for issue #1465.