### PR TITLE
Re-add build option to be enable some kind of custom builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -97,7 +97,7 @@ build-all: $(foreach I, $(ALL_IMAGES), build/$(I)) ## build all stacks
 #    without needing to update this Makefile, and if all tests succeeds we can
 #    do a publish job that creates a multi-platform image for us.
 #
-build/%: DOCKER_BUILD_ARGS?=
+build-multi/%: DOCKER_BUILD_ARGS?=
 build-multi/%: ## build the latest image for a stack on both amd64 and arm64
 	@echo "::group::Build $(OWNER)/$(notdir $@) (system's architecture)"
 	docker buildx build $(DOCKER_BUILD_ARGS) -t $(OWNER)/$(notdir $@):latest ./$(notdir $@) --build-arg OWNER=$(OWNER) --load


### PR DESCRIPTION
For example, with:

```
$ BASE_CONTAINER=ubuntu:focal-20211006@sha256:26c3bd3ae441c873a210200bcbb975ffd2bbf0c0841a4584f4476c8a5b8f3d99
$ NB_UID=1234
$ make build/base-notebook \
  ARGS="--build-arg BASE_CONTAINER=$BASE_CONTAINER --build-arg NB_USER=$NB_USER_TEACHER --build-arg NB_UID=$NB_UID"
```

we could generate base-notebook using a specific base image and where
jovyan is uid 1234 instead of 1000