### PR TITLE
Fix spurious warnings when using docker run --user=X

### DIFF
--- a/base-notebook/start.sh
+++ b/base-notebook/start.sh
@@ -199,6 +199,10 @@ else
             rm /tmp/passwd
 
             _log "Added new ${NB_USER} user ($(id -u):$(id -g)). Fixed UID!"
+
+            if [[ "${NB_USER}" != "jovyan" ]]; then
+                _log "WARNING: user is ${NB_USER} but home is /home/jovyan. You must run as root to rename the home directory!"
+            fi
         else
             _log "WARNING: unable to fix missing /etc/passwd entry because we don't have write permission. Try setting gid=0 with \"--user=$(id -u):0\"."
         fi

--- a/base-notebook/start.sh
+++ b/base-notebook/start.sh
@@ -172,21 +172,13 @@ if [ "$(id -u)" == 0 ] ; then
 # The container didn't start as the root user, so we will have to act as the
 # user we started as.
 else
-    # Warn about misconfiguration of: desired username, user id, or group id
-    if [[ -n "${NB_USER}" && "${NB_USER}" != "$(id -un)" ]]; then
-        _log "WARNING: container must be started as root to change the desired user's name with NB_USER!"
-    fi
-    if [[ -n "${NB_UID}" && "${NB_UID}" != "$(id -u)" ]]; then
-        _log "WARNING: container must be started as root to change the desired user's id with NB_UID!"
-    fi
-    if [[ -n "${NB_GID}" && "${NB_GID}" != "$(id -g)" ]]; then
-        _log "WARNING: container must be started as root to change the desired user's group id with NB_GID!"
-    fi
-
     # Warn about misconfiguration of: granting sudo rights
     if [[ "${GRANT_SUDO}" == "1" || "${GRANT_SUDO}" == "yes" ]]; then
         _log "WARNING: container must be started as root to grant sudo permissions!"
     fi
+
+    JOVYAN_UID="$(id -u jovyan 2>/dev/null)"  # The default UID for the jovyan user
+    JOVYAN_GID="$(id -g jovyan 2>/dev/null)"  # The default GID for the jovyan user
 
     # Attempt to ensure the user uid we currently run as has a named entry in
     # the /etc/passwd file, as it avoids software crashing on hard assumptions
@@ -195,26 +187,40 @@ else
     #
     # ref: https://github.com/jupyter/docker-stacks/issues/552
     if ! whoami &> /dev/null; then
-        _log "There is no entry in /etc/passwd for our UID. Attempting to fix..."
+        _log "There is no entry in /etc/passwd for our UID=$(id -u). Attempting to fix..."
         if [[ -w /etc/passwd ]]; then
             _log "Renaming old jovyan user to nayvoj ($(id -u jovyan):$(id -g jovyan))"
 
             # We cannot use "sed --in-place" since sed tries to create a temp file in
             # /etc/ and we may not have write access. Apply sed on our own temp file:
             sed --expression="s/^jovyan:/nayvoj:/" /etc/passwd > /tmp/passwd
-            echo "jovyan:x:$(id -u):$(id -g):,,,:/home/jovyan:/bin/bash" >> /tmp/passwd
+            echo "${NB_USER}:x:$(id -u):$(id -g):,,,:/home/jovyan:/bin/bash" >> /tmp/passwd
             cat /tmp/passwd > /etc/passwd
             rm /tmp/passwd
 
-            _log "Added new jovyan user ($(id -u):$(id -g)). Fixed UID!"
+            _log "Added new ${NB_USER} user ($(id -u):$(id -g)). Fixed UID!"
         else
-            _log "WARNING: unable to fix missing /etc/passwd entry because we don't have write permission."
+            _log "WARNING: unable to fix missing /etc/passwd entry because we don't have write permission. Try setting gid=0 with \"--user=$(id -u):0\"."
         fi
+    fi
+
+    # Warn about misconfiguration of: desired username, user id, or group id.
+    # A misconfiguration occurs when the user modifies the default values of
+    # NB_USER, NB_UID, or NB_GID, but we cannot update those values because we
+    # are not root.
+    if [[ "${NB_USER}" != "jovyan" && "${NB_USER}" != "$(id -un)" ]]; then
+        _log "WARNING: container must be started as root to change the desired user's name with NB_USER=\"${NB_USER}\"!"
+    fi
+    if [[ "${NB_UID}" != "${JOVYAN_UID}" && "${NB_UID}" != "$(id -u)" ]]; then
+        _log "WARNING: container must be started as root to change the desired user's id with NB_UID=\"${NB_UID}\"!"
+    fi
+    if [[ "${NB_GID}" != "${JOVYAN_GID}" && "${NB_GID}" != "$(id -g)" ]]; then
+        _log "WARNING: container must be started as root to change the desired user's group id with NB_GID=\"${NB_GID}\"!"
     fi
 
     # Warn if the user isn't able to write files to ${HOME}
     if [[ ! -w /home/jovyan ]]; then
-        _log "WARNING: no write access to /home/jovyan. Try starting the container with group 'users' (100)."
+        _log "WARNING: no write access to /home/jovyan. Try starting the container with group 'users' (100), e.g. using \"--group-add=users\"."
     fi
 
     # NOTE: This hook is run as the user we started the container as!

--- a/base-notebook/test/test_container_options.py
+++ b/base-notebook/test/test_container_options.py
@@ -286,8 +286,12 @@ def test_set_uid_and_nb_user(container):
     assert rv == 0 or rv["StatusCode"] == 0
     logs = c.logs(stdout=True).decode("utf-8")
     assert "ERROR" not in logs
-    assert "WARNING" not in logs
     assert "uid=1010(kitten) gid=0(root)" in logs
+    warnings = [
+        warning for warning in logs.split("\n") if warning.startswith("WARNING")
+    ]
+    assert len(warnings) == 1
+    assert "user is kitten but home is /home/jovyan" in warnings[0]
 
 
 def test_container_not_delete_bind_mount(container, tmp_path):

--- a/base-notebook/test/test_container_options.py
+++ b/base-notebook/test/test_container_options.py
@@ -15,11 +15,11 @@ def test_cli_args(container, http_client):
     resp = http_client.get("http://localhost:8888")
     resp.raise_for_status()
     logs = c.logs(stdout=True).decode("utf-8")
+    LOGGER.debug(logs)
     assert "ERROR" not in logs
     warnings = [
         warning for warning in logs.split("\n") if warning.startswith("WARNING")
     ]
-    LOGGER.debug(logs)
     assert len(warnings) == 1
     assert warnings[0].startswith("WARNING: Jupyter Notebook deprecation notice")
     assert "login_submit" not in resp.text

--- a/base-notebook/test/test_package_managers.py
+++ b/base-notebook/test/test_package_managers.py
@@ -29,6 +29,8 @@ def test_package_manager(container, package_manager, version_arg):
     rv = c.wait(timeout=5)
     logs = c.logs(stdout=True).decode("utf-8")
     LOGGER.debug(logs)
+    assert "ERROR" not in logs
+    assert "WARNING" not in logs
     assert (
         rv == 0 or rv["StatusCode"] == 0
     ), f"Package manager {package_manager} not working"

--- a/base-notebook/test/test_pandoc.py
+++ b/base-notebook/test/test_pandoc.py
@@ -14,5 +14,7 @@ def test_pandoc(container):
     )
     c.wait(timeout=10)
     logs = c.logs(stdout=True).decode("utf-8")
+    assert "ERROR" not in logs
+    assert "WARNING" not in logs
     LOGGER.debug(logs)
     assert "<p><strong>BOLD</strong></p>" in logs

--- a/base-notebook/test/test_python.py
+++ b/base-notebook/test/test_python.py
@@ -16,6 +16,8 @@ def test_python_version(container, python_next_version="3.10"):
     )
     cmd = c.exec_run("python --version")
     output = cmd.output.decode("utf-8")
+    assert "ERROR" not in output
+    assert "WARNING" not in output
     actual_python_version = version.parse(output.split()[1])
     assert actual_python_version < version.parse(
         python_next_version

--- a/base-notebook/test/test_start_container.py
+++ b/base-notebook/test/test_start_container.py
@@ -27,6 +27,15 @@ def test_start_notebook(container, http_client, env, expected_server):
     resp = http_client.get("http://localhost:8888")
     logs = c.logs(stdout=True).decode("utf-8")
     LOGGER.debug(logs)
+    assert "ERROR" not in logs
+    if expected_server != "notebook":
+        assert "WARNING" not in logs
+    else:
+        warnings = [
+            warning for warning in logs.split("\n") if warning.startswith("WARNING")
+        ]
+        assert len(warnings) == 1
+        assert warnings[0].startswith("WARNING: Jupyter Notebook deprecation notice")
     assert resp.status_code == 200, "Server is not listening"
     assert (
         f"Executing the command: jupyter {expected_server}" in logs
@@ -51,4 +60,6 @@ def test_tini_entrypoint(container, pid=1, command="tini"):
     # Select the PID 1 and get the corresponding command
     cmd = c.exec_run(f"ps -p {pid} -o comm=")
     output = cmd.output.decode("utf-8").strip("\n")
+    assert "ERROR" not in output
+    assert "WARNING" not in output
     assert output == command, f"{command} shall be launched as pid {pid}, got {output}"


### PR DESCRIPTION
Closes #1520

During tests, I now check for unexpected ERROR/WARNING messages.

I added a few tests to check for expected warning messages regarding
- unable to write to `/etc/passwd` because `uid != 0`
- unable to write to `/home/jovyan` because user not in `users(100)` group

I also improved the warning messages to suggest solutions in both cases.

To suppress the spurious warnings from #1520, I warn only when the defaults change, which is in-line with [the old logic](https://github.com/jupyter/docker-stacks/blob/93a6865aa3540cd4df94aba312bbab5b9a9d147c/base-notebook/start.sh#L108).

I removed the "test for nonempty" tests `-n "${NB_USER}"`, `-n "${NB_UID}"`, `-n "${NB_GID}"`, because these variables all have nonempty default values, so they should never be empty in the first place.

Finally, if the user goes through the trouble of setting it, I allow the `jovyan` user to be replaced in `/etc/passwd` with `${NB_USER}` instead of just `jovyan`, because we can.