### PR TITLE
Update Julia to 1.7.0

### DIFF
--- a/datascience-notebook/Dockerfile
+++ b/datascience-notebook/Dockerfile
@@ -15,7 +15,7 @@ USER root
 # Default values can be overridden at build time
 # (ARGS are in lower case to distinguish them from ENV)
 # Check https://julialang.org/downloads/
-ARG julia_version="1.6.4"
+ARG julia_version="1.7.0"
 
 # R pre-requisites
 RUN apt-get update --yes && \


### PR DESCRIPTION
A [new stable version](https://julialang.org/blog/2021/11/julia-1.7-highlights/) just came out.
