### PR TITLE
Prototype for multi-arch manifest

### DIFF
--- a/tagging/docker_runner.py
+++ b/tagging/docker_runner.py
@@ -1,5 +1,6 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
+from platform import platform
 from typing import Optional
 from types import TracebackType
 import docker
@@ -14,11 +15,13 @@ class DockerRunner:
     def __init__(
         self,
         image_name: str,
+        platform: Optional[str] = None,
         docker_client: docker.DockerClient = docker.from_env(),
         command: str = "sleep infinity",
     ):
         self.container: Optional[Container] = None
         self.image_name: str = image_name
+        self.platform: Optional[str] = platform
         self.command: str = command
         self.docker_client: docker.DockerClient = docker_client
 
@@ -26,6 +29,7 @@ class DockerRunner:
         LOGGER.info(f"Creating container for image {self.image_name} ...")
         self.container = self.docker_client.containers.run(
             image=self.image_name,
+            platform=platform,
             command=self.command,
             detach=True,
         )

--- a/tagging/manifests.py
+++ b/tagging/manifests.py
@@ -20,7 +20,9 @@ class ManifestHeader:
     """ManifestHeader doesn't fall under common interface and we run it separately"""
 
     @staticmethod
-    def create_header(short_image_name: str, owner: str, build_timestamp: str) -> str:
+    def create_header(
+        short_image_name: str, owner: str, platform: str, build_timestamp: str
+    ) -> str:
         commit_hash = GitHelper.commit_hash()
         commit_hash_tag = GitHelper.commit_hash_tag()
         commit_message = GitHelper.commit_message()
@@ -35,6 +37,7 @@ class ManifestHeader:
                 "",
                 "## Build Info",
                 "",
+                f"* OS / Architecture: {platform}",
                 f"* Build datetime: {build_timestamp}",
                 f"* Docker image: {owner}/{short_image_name}:{commit_hash_tag}",
                 f"* Docker image size: {image_size}",


### PR DESCRIPTION
Hello,

This PR is a proposal to fix #1401.
It has two main points described below.

## 1. Make the manifest tool able to handle different os/architectures

I've made a first beta prototype to make it work on different architecture--there is still a lot of work to do. So the following call will generate a manifest from the image `docker pull --platform linux/arm64 jupyter/base-notebook:b020a0cf3b96`

```bash
python3 -m tagging.create_manifests --short-image-name base-notebook --platform linux/arm64 --owner jupyter --tag b020a0cf3b96 --wiki-path ../wiki

grep "arm" ../wiki/manifests/base-notebook-b020a0cf3b96.md | head
# * OS / Architecture: linux/arm64
# apt/now 2.0.6 arm64 [installed,local]
# base-files/now 11ubuntu5.4 arm64 [installed,local]
# base-passwd/now 3.5.47 arm64 [installed,local]
# bash/now 5.0-6ubuntu1.1 arm64 [installed,local]
# bsdutils/now 1:2.34-0.1ubuntu9.1 arm64 [installed,local]
```

TODO (at least):

- [ ] put architecture in filename (or find another way of doing it)
- [ ] manage the index

## 2. Create the manifest after the push to the registry

By creating the manifest **after the push** to the registry we would be able to access easily (without having to export them) the images of the various architectures.
I guess we will benefit from the `buildx` cache (or at least I'm pretty sure it's possible to do so) so the pull should not be a penalty.

@consideRatio and @mathbunnyru what do you think about this solution?
Once again is only a early prototype only modified to illustrate the proposal.
Thanks.
