### PR TITLE
start.sh: JUPYTER_ENV_VARS_TO_UNSET introduced

### DIFF
--- a/base-notebook/start.sh
+++ b/base-notebook/start.sh
@@ -39,6 +39,18 @@ run-hooks () {
     echo "${0}: done running hooks in ${1}"
 }
 
+# A helper function to unset env vars listed in the value of the env var
+# JUPYTER_ENV_VARS_TO_UNSET.
+unset_explicit_env_vars () {
+    if [ -n "${JUPYTER_ENV_VARS_TO_UNSET}" ]; then
+        for env_var_to_unset in $(echo "${JUPYTER_ENV_VARS_TO_UNSET}" | tr ',;:' ' '); do
+            echo "Unset ${env_var_to_unset} due to JUPYTER_ENV_VARS_TO_UNSET"
+            unset "${env_var_to_unset}"
+        done
+        unset JUPYTER_ENV_VARS_TO_UNSET
+    fi
+}
+
 
 # NOTE: This hook will run as the user the container was started with!
 run-hooks /usr/local/bin/start-notebook.d
@@ -143,6 +155,7 @@ if [ "$(id -u)" == 0 ] ; then
     # NOTE: This hook is run as the root user!
     run-hooks /usr/local/bin/before-notebook.d
 
+    unset_explicit_env_vars
     echo "Running as ${NB_USER}:" "${cmd[@]}"
     exec sudo --preserve-env --set-home --user "${NB_USER}" \
         PATH="${PATH}" \
@@ -199,6 +212,7 @@ else
 
     # NOTE: This hook is run as the user we started the container as!
     run-hooks /usr/local/bin/before-notebook.d
+    unset_explicit_env_vars
     echo "Executing the command:" "${cmd[@]}"
     exec "${cmd[@]}"
 fi

--- a/base-notebook/start.sh
+++ b/base-notebook/start.sh
@@ -43,7 +43,7 @@ run-hooks () {
 # JUPYTER_ENV_VARS_TO_UNSET.
 unset_explicit_env_vars () {
     if [ -n "${JUPYTER_ENV_VARS_TO_UNSET}" ]; then
-        for env_var_to_unset in $(echo "${JUPYTER_ENV_VARS_TO_UNSET}" | tr ',;:' ' '); do
+        for env_var_to_unset in $(echo "${JUPYTER_ENV_VARS_TO_UNSET}" | tr ',' ' '); do
             echo "Unset ${env_var_to_unset} due to JUPYTER_ENV_VARS_TO_UNSET"
             unset "${env_var_to_unset}"
         done

--- a/base-notebook/test/test_container_options.py
+++ b/base-notebook/test/test_container_options.py
@@ -249,14 +249,14 @@ def test_jupyter_env_vars_to_unset_as_root(container):
         environment=[
             "JUPYTER_ENV_VARS_TO_UNSET=SECRET_ANIMAL,UNUSED_ENV,SECRET_FRUIT",
             "FRUIT=bananas",
-            "SECRET_FRUIT=mango",
             "SECRET_ANIMAL=cats",
+            "SECRET_FRUIT=mango",
         ],
         command=[
             "start.sh",
             "bash",
             "-c",
-            "echo I like $FRUIT and ${SECRET_FRUIT:-stuff}, and love ${SECRET_LOVE:-to keep secrets}!",
+            "echo I like $FRUIT and ${SECRET_FRUIT:-stuff}, and love ${SECRET_ANIMAL:-to keep secrets}!",
         ],
     )
     rv = c.wait(timeout=10)

--- a/base-notebook/test/test_container_options.py
+++ b/base-notebook/test/test_container_options.py
@@ -240,7 +240,6 @@ def test_container_not_delete_bind_mount(container, tmp_path):
     assert len(list(tmp_path.iterdir())) == 1
 
 
-@pytest.mark.skip(reason="not yet implemented; TODO: cherry-pick b44b7ab")
 def test_jupyter_env_vars_to_unset_as_root(container):
     """Environment variables names listed in JUPYTER_ENV_VARS_TO_UNSET
     should be unset in the final environment."""

--- a/docs/using/common.md
+++ b/docs/using/common.md
@@ -78,6 +78,8 @@ You do so by passing arguments to the `docker run` command.
   **You must grant the within-container notebook user or group (`NB_UID` or `NB_GID`) write access to the host directory (e.g., `sudo chown 1000 /some/host/folder/for/work`).**
 - `--user 5000 --group-add users` - Launches the container with a specific user ID and adds that user to the `users` group so that it can modify files in the default home directory and `/opt/conda`.
   You can use these arguments as alternatives to setting `${NB_UID}` and `${NB_GID}`.
+- `-e JUPYTER_ENV_VARS_TO_UNSET=ADMIN_SECRET_1,ADMIN_SECRET_2` - Unsets specified environment variables in the default startup script.
+  The variables are unset after the hooks have executed but before the command provided to the startup script runs.
 
 ## Startup Hooks
 


### PR DESCRIPTION
Cherry-pick of b44b7ab. I'm working through https://github.com/jupyter/docker-stacks/pull/1512#issuecomment-962672049

> Allow you to define variables to be unset before running the command
> that start.sh is supposed to start. These variables will still be
> available in the hooks run before.