### PR TITLE
Add datascience-python-r-notebook

### DIFF
--- a/.github/workflows/docker-amd64.yml
+++ b/.github/workflows/docker-amd64.yml
@@ -10,6 +10,7 @@ on:
 
       - "all-spark-notebook/**"
       - "base-notebook/**"
+      - "datascience-python-r-notebook/**"
       - "datascience-notebook/**"
       - "minimal-notebook/**"
       - "pyspark-notebook/**"
@@ -32,6 +33,7 @@ on:
 
       - "all-spark-notebook/**"
       - "base-notebook/**"
+      - "datascience-python-r-notebook/**"
       - "datascience-notebook/**"
       - "minimal-notebook/**"
       - "pyspark-notebook/**"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -10,6 +10,7 @@ on:
 
       - "all-spark-notebook/**"
       - "base-notebook/**"
+      - "datascience-python-r-notebook/**"
       - "datascience-notebook/**"
       - "minimal-notebook/**"
       - "pyspark-notebook/**"
@@ -32,6 +33,7 @@ on:
 
       - "all-spark-notebook/**"
       - "base-notebook/**"
+      - "datascience-python-r-notebook/**"
       - "datascience-notebook/**"
       - "minimal-notebook/**"
       - "pyspark-notebook/**"

--- a/.github/workflows/hub-overview.yml
+++ b/.github/workflows/hub-overview.yml
@@ -10,6 +10,7 @@ on:
 
       - "all-spark-notebook/README.md"
       - "base-notebook/README.md"
+      - "datascience-python-r-notebook/README.md"
       - "datascience-notebook/README.md"
       - "minimal-notebook/README.md"
       - "pyspark-notebook/README.md"

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@ MULTI_IMAGES:= \
 	minimal-notebook \
 	r-notebook \
 	scipy-notebook \
+	datascience-python-r-notebook \
 	pyspark-notebook \
 	all-spark-notebook
 # Images that can only be built on the amd64 architecture (aka. x86_64)
@@ -29,6 +30,7 @@ ALL_IMAGES:= \
 	r-notebook \
 	scipy-notebook \
 	tensorflow-notebook \
+	datascience-python-r-notebook \
 	datascience-notebook \
 	pyspark-notebook \
 	all-spark-notebook

--- a/datascience-notebook/Dockerfile
+++ b/datascience-notebook/Dockerfile
@@ -1,13 +1,10 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 ARG OWNER=jupyter
-ARG BASE_CONTAINER=$OWNER/scipy-notebook
+ARG BASE_CONTAINER=$OWNER/datascience-python-r-notebook
 FROM $BASE_CONTAINER
 
 LABEL maintainer="Jupyter Project <jupyter@googlegroups.com>"
-
-# Fix DL4006
-SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 USER root
 
@@ -16,14 +13,6 @@ USER root
 # (ARGS are in lower case to distinguish them from ENV)
 # Check https://julialang.org/downloads/
 ARG julia_version="1.7.1"
-
-# R pre-requisites
-RUN apt-get update --yes && \
-    apt-get install --yes --no-install-recommends \
-    fonts-dejavu \
-    gfortran \
-    gcc && \
-    apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Julia dependencies
 # install Julia packages in /opt/julia instead of ${HOME}
@@ -57,44 +46,6 @@ RUN mkdir /etc/julia && \
     fix-permissions "${JULIA_PKGDIR}"
 
 USER ${NB_UID}
-
-# R packages including IRKernel which gets installed globally.
-# r-e1071: dependency of the caret R package
-RUN mamba install --quiet --yes \
-    'r-base' \
-    'r-caret' \
-    'r-crayon' \
-    'r-devtools' \
-    'r-e1071' \
-    'r-forecast' \
-    'r-hexbin' \
-    'r-htmltools' \
-    'r-htmlwidgets' \
-    'r-irkernel' \
-    'r-nycflights13' \
-    'r-randomforest' \
-    'r-rcurl' \
-    'r-rodbc' \
-    'r-rsqlite' \
-    'r-shiny' \
-    'rpy2' \
-    'unixodbc' && \
-    mamba clean --all -f -y && \
-    fix-permissions "${CONDA_DIR}" && \
-    fix-permissions "/home/${NB_USER}"
-
-# These packages are not easy to install under arm
-RUN set -x && \
-    arch=$(uname -m) && \
-    if [ "${arch}" == "x86_64" ]; then \
-        mamba install --quiet --yes \
-            'r-rmarkdown' \
-            'r-tidymodels' \
-            'r-tidyverse' && \
-            mamba clean --all -f -y && \
-            fix-permissions "${CONDA_DIR}" && \
-            fix-permissions "/home/${NB_USER}"; \
-    fi;
 
 # Add Julia packages.
 # Install IJulia as jovyan and then move the kernelspec out

--- a/datascience-python-r-notebook/.dockerignore
+++ b/datascience-python-r-notebook/.dockerignore
@@ -1,0 +1,2 @@
+# Documentation
+README.md

--- a/datascience-python-r-notebook/Dockerfile
+++ b/datascience-python-r-notebook/Dockerfile
@@ -1,0 +1,64 @@
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+ARG OWNER=jupyter
+ARG BASE_CONTAINER=$OWNER/scipy-notebook
+FROM $BASE_CONTAINER
+
+LABEL maintainer="Jupyter Project <jupyter@googlegroups.com>"
+
+# Fix DL4006
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+USER root
+
+# R pre-requisites
+RUN apt-get update --yes && \
+    apt-get install --yes --no-install-recommends \
+    fonts-dejavu \
+    gfortran \
+    gcc && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /tmp
+
+USER ${NB_UID}
+
+# R packages including IRKernel which gets installed globally.
+# r-e1071: dependency of the caret R package
+RUN mamba install --quiet --yes \
+    'r-base' \
+    'r-caret' \
+    'r-crayon' \
+    'r-devtools' \
+    'r-e1071' \
+    'r-forecast' \
+    'r-hexbin' \
+    'r-htmltools' \
+    'r-htmlwidgets' \
+    'r-irkernel' \
+    'r-nycflights13' \
+    'r-randomforest' \
+    'r-rcurl' \
+    'r-rodbc' \
+    'r-rsqlite' \
+    'r-shiny' \
+    'rpy2' \
+    'unixodbc' && \
+    mamba clean --all -f -y && \
+    fix-permissions "${CONDA_DIR}" && \
+    fix-permissions "/home/${NB_USER}"
+
+# These packages are not easy to install under arm
+RUN set -x && \
+    arch=$(uname -m) && \
+    if [ "${arch}" == "x86_64" ]; then \
+        mamba install --quiet --yes \
+            'r-rmarkdown' \
+            'r-tidymodels' \
+            'r-tidyverse' && \
+            mamba clean --all -f -y && \
+            fix-permissions "${CONDA_DIR}" && \
+            fix-permissions "/home/${NB_USER}"; \
+    fi;
+
+WORKDIR "${HOME}"

--- a/datascience-python-r-notebook/README.md
+++ b/datascience-python-r-notebook/README.md
@@ -1,0 +1,12 @@
+# Jupyter Notebook Data Science (Python and R)
+
+[![docker pulls](https://img.shields.io/docker/pulls/jupyter/datascience-notebook.svg)](https://hub.docker.com/r/jupyter/datascience-notebook/)
+[![docker stars](https://img.shields.io/docker/stars/jupyter/datascience-notebook.svg)](https://hub.docker.com/r/jupyter/datascience-notebook/)
+[![image size](https://img.shields.io/docker/image-size/jupyter/datascience-notebook/latest)](https://hub.docker.com/r/jupyter/datascience-notebook/ "jupyter/datascience-notebook image size")
+
+GitHub Actions in the <https://github.com/jupyter/docker-stacks> project builds and pushes this image to Docker Hub.
+
+Please visit the project documentation site for help using and contributing to this image and others.
+
+- [Jupyter Docker Stacks on ReadTheDocs](https://jupyter-docker-stacks.readthedocs.io/en/latest/index.html)
+- [Selecting an Image :: Core Stacks :: jupyter/datascience-notebook](https://jupyter-docker-stacks.readthedocs.io/en/latest/using/selecting.html#jupyter-datascience-notebook)

--- a/tagging/images_hierarchy.py
+++ b/tagging/images_hierarchy.py
@@ -59,8 +59,13 @@ ALL_IMAGES = {
     "tensorflow-notebook": ImageDescription(
         parent_image="scipy-notebook", taggers=[TensorflowVersionTagger]
     ),
-    "datascience-notebook": ImageDescription(
+    "datascience-python-r-notebook": ImageDescription(
         parent_image="scipy-notebook",
+        taggers=[RVersionTagger],
+        manifests=[RPackagesManifest],
+    ),
+    "datascience-notebook": ImageDescription(
+        parent_image="datascience-python-r-notebook",
         taggers=[RVersionTagger, JuliaVersionTagger],
         manifests=[RPackagesManifest, JuliaPackagesManifest],
     ),


### PR DESCRIPTION
fix https://github.com/jupyter/docker-stacks/issues/1551

I add `datascience-python-r-notebook`, which is a multi-architecture stack based on `jupyter/datascience-notebook` without Julia.
If it add, users who do not use Julia will be able to use `jupyter/datascience-notebook` on M1 Mac and latest Docker Desktop for Mac.