### PR TITLE
Spark version incompatibility with Delta

### DIFF
--- a/docs/using/recipes.md
+++ b/docs/using/recipes.md
@@ -530,7 +530,7 @@ By adding the properties to `spark-defaults.conf`, the user no longer needs to e
 ```dockerfile
 FROM jupyter/pyspark-notebook:lab-3.1.18
 
-ARG DELTA_CORE_VERSION="1.0.0"
+ARG DELTA_CORE_VERSION="1.1.0"
 RUN pip install --quiet --no-cache-dir delta-spark==${DELTA_CORE_VERSION} && \
      fix-permissions "${HOME}" && \
      fix-permissions "${CONDA_DIR}"

--- a/docs/using/recipes.md
+++ b/docs/using/recipes.md
@@ -528,7 +528,7 @@ Please note that the [Delta Lake](https://delta.io/) packages are only available
 By adding the properties to `spark-defaults.conf`, the user no longer needs to enable Delta support in each notebook.
 
 ```dockerfile
-FROM jupyter/pyspark-notebook:latest
+FROM jupyter/pyspark-notebook:lab-3.1.18
 
 ARG DELTA_CORE_VERSION="1.0.0"
 RUN pip install --quiet --no-cache-dir delta-spark==${DELTA_CORE_VERSION} && \

--- a/docs/using/recipes.md
+++ b/docs/using/recipes.md
@@ -528,7 +528,7 @@ Please note that the [Delta Lake](https://delta.io/) packages are only available
 By adding the properties to `spark-defaults.conf`, the user no longer needs to enable Delta support in each notebook.
 
 ```dockerfile
-FROM jupyter/pyspark-notebook:lab-3.1.18
+FROM jupyter/pyspark-notebook:latest
 
 ARG DELTA_CORE_VERSION="1.1.0"
 RUN pip install --quiet --no-cache-dir delta-spark==${DELTA_CORE_VERSION} && \


### PR DESCRIPTION
Calling the "latest" tag ( "FROM jupyter/pyspark-notebook:latest" ) installs Spark 3.2 version, which is incompatible with delta lake ( https://docs.delta.io/latest/releases.html#-compatibility-with-as ). Installing the last version of Spark 3.1.x resolves the issue. In the jupyter docker repo that would be version 3.1.18