### PR TITLE
Fix broken markdown anchors in the doc

### DIFF
--- a/docs/contributing/features.md
+++ b/docs/contributing/features.md
@@ -11,7 +11,7 @@ Please follow the process below to suggest a new feature for inclusion in one of
 1. [Open a GitHub issue](https://github.com/jupyter/docker-stacks/issues) describing the feature
    you'd like to contribute.
 2. Discuss with the maintainers whether the addition makes sense in
-   [one of the core stacks](../using/selecting.md#core-stacks), as a
+   [one of the core stacks](../using/selecting.html#core-stacks), as a
    [recipe in the documentation](recipes.md), as a [community stack](stacks.md), or as something
    else entirely.
 

--- a/docs/contributing/stacks.md
+++ b/docs/contributing/stacks.md
@@ -8,7 +8,7 @@ Following these steps will:
 1. Setup a project on GitHub containing a Dockerfile based on either the `jupyter/base-notebook` or `jupyter/minimal-notebook` image.
 2. Configure GitHub Actions to build and test your image when users submit pull requests to your repository.
 3. Configure Docker Hub to build and host your images for others to use.
-4. Update the [list of community stacks](../using/selecting.md#community-stacks) in this documentation to include your image.
+4. Update the [list of community stacks](../using/selecting.html#community-stacks) in this documentation to include your image.
 
 This approach mirrors how we build and share the core stack images.
 Feel free to follow it or pave your own path using alternative services and build tools.


### PR DESCRIPTION
Hello,

Fixes #1552 .

Anchors are not supported with Markdown.
I've used a workaround to fix the broken links by transforming Markdown to HTML anchors as described [here](https://stackoverflow.com/a/64044458/4413446).

Best