### PR TITLE
Install more r packages for arm

### DIFF
--- a/r-notebook/Dockerfile
+++ b/r-notebook/Dockerfile
@@ -47,7 +47,7 @@ RUN mamba install --quiet --yes \
     fix-permissions "${CONDA_DIR}" && \
     fix-permissions "/home/${NB_USER}"
 
-# These packages are not easy to install under arm
+# `r-tidymodels` is not easy to install under arm
 # hadolint ignore=SC2039
 RUN set -x && \
     arch=$(uname -m) && \

--- a/r-notebook/Dockerfile
+++ b/r-notebook/Dockerfile
@@ -37,9 +37,11 @@ RUN mamba install --quiet --yes \
     'r-nycflights13' \
     'r-randomforest' \
     'r-rcurl' \
+    'r-rmarkdown' \
     'r-rodbc' \
     'r-rsqlite' \
     'r-shiny' \
+    'r-tidyverse' \
     'unixodbc' && \
     mamba clean --all -f -y && \
     fix-permissions "${CONDA_DIR}" && \
@@ -51,9 +53,7 @@ RUN set -x && \
     arch=$(uname -m) && \
     if [ "${arch}" == "x86_64" ]; then \
         mamba install --quiet --yes \
-            'r-rmarkdown' \
-            'r-tidymodels' \
-            'r-tidyverse' && \
+            'r-tidymodels' && \
             mamba clean --all -f -y && \
             fix-permissions "${CONDA_DIR}" && \
             fix-permissions "/home/${NB_USER}"; \


### PR DESCRIPTION
Summary by Erik: In the past we have omitted installing three R packages in our arm64 image specifically. Now though, it seems like arm64 support has improved and we only need to omit one R package.