### PR TITLE
Run apt-get upgrade to patch known vulnerabilities faster

### DIFF
--- a/base-notebook/Dockerfile
+++ b/base-notebook/Dockerfile
@@ -19,9 +19,14 @@ USER root
 
 # Install all OS dependencies for notebook server that starts but lacks all
 # features (e.g., download as all possible file formats)
-# Install tini: init for containers
+# - tini is installed as a helpful container entrypoint that reaps zombie
+#   processes and such of the actual executable we want to start, see
+#   https://github.com/krallin/tini#why-tini for details.
+# - apt-get upgrade is run to patch known vulnerabilities in apt-get packages as
+#   the ubuntu base image is rebuilt too seldom (less than once a month)
 ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update --yes && \
+    apt-get upgrade --yes && \
     apt-get install --yes --no-install-recommends \
     tini \
     wget \

--- a/base-notebook/Dockerfile
+++ b/base-notebook/Dockerfile
@@ -23,7 +23,7 @@ USER root
 #   processes and such of the actual executable we want to start, see
 #   https://github.com/krallin/tini#why-tini for details.
 # - apt-get upgrade is run to patch known vulnerabilities in apt-get packages as
-#   the ubuntu base image is rebuilt too seldom (less than once a month)
+#   the ubuntu base image is rebuilt too seldom sometimes (less than once a month)
 ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update --yes && \
     apt-get upgrade --yes && \


### PR DESCRIPTION
There are various tools that scans for known vulnerabilities in images. The base image we use, `ubutnu:focal` has at the moment was latest updated more than 2 months ago, meaning all known vulnerabilities that actually has been patched, hasn't been patched in new builds of our image as the `ubuntu:focal` image hasn't been updated.

Due to that, I suggest we run `apt-get upgrade` when we build the base image.