### PR TITLE
Prototype using docker buildx bake

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -1,0 +1,101 @@
+group "default" {
+  targets = [
+    "base-notebook",
+    "minimal-notebook",
+    "r-notebook",
+	  "scipy-notebook",
+    "tensorflow-notebook",
+    "datascience-notebook",
+    "pyspark-notebook",
+	  "all-spark-notebook"
+  ]
+}
+
+group "linux-arm64" {
+  targets = [
+    "base-notebook",
+    "minimal-notebook",
+    "r-notebook",
+	  "scipy-notebook",
+    "pyspark-notebook",
+	  "all-spark-notebook"
+  ]
+}
+
+variable "OWNER" {
+  default = "jupyter"
+}
+
+
+target "_default" {
+  args = {
+    OWNER = OWNER
+  }
+  platforms = ["linux/amd64", "linux/arm64"]
+}
+
+target "base-notebook" {
+  inherits = ["_default"]
+  context = "base-notebook"
+  tags = [
+    "${OWNER}/base-notebook:latest"
+  ]
+}
+
+target "minimal-notebook" {
+  inherits = ["_default"]
+  context = "minimal-notebook"
+  tags = [
+    "${OWNER}/minimal-notebook:latest"
+  ]
+}
+
+target "r-notebook" {
+  inherits = ["_default"]
+  context = "r-notebook"
+  tags = [
+    "${OWNER}/r-notebook:latest"
+  ]
+}
+
+target "scipy-notebook" {
+  inherits = ["_default"]
+  context = "scipy-notebook"
+  tags = [
+    "${OWNER}/scipy-notebook:latest"
+  ]
+}
+
+target "tensorflow-notebook" {
+  inherits = ["_default"]
+  context = "tensorflow-notebook"
+  tags = [
+    "${OWNER}/tensorflow-notebook:latest"
+  ]
+  platforms = ["linux/amd64"]
+}
+
+target "datascience-notebook" {
+  inherits = ["_default"]
+  context = "datascience-notebook"
+  tags = [
+    "${OWNER}/datascience-notebook:latest"
+  ]
+  platforms = ["linux/amd64"]
+}
+
+target "pyspark-notebook" {
+  inherits = ["_default"]
+  context = "pyspark-notebook"
+  tags = [
+    "${OWNER}/pyspark-notebook:latest"
+  ]
+}
+
+target "all-spark-notebook" {
+  inherits = ["_default"]
+  context = "all-spark-notebook"
+  tags = [
+    "${OWNER}/all-spark-notebook:latest"
+  ]
+}

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -3,11 +3,11 @@ group "default" {
     "base-notebook",
     "minimal-notebook",
     "r-notebook",
-	  "scipy-notebook",
+    "scipy-notebook",
     "tensorflow-notebook",
     "datascience-notebook",
     "pyspark-notebook",
-	  "all-spark-notebook"
+    "all-spark-notebook"
   ]
 }
 
@@ -16,9 +16,9 @@ group "linux-arm64" {
     "base-notebook",
     "minimal-notebook",
     "r-notebook",
-	  "scipy-notebook",
+    "scipy-notebook",
     "pyspark-notebook",
-	  "all-spark-notebook"
+    "all-spark-notebook"
   ]
 }
 
@@ -26,6 +26,10 @@ variable "OWNER" {
   default = "jupyter"
 }
 
+function "tags" {
+  params = [image]
+  result = ["${OWNER}/${image}:latest"]
+}
 
 target "_default" {
   args = {
@@ -37,65 +41,49 @@ target "_default" {
 target "base-notebook" {
   inherits = ["_default"]
   context = "base-notebook"
-  tags = [
-    "${OWNER}/base-notebook:latest"
-  ]
+  tags = tags("base-notebook")
 }
 
 target "minimal-notebook" {
   inherits = ["_default"]
   context = "minimal-notebook"
-  tags = [
-    "${OWNER}/minimal-notebook:latest"
-  ]
+  tags = tags("minimal-notebook")
 }
 
 target "r-notebook" {
   inherits = ["_default"]
   context = "r-notebook"
-  tags = [
-    "${OWNER}/r-notebook:latest"
-  ]
+  tags = tags("r-notebook")
 }
 
 target "scipy-notebook" {
   inherits = ["_default"]
   context = "scipy-notebook"
-  tags = [
-    "${OWNER}/scipy-notebook:latest"
-  ]
+  tags = tags("scipy-notebook")
 }
 
 target "tensorflow-notebook" {
   inherits = ["_default"]
   context = "tensorflow-notebook"
-  tags = [
-    "${OWNER}/tensorflow-notebook:latest"
-  ]
+  tags = tags("tensorflow-notebook")
   platforms = ["linux/amd64"]
 }
 
 target "datascience-notebook" {
   inherits = ["_default"]
   context = "datascience-notebook"
-  tags = [
-    "${OWNER}/datascience-notebook:latest"
-  ]
+  tags = tags("datascience-notebook")
   platforms = ["linux/amd64"]
 }
 
 target "pyspark-notebook" {
   inherits = ["_default"]
   context = "pyspark-notebook"
-  tags = [
-    "${OWNER}/pyspark-notebook:latest"
-  ]
+  tags = tags("pyspark-notebook")
 }
 
 target "all-spark-notebook" {
   inherits = ["_default"]
   context = "all-spark-notebook"
-  tags = [
-    "${OWNER}/all-spark-notebook:latest"
-  ]
+  tags = tags("all-spark-notebook")
 }


### PR DESCRIPTION
Hello,

Before going further #1585 on I wanted to give a try to [`docker buildx bake`](https://docs.docker.com/engine/reference/commandline/buildx_bake/).

> Bake is a high-level build command. Each specified target will run in parallel as part of the build.

My inspiration comes from the [Official Jenkins Docker image](https://github.com/jenkinsci/docker) repository.

## Conclusion

### Pros
- Permit to build everything in parallel and so improve performances by parallelization.
  - avoiding to start / stop build process and to load / unload resources multiple times.
  - Hard to say but could improve by a little bit more of ~ 15 % the build time and therefore resource consumption.
- Permits to have a standard way to manage build definitions and the various platforms.
  - Definition can be displayed by running `make print/<image short name>` . 

### Cons
- In our use case with something like 11 different and **dynamic** tags applied on 8 images, it appears difficult to manage tags in the build definition file `docker-backe.hcl`
  - The only solution I have seen is to use environment variables to transmit tags information.
  - If we consider that most of the tags can be different between two images, the number of variable become unmanageable
  - It is possible to define function to factorize tagging (see example below), but variables still need to be defined in a `hcl` file (if not the `build bake` complains).
  - It could be possible to _generate_ this variable definition in another file (it is possible to use variables across files) but it does not seem to be a good solution.
  - So according to those constrains, I have not modified the existing to `push` mechanism.

Example of tagging function and its usage.

```hcl
function "tags" {
  params = [image]
  result = [
    "${OWNER}/${image}:latest",
    notequal("",T_SHA) ? "${OWNER}/${image}:${T_SHA}": "",
    notequal("",T_DATE) ? "${OWNER}/${image}:${T_DATE}": "",
    notequal("",T_UBUNTU) ? "${OWNER}/${image}:${T_UBUNTU}": "",
  ]
}

target "base-notebook" {
  inherits = ["_default"]
  context = "base-notebook"
  tags = tags("minimal-notebook")
}
```

I'm unsure if we should merge or not this PR just to save time and resources without having tags managed in this way 😕.
In any case it was interesting at least for me, and I hope it will open new possibilities or axis of improvements.

@consideRatio and @mathbunnyru do not hesitate to share your feedback.

Best.