### PR TITLE
Fail make docs on docs warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -138,7 +138,7 @@ install-dev-env: ## install libraries required to build images and run tests
 
 
 docs: ## build HTML documentation
-	sphinx-build docs/ docs/_build/
+	sphinx-build -W docs/ docs/_build/
 
 install-docs-env: ## install libraries required to build docs
 	@pip install -r requirements-docs.txt


### PR DESCRIPTION
I think, this is the default behaviour on RTD, I would like it to be the default behaviour when I run `make docs`.
Makes local build process more similar to what happens in the CI.