### PR TITLE
Add conda mirror option in base notebook

### DIFF
--- a/base-notebook/Dockerfile
+++ b/base-notebook/Dockerfile
@@ -79,7 +79,7 @@ RUN mkdir "/home/${NB_USER}/work" && \
 WORKDIR /tmp
 
 # CONDA_MIRROR is a mirror prefix to speed up downloading
-# For example, people from mainland China chould set it as
+# For example, people from mainland China could set it as
 # https://mirrors.tuna.tsinghua.edu.cn/github-release/conda-forge/miniforge/LatestRelease
 ARG CONDA_MIRROR=https://github.com/conda-forge/miniforge/releases/latest/download
 


### PR DESCRIPTION
Users having high latency from default conda download site
could set this option to speed up downloading.

Signed-off-by: Peng Gao <peng.gao.dut@gmail.com>