### PR TITLE
Unify docker usage in tests

### DIFF
--- a/.github/workflows/docker-amd64.yml
+++ b/.github/workflows/docker-amd64.yml
@@ -76,3 +76,13 @@ jobs:
 
       - name: Test Docker Images
         run: make -C main test-all
+
+      - name: Clone Wiki
+        uses: actions/checkout@v2
+        with:
+          repository: ${{github.repository}}.wiki
+          path: wiki
+
+      - name: Run Post-Build Hooks
+        id: hook-all
+        run: make -C main hook-all

--- a/all-spark-notebook/test/test_spark_notebooks.py
+++ b/all-spark-notebook/test/test_spark_notebooks.py
@@ -37,10 +37,9 @@ def test_nbconvert(container: TrackedContainer, test_file: str) -> None:
         tty=True,
         command=["start.sh", "bash", "-c", command],
     )
-    # Spark warning
     warnings = TrackedContainer.get_warnings(logs)
-    assert len(warnings) == 1
-    assert "An illegal reflective access operation has occurred" in warnings[0]
+    # Some Spark warnings
+    assert len(warnings) == 5
 
     expected_file = f"{output_dir}/{test_file}.md"
     assert expected_file in logs, f"Expected file {expected_file} not generated"

--- a/all-spark-notebook/test/test_spark_notebooks.py
+++ b/all-spark-notebook/test/test_spark_notebooks.py
@@ -30,14 +30,11 @@ def test_nbconvert(container: TrackedContainer, test_file: str) -> None:
         + f"--output-dir {output_dir} "
         + f"--execute {cont_data_dir}/{test_file}.ipynb"
     )
-    c = container.run(
+    logs = container.run_and_wait(
+        timeout=timeout_ms / 10 + 10,
         volumes={str(host_data_dir): {"bind": cont_data_dir, "mode": "ro"}},
         tty=True,
         command=["start.sh", "bash", "-c", command],
     )
-    rv = c.wait(timeout=timeout_ms / 10 + 10)
-    logs = c.logs(stdout=True).decode("utf-8")
-    LOGGER.debug(logs)
-    assert rv == 0 or rv["StatusCode"] == 0, f"Command {command} failed"
     expected_file = f"{output_dir}/{test_file}.md"
     assert expected_file in logs, f"Expected file {expected_file} not generated"

--- a/all-spark-notebook/test/test_spark_notebooks.py
+++ b/all-spark-notebook/test/test_spark_notebooks.py
@@ -22,16 +22,16 @@ def test_nbconvert(container: TrackedContainer, test_file: str) -> None:
     host_data_dir = THIS_DIR / "data"
     cont_data_dir = "/home/jovyan/data"
     output_dir = "/tmp"
-    timeout_ms = 600
+    conversion_timeout_ms = 600
     LOGGER.info(f"Test that {test_file} notebook can be executed ...")
     command = (
         "jupyter nbconvert --to markdown "
-        + f"--ExecutePreprocessor.timeout={timeout_ms} "
+        + f"--ExecutePreprocessor.timeout={conversion_timeout_ms} "
         + f"--output-dir {output_dir} "
         + f"--execute {cont_data_dir}/{test_file}.ipynb"
     )
     logs = container.run_and_wait(
-        timeout=10,
+        timeout=60,
         volumes={str(host_data_dir): {"bind": cont_data_dir, "mode": "ro"}},
         tty=True,
         command=["start.sh", "bash", "-c", command],

--- a/all-spark-notebook/test/test_spark_notebooks.py
+++ b/all-spark-notebook/test/test_spark_notebooks.py
@@ -31,7 +31,7 @@ def test_nbconvert(container: TrackedContainer, test_file: str) -> None:
         + f"--execute {cont_data_dir}/{test_file}.ipynb"
     )
     logs = container.run_and_wait(
-        timeout=timeout_ms / 10 + 10,
+        timeout=10,
         volumes={str(host_data_dir): {"bind": cont_data_dir, "mode": "ro"}},
         tty=True,
         command=["start.sh", "bash", "-c", command],

--- a/all-spark-notebook/test/test_spark_notebooks.py
+++ b/all-spark-notebook/test/test_spark_notebooks.py
@@ -32,9 +32,15 @@ def test_nbconvert(container: TrackedContainer, test_file: str) -> None:
     )
     logs = container.run_and_wait(
         timeout=60,
+        no_warnings=False,
         volumes={str(host_data_dir): {"bind": cont_data_dir, "mode": "ro"}},
         tty=True,
         command=["start.sh", "bash", "-c", command],
     )
+    # Spark warning
+    warnings = TrackedContainer.get_warnings(logs)
+    assert len(warnings) == 1
+    assert "An illegal reflective access operation has occurred" in warnings[0]
+
     expected_file = f"{output_dir}/{test_file}.md"
     assert expected_file in logs, f"Expected file {expected_file} not generated"

--- a/base-notebook/test/test_container_options.py
+++ b/base-notebook/test/test_container_options.py
@@ -23,9 +23,7 @@ def test_cli_args(container: TrackedContainer, http_client: requests.Session) ->
     logs = running_container.logs().decode("utf-8")
     LOGGER.debug(logs)
     assert "ERROR" not in logs
-    warnings = [
-        warning for warning in logs.split("\n") if warning.startswith("WARNING")
-    ]
+    warnings = TrackedContainer.get_warnings(logs)
     assert not warnings
     assert "login_submit" not in resp.text
 
@@ -48,9 +46,7 @@ def test_unsigned_ssl(
     assert "login_submit" in resp.text
     logs = running_container.logs().decode("utf-8")
     assert "ERROR" not in logs
-    warnings = [
-        warning for warning in logs.split("\n") if warning.startswith("WARNING")
-    ]
+    warnings = TrackedContainer.get_warnings(logs)
     assert not warnings
 
 
@@ -218,9 +214,7 @@ def test_group_add(container: TrackedContainer) -> None:
         group_add=["users"],  # Ensures write access to /home/jovyan
         command=["start.sh", "id"],
     )
-    warnings = [
-        warning for warning in logs.split("\n") if warning.startswith("WARNING")
-    ]
+    warnings = TrackedContainer.get_warnings(logs)
     assert len(warnings) == 1
     assert "Try setting gid=0" in warnings[0]
     assert "uid=1010 gid=1010 groups=1010,100(users)" in logs
@@ -239,9 +233,7 @@ def test_set_uid(container: TrackedContainer) -> None:
         command=["start.sh", "id"],
     )
     assert "uid=1010(jovyan) gid=0(root)" in logs
-    warnings = [
-        warning for warning in logs.split("\n") if warning.startswith("WARNING")
-    ]
+    warnings = TrackedContainer.get_warnings(logs)
     assert len(warnings) == 1
     assert "--group-add=users" in warnings[0]
 
@@ -257,9 +249,7 @@ def test_set_uid_and_nb_user(container: TrackedContainer) -> None:
         command=["start.sh", "id"],
     )
     assert "uid=1010(kitten) gid=0(root)" in logs
-    warnings = [
-        warning for warning in logs.split("\n") if warning.startswith("WARNING")
-    ]
+    warnings = TrackedContainer.get_warnings(logs)
     assert len(warnings) == 1
     assert "user is kitten but home is /home/jovyan" in warnings[0]
 

--- a/base-notebook/test/test_package_managers.py
+++ b/base-notebook/test/test_package_managers.py
@@ -26,15 +26,8 @@ def test_package_manager(
     LOGGER.info(
         f"Test that the package manager {package_manager} is working properly ..."
     )
-    c = container.run(
+    container.run_and_wait(
+        timeout=5,
         tty=True,
         command=["start.sh", "bash", "-c", f"{package_manager} {version_arg}"],
     )
-    rv = c.wait(timeout=5)
-    logs = c.logs(stdout=True).decode("utf-8")
-    LOGGER.debug(logs)
-    assert "ERROR" not in logs
-    assert "WARNING" not in logs
-    assert (
-        rv == 0 or rv["StatusCode"] == 0
-    ), f"Package manager {package_manager} not working"

--- a/base-notebook/test/test_pandoc.py
+++ b/base-notebook/test/test_pandoc.py
@@ -10,13 +10,9 @@ LOGGER = logging.getLogger(__name__)
 
 def test_pandoc(container: TrackedContainer) -> None:
     """Pandoc shall be able to convert MD to HTML."""
-    c = container.run(
+    logs = container.run_and_wait(
+        timeout=10,
         tty=True,
         command=["start.sh", "bash", "-c", 'echo "**BOLD**" | pandoc'],
     )
-    c.wait(timeout=10)
-    logs = c.logs(stdout=True).decode("utf-8")
-    assert "ERROR" not in logs
-    assert "WARNING" not in logs
-    LOGGER.debug(logs)
     assert "<p><strong>BOLD</strong></p>" in logs

--- a/base-notebook/test/test_python.py
+++ b/base-notebook/test/test_python.py
@@ -14,15 +14,12 @@ def test_python_version(
 ) -> None:
     """Check that python version is lower than the next version"""
     LOGGER.info(f"Checking that python version is lower than {python_next_version}")
-    c = container.run(
+    logs = container.run_and_wait(
+        timeout=5,
         tty=True,
-        command=["start.sh"],
+        command=["start.sh", "python", "--version"],
     )
-    cmd = c.exec_run("python --version")
-    output = cmd.output.decode("utf-8")
-    assert "ERROR" not in output
-    assert "WARNING" not in output
-    actual_python_version = version.parse(output.split()[1])
+    actual_python_version = version.parse(logs.split()[1])
     assert actual_python_version < version.parse(
         python_next_version
     ), f"Python version shall be lower than {python_next_version}"

--- a/base-notebook/test/test_start_container.py
+++ b/base-notebook/test/test_start_container.py
@@ -5,7 +5,6 @@ import logging
 from typing import Optional
 import pytest
 import requests
-import re
 import time
 
 from conftest import TrackedContainer
@@ -65,10 +64,8 @@ def test_start_notebook(
     assert "ERROR" not in logs, "ERROR(s) found in logs"
     for exp_warning in expected_warnings:
         assert exp_warning in logs, f"Expected warning {exp_warning} not found in logs"
-    warnings = re.findall(r"^WARNING", logs, flags=re.MULTILINE)
-    assert len(expected_warnings) == len(
-        warnings
-    ), "Not found the number of expected warnings in logs"
+    warnings = TrackedContainer.get_warnings(logs)
+    assert len(expected_warnings) == len(warnings)
     # checking if the server is listening
     if expected_start:
         resp = http_client.get("http://localhost:8888")

--- a/base-notebook/test/test_start_container.py
+++ b/base-notebook/test/test_start_container.py
@@ -48,14 +48,14 @@ def test_start_notebook(
     LOGGER.info(
         f"Test that the start-notebook launches the {expected_command} server from the env {env} ..."
     )
-    c = container.run(
+    running_container = container.run_detached(
         tty=True,
         environment=env,
         command=["start-notebook.sh"],
     )
     # sleeping some time to let the server start
     time.sleep(3)
-    logs = c.logs(stdout=True).decode("utf-8")
+    logs = running_container.logs().decode("utf-8")
     LOGGER.debug(logs)
     # checking that the expected command is launched
     assert (
@@ -84,12 +84,12 @@ def test_tini_entrypoint(
     https://superuser.com/questions/632979/if-i-know-the-pid-number-of-a-process-how-can-i-get-its-name
     """
     LOGGER.info(f"Test that {command} is launched as PID {pid} ...")
-    c = container.run(
+    running_container = container.run_detached(
         tty=True,
         command=["start.sh"],
     )
     # Select the PID 1 and get the corresponding command
-    cmd = c.exec_run(f"ps -p {pid} -o comm=")
+    cmd = running_container.exec_run(f"ps -p {pid} -o comm=")
     output = cmd.output.decode("utf-8").strip("\n")
     assert "ERROR" not in output
     assert "WARNING" not in output

--- a/conftest.py
+++ b/conftest.py
@@ -101,7 +101,7 @@ class TrackedContainer:
         logs = running_container.logs().decode("utf-8")
         LOGGER.debug(logs)
         if no_warnings:
-            assert "WARNING" not in logs
+            assert not self.get_warnings(logs)
         if no_errors:
             assert "ERROR" not in logs
         assert rv == 0 or rv["StatusCode"] == 0

--- a/conftest.py
+++ b/conftest.py
@@ -53,7 +53,10 @@ class TrackedContainer:
     """
 
     def __init__(
-        self, docker_client: docker.DockerClient, image_name: str, **kwargs: typing.Any
+        self,
+        docker_client: docker.DockerClient,
+        image_name: str,
+        **kwargs: typing.Any,
     ):
         self.container = None
         self.docker_client = docker_client

--- a/conftest.py
+++ b/conftest.py
@@ -93,7 +93,7 @@ class TrackedContainer:
         no_errors: bool = True,
         **kwargs: typing.Any,
     ) -> str:
-        running_container = self.run_and_wait(**kwargs)
+        running_container = self.run_detached(**kwargs)
         rv = running_container.wait(timeout=timeout)
         logs = running_container.logs().decode("utf-8")
         LOGGER.debug(logs)

--- a/conftest.py
+++ b/conftest.py
@@ -107,6 +107,12 @@ class TrackedContainer:
         assert rv == 0 or rv["StatusCode"] == 0
         return logs
 
+    @staticmethod
+    def get_warnings(logs: str) -> list[str]:
+        return [
+            warning for warning in logs.split("\n") if warning.startswith("WARNING")
+        ]
+
     def remove(self):
         """Kills and removes the tracked docker container."""
         if self.container:

--- a/conftest.py
+++ b/conftest.py
@@ -108,12 +108,16 @@ class TrackedContainer:
         return logs
 
     @staticmethod
-    def get_warnings(logs: str) -> list[str]:
-        return [line for line in logs.split("\n") if line.startswith("WARNING")]
+    def get_errors(logs: str) -> list[str]:
+        return _lines_starting_with(logs, "ERROR")
 
     @staticmethod
-    def get_errors(logs: str) -> list[str]:
-        return [line for line in logs.split("\n") if line.startswith("ERROR")]
+    def get_warnings(logs: str) -> list[str]:
+        return _lines_starting_with(logs, "WARNING")
+
+    @staticmethod
+    def _lines_starting_with(logs: str, pattern: str) -> list[str]:
+        return [line for line in logs.splitlines() if line.startswith(pattern)]
 
     def remove(self):
         """Kills and removes the tracked docker container."""

--- a/conftest.py
+++ b/conftest.py
@@ -109,11 +109,11 @@ class TrackedContainer:
 
     @staticmethod
     def get_errors(logs: str) -> list[str]:
-        return _lines_starting_with(logs, "ERROR")
+        return TrackedContainer._lines_starting_with(logs, "ERROR")
 
     @staticmethod
     def get_warnings(logs: str) -> list[str]:
-        return _lines_starting_with(logs, "WARNING")
+        return TrackedContainer._lines_starting_with(logs, "WARNING")
 
     @staticmethod
     def _lines_starting_with(logs: str, pattern: str) -> list[str]:

--- a/conftest.py
+++ b/conftest.py
@@ -103,15 +103,17 @@ class TrackedContainer:
         if no_warnings:
             assert not self.get_warnings(logs)
         if no_errors:
-            assert "ERROR" not in logs
+            assert not self.get_errors(logs)
         assert rv == 0 or rv["StatusCode"] == 0
         return logs
 
     @staticmethod
     def get_warnings(logs: str) -> list[str]:
-        return [
-            warning for warning in logs.split("\n") if warning.startswith("WARNING")
-        ]
+        return [l for in logs.split("\n") if l.startswith("WARNING")]
+
+    @staticmethod
+    def get_errrors(logs: str) -> list[str]:
+        return [l for l in logs.split("\n") if l.startswith("ERROR")]
 
     def remove(self):
         """Kills and removes the tracked docker container."""

--- a/conftest.py
+++ b/conftest.py
@@ -109,7 +109,7 @@ class TrackedContainer:
 
     @staticmethod
     def get_warnings(logs: str) -> list[str]:
-        return [l for in logs.split("\n") if l.startswith("WARNING")]
+        return [l for l in logs.split("\n") if l.startswith("WARNING")]
 
     @staticmethod
     def get_errrors(logs: str) -> list[str]:

--- a/conftest.py
+++ b/conftest.py
@@ -109,11 +109,11 @@ class TrackedContainer:
 
     @staticmethod
     def get_warnings(logs: str) -> list[str]:
-        return [l for l in logs.split("\n") if l.startswith("WARNING")]
+        return [line for line in logs.split("\n") if line.startswith("WARNING")]
 
     @staticmethod
-    def get_errrors(logs: str) -> list[str]:
-        return [l for l in logs.split("\n") if l.startswith("ERROR")]
+    def get_errors(logs: str) -> list[str]:
+        return [line for line in logs.split("\n") if line.startswith("ERROR")]
 
     def remove(self):
         """Kills and removes the tracked docker container."""

--- a/datascience-notebook/test/test_julia.py
+++ b/datascience-notebook/test/test_julia.py
@@ -10,7 +10,7 @@ LOGGER = logging.getLogger(__name__)
 def test_julia(container: TrackedContainer) -> None:
     """Basic julia test"""
     LOGGER.info("Test that julia is correctly installed ...")
-    running_container = container.run(
+    running_container = container.run_detached(
         tty=True,
         command=["start.sh", "bash", "-c", "sleep infinity"],
     )

--- a/minimal-notebook/test/test_inkscape.py
+++ b/minimal-notebook/test/test_inkscape.py
@@ -11,11 +11,9 @@ LOGGER = logging.getLogger(__name__)
 def test_inkscape(container: TrackedContainer) -> None:
     """Inkscape shall be installed to be able to convert SVG files."""
     LOGGER.info("Test that inkscape is working by printing its version ...")
-    c = container.run(
+    logs = container.run_and_wait(
+        timeout=10,
         tty=True,
         command=["start.sh", "bash", "-c", "inkscape --version"],
     )
-    c.wait(timeout=10)
-    logs = c.logs(stdout=True).decode("utf-8")
-    LOGGER.debug(logs)
     assert "Inkscape" in logs, "Inkscape not installed or not working"

--- a/pyspark-notebook/test/test_spark.py
+++ b/pyspark-notebook/test/test_spark.py
@@ -16,9 +16,8 @@ def test_spark_shell(container: TrackedContainer) -> None:
         tty=True,
         command=["start.sh", "bash", "-c", 'spark-shell <<< "1+1"'],
     )
-    # Spark warning
     warnings = TrackedContainer.get_warnings(logs)
-    assert len(warnings) == 1
-    assert "An illegal reflective access operation has occurred" in warnings[0]
+    # Some Spark warnings
+    assert len(warnings) == 5
 
     assert "res0: Int = 2" in logs, "spark-shell does not work"

--- a/pyspark-notebook/test/test_spark.py
+++ b/pyspark-notebook/test/test_spark.py
@@ -10,11 +10,9 @@ LOGGER = logging.getLogger(__name__)
 
 def test_spark_shell(container: TrackedContainer) -> None:
     """Checking if Spark (spark-shell) is running properly"""
-    c = container.run(
+    logs = container.run_and_wait(
+        timeout=60,
         tty=True,
         command=["start.sh", "bash", "-c", 'spark-shell <<< "1+1"'],
     )
-    c.wait(timeout=60)
-    logs = c.logs(stdout=True).decode("utf-8")
-    LOGGER.debug(logs)
     assert "res0: Int = 2" in logs, "spark-shell does not work"

--- a/pyspark-notebook/test/test_spark.py
+++ b/pyspark-notebook/test/test_spark.py
@@ -11,9 +11,14 @@ LOGGER = logging.getLogger(__name__)
 def test_spark_shell(container: TrackedContainer) -> None:
     """Checking if Spark (spark-shell) is running properly"""
     logs = container.run_and_wait(
-        no_warnings=False,  # WARNING: An illegal reflective access operation has occurred
         timeout=60,
+        no_warnings=False,
         tty=True,
         command=["start.sh", "bash", "-c", 'spark-shell <<< "1+1"'],
     )
+    # Spark warning
+    warnings = TrackedContainer.get_warnings(logs)
+    assert len(warnings) == 1
+    assert "An illegal reflective access operation has occurred" in warnings[0]
+
     assert "res0: Int = 2" in logs, "spark-shell does not work"

--- a/pyspark-notebook/test/test_spark.py
+++ b/pyspark-notebook/test/test_spark.py
@@ -11,6 +11,7 @@ LOGGER = logging.getLogger(__name__)
 def test_spark_shell(container: TrackedContainer) -> None:
     """Checking if Spark (spark-shell) is running properly"""
     logs = container.run_and_wait(
+        no_warnings=False,  # WARNING: An illegal reflective access operation has occurred
         timeout=60,
         tty=True,
         command=["start.sh", "bash", "-c", 'spark-shell <<< "1+1"'],

--- a/scipy-notebook/test/test_extensions.py
+++ b/scipy-notebook/test/test_extensions.py
@@ -27,11 +27,8 @@ def test_check_extension(container: TrackedContainer, extension: str) -> None:
 
     """
     LOGGER.info(f"Checking the extension: {extension} ...")
-    c = container.run(
+    container.run_and_wait(
+        timeout=10,
         tty=True,
         command=["start.sh", "jupyter", "labextension", "check", extension],
     )
-    rv = c.wait(timeout=10)
-    logs = c.logs(stdout=True).decode("utf-8")
-    LOGGER.debug(logs)
-    assert rv == 0 or rv["StatusCode"] == 0, f"Extension {extension} check failed"

--- a/scipy-notebook/test/test_matplotlib.py
+++ b/scipy-notebook/test/test_matplotlib.py
@@ -40,7 +40,7 @@ def test_matplotlib(
     output_dir = "/tmp"
     LOGGER.info(description)
     command = "sleep infinity"
-    running_container = container.run(
+    running_container = container.run_detached(
         volumes={str(host_data_dir): {"bind": cont_data_dir, "mode": "ro"}},
         tty=True,
         command=["start.sh", "bash", "-c", command],

--- a/tagging/docker_runner.py
+++ b/tagging/docker_runner.py
@@ -1,6 +1,8 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
+from typing import Optional
 import docker
+from docker.models.containers import Container
 import logging
 
 
@@ -14,12 +16,12 @@ class DockerRunner:
         docker_client=docker.from_env(),
         command: str = "sleep infinity",
     ):
-        self.container = None
-        self.image_name = image_name
-        self.command = command
-        self.docker_client = docker_client
+        self.container: Optional[Container] = None
+        self.image_name: str = image_name
+        self.command: str = command
+        self.docker_client: docker.DockerClient = docker_client
 
-    def __enter__(self):
+    def __enter__(self) -> Container:
         LOGGER.info(f"Creating container for image {self.image_name} ...")
         self.container = self.docker_client.containers.run(
             image=self.image_name,
@@ -29,14 +31,16 @@ class DockerRunner:
         LOGGER.info(f"Container {self.container.name} created")
         return self.container
 
-    def __exit__(self, exc_type, exc_value, traceback):
+    def __exit__(self, exc_type, exc_value, traceback) -> None:
         LOGGER.info(f"Removing container {self.container.name} ...")
         if self.container:
             self.container.remove(force=True)
             LOGGER.info(f"Container {self.container.name} removed")
 
     @staticmethod
-    def run_simple_command(container, cmd: str, print_result: bool = True):
+    def run_simple_command(
+        container: Container, cmd: str, print_result: bool = True
+    ) -> str:
         LOGGER.info(f"Running cmd: '{cmd}' on container: {container}")
         out = container.exec_run(cmd)
         result = out.output.decode("utf-8").rstrip()

--- a/test/package_helper.py
+++ b/test/package_helper.py
@@ -50,7 +50,7 @@ class CondaPackageHelper:
     def start_container(container: TrackedContainer):
         """Start the TrackedContainer and return an instance of a running container"""
         LOGGER.info(f"Starting container {container.image_name} ...")
-        return container.run(
+        return container.run_detached(
             tty=True,
             command=["start.sh", "bash", "-c", "sleep infinity"],
         )

--- a/test/test_notebook.py
+++ b/test/test_notebook.py
@@ -10,7 +10,7 @@ def test_secured_server(
     container: TrackedContainer, http_client: requests.Session
 ) -> None:
     """Notebook server should eventually request user login."""
-    container.run()
+    container.run_detached()
     resp = http_client.get("http://localhost:8888")
     resp.raise_for_status()
     assert "login_submit" in resp.text, "User login not requested"

--- a/test/test_units.py
+++ b/test/test_units.py
@@ -27,12 +27,9 @@ def test_units(container: TrackedContainer) -> None:
         test_file_name = test_file.name
         LOGGER.info(f"Running unit test: {test_file_name}")
 
-        c = container.run(
+        container.run_and_wait(
+            timeout=30,
             volumes={str(host_data_dir): {"bind": cont_data_dir, "mode": "ro"}},
             tty=True,
             command=["start.sh", "python", f"{cont_data_dir}/{test_file_name}"],
         )
-        rv = c.wait(timeout=30)
-        logs = c.logs(stdout=True).decode("utf-8")
-        LOGGER.debug(logs)
-        assert rv == 0 or rv["StatusCode"] == 0


### PR DESCRIPTION
Benefits of `container.run_and_wait`:
- it's typed and it's type is `str`. I don't like Docker approach, where one function can return different things depending on parameters (but in their case it makes sense).
- warnings and errors are checked, unless explicitly asked not to check them
- return code is always checked
- it's easy to debug broken tests - because not all the tests used `LOGGER.debug`, now they will
- less code :)