### PR TITLE
Build and test amd64 docker images in a dedicated workflow for quick feedback

### DIFF
--- a/.github/workflows/docker-amd64.yml
+++ b/.github/workflows/docker-amd64.yml
@@ -1,4 +1,7 @@
 name: Build and test amd64 Docker Images
+# This workflow runs a lot quicker, than building multi-images in docker.yml
+# This will allow us to conclude if things work or not far quicker,
+# when we don't expect there to be any platform specific breaking change.
 
 on:
   pull_request:

--- a/.github/workflows/docker-amd64.yml
+++ b/.github/workflows/docker-amd64.yml
@@ -1,9 +1,9 @@
-name: Build and test x86 Docker Images
+name: Build and test amd64 Docker Images
 
 on:
   pull_request:
     paths:
-      - ".github/workflows/docker-x86.yml"
+      - ".github/workflows/docker-amd64.yml"
 
       - "all-spark-notebook/**"
       - "base-notebook/**"
@@ -25,7 +25,7 @@ on:
       - main
       - master
     paths:
-      - ".github/workflows/docker-x86.yml"
+      - ".github/workflows/docker-amd64.yml"
 
       - "all-spark-notebook/**"
       - "base-notebook/**"
@@ -45,8 +45,8 @@ on:
   workflow_dispatch:
 
 jobs:
-  build-test-x86-images:
-    name: Build and test x86 Docker Images
+  build-test-amd64-images:
+    name: Build and test amd64 Docker Images
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/docker-x86.yml
+++ b/.github/workflows/docker-x86.yml
@@ -1,0 +1,74 @@
+name: Build and test x86 Docker Images
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/docker-x86.yml"
+
+      - "all-spark-notebook/**"
+      - "base-notebook/**"
+      - "datascience-notebook/**"
+      - "minimal-notebook/**"
+      - "pyspark-notebook/**"
+      - "r-notebook/**"
+      - "scipy-notebook/**"
+      - "tensorflow-notebook/**"
+
+      - "tagging/**"
+      - "test/**"
+      - "conftest.py"
+      - "Makefile"
+      - "pytest.ini"
+      - "requirements-dev.txt"
+  push:
+    branches:
+      - main
+      - master
+    paths:
+      - ".github/workflows/docker-x86.yml"
+
+      - "all-spark-notebook/**"
+      - "base-notebook/**"
+      - "datascience-notebook/**"
+      - "minimal-notebook/**"
+      - "pyspark-notebook/**"
+      - "r-notebook/**"
+      - "scipy-notebook/**"
+      - "tensorflow-notebook/**"
+
+      - "tagging/**"
+      - "test/**"
+      - "conftest.py"
+      - "Makefile"
+      - "pytest.ini"
+      - "requirements-dev.txt"
+
+jobs:
+  build-test-x86-images:
+    name: Build and test x86 Docker Images
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Clone Main Repo
+        uses: actions/checkout@v2
+        with:
+          path: main
+
+      - name: Set Up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.x
+
+      - name: Install Dev Dependencies
+        run: |
+          python -m pip install --upgrade pip
+          make -C main dev-env
+
+      - name: Build Docker Images
+        run: make -C main build-all
+        env:
+          # Full logs for CI build
+          BUILDKIT_PROGRESS: plain
+
+      - name: Test Docker Images
+        run: make -C main test-all

--- a/.github/workflows/docker-x86.yml
+++ b/.github/workflows/docker-x86.yml
@@ -42,6 +42,7 @@ on:
       - "Makefile"
       - "pytest.ini"
       - "requirements-dev.txt"
+  workflow_dispatch:
 
 jobs:
   build-test-x86-images:


### PR DESCRIPTION
The idea behind this is simple - let's build x86 images in a different workflow.
It's enough for most PRs and we can skip long x86+arm builds and merge quicker.