### PR TITLE
Fix wrong links

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -85,3 +85,5 @@ source_suffix = {
     ".md": "markdown",
 }
 pygments_style = "sphinx"
+
+myst_heading_anchors = 3

--- a/docs/contributing/features.md
+++ b/docs/contributing/features.md
@@ -8,10 +8,10 @@ community with the cost of maintaining the images over time.
 
 Please follow the process below to suggest a new feature for inclusion in one of the core stacks:
 
-1. [Open a GitHub issue](https://github.com/jupyter/docker-stacks/issues/new?assignees=&labels=type%3AEnhancement&template=feature_request.md&title=) describing the feature
-   you'd like to contribute.
+1. Open a [GitHub feature request issue](https://github.com/jupyter/docker-stacks/issues/new?assignees=&labels=type%3AEnhancement&template=feature_request.md&title=)
+   describing the feature you'd like to contribute.
 2. Discuss with the maintainers whether the addition makes sense in
-   [one of the core stacks](../using/selecting.html#core-stacks), as a
+   [one of the core stacks](../using/selecting.md#core-stacks), as a
    [recipe in the documentation](recipes.md), as a [community stack](stacks.md), or as something
    else entirely.
 

--- a/docs/contributing/issues.md
+++ b/docs/contributing/issues.md
@@ -9,7 +9,8 @@ Please review the following guidelines when reporting your problem.
 - If you think your problem is unique to the Jupyter Docker Stacks images,
   please search the [jupyter/docker-stacks issue tracker](https://github.com/jupyter/docker-stacks/issues)
   to see if someone else has already reported the same problem.
-  If not, please open a [new issue](https://github.com/jupyter/docker-stacks/issues/new) and provide all of the information requested in the issue template.
+  If not, please open a [GitHub bug report issue](https://github.com/jupyter/docker-stacks/issues/new?assignees=&labels=type%3ABug&template=bug_report.md&title=)
+  and provide all of the information requested in the issue template.
   Additionally, make sure to check the [Troubleshooting common error](../using/troubleshooting.md) page in the documentation before submitting an issue.
 - If the issue you're seeing is with one of the open-source libraries included in the Docker images and is reproducible outside the images,
   please file a bug with the appropriate open source project.

--- a/docs/contributing/stacks.md
+++ b/docs/contributing/stacks.md
@@ -9,7 +9,7 @@ Following these steps will:
 1. Setup a project on GitHub containing a Dockerfile based on any of the images we provide.
 2. Configure GitHub Actions to build and test your image when users submit pull requests to your repository.
 3. Configure Docker Hub to build and host your images for others to use.
-4. Update the [list of community stacks](../using/selecting.html#community-stacks) in this documentation to include your image.
+4. Update the [list of community stacks](../using/selecting.md#community-stacks) in this documentation to include your image.
 
 This approach mirrors how we build and share the core stack images.
 Feel free to follow it or pave your own path using alternative services and build tools.

--- a/docs/maintaining/tasks.md
+++ b/docs/maintaining/tasks.md
@@ -34,7 +34,7 @@ In general, we do not add new core images and ask contributors to either create 
 When there's a new stack definition, do the following before merging the PR with the new stack:
 
 1. Ensure the PR includes an update to the stack overview diagram
-   [in the documentation](https://github.com/jupyter/docker-stacks/blob/master/docs/using/selecting.md#image-relationships).
+   [in the documentation](../using/selecting.md#image-relationships).
    The image links to the [blockdiag source](http://interactive.blockdiag.com/) used to create it.
 2. Ensure the PR updates the [Makefile](https://github.com/jupyter/docker-stacks/blob/master/Makefile), which is used to build the stacks in order on GitHub Actions.
 3. Ensure necessary tags / manifests are added for the new image in the [tagging](https://github.com/jupyter/docker-stacks/tree/master/tagging) folder.

--- a/docs/maintaining/tasks.md
+++ b/docs/maintaining/tasks.md
@@ -34,7 +34,7 @@ In general, we do not add new core images and ask contributors to either create 
 When there's a new stack definition, do the following before merging the PR with the new stack:
 
 1. Ensure the PR includes an update to the stack overview diagram
-   [in the documentation](../using/selecting.md#image-relationships).
+   [in the documentation](https://github.com/jupyter/docker-stacks/blob/master/docs/using/selecting.md#image-relationships).
    The image links to the [blockdiag source](http://interactive.blockdiag.com/) used to create it.
 2. Ensure the PR updates the [Makefile](https://github.com/jupyter/docker-stacks/blob/master/Makefile), which is used to build the stacks in order on GitHub Actions.
 3. Ensure necessary tags / manifests are added for the new image in the [tagging](https://github.com/jupyter/docker-stacks/tree/master/tagging) folder.

--- a/docs/using/common.md
+++ b/docs/using/common.md
@@ -274,4 +274,4 @@ mamba install --quiet --yes humanize && \
     fix-permissions "/home/${NB_USER}"
 ```
 
-[switch_back]: common.html#switching-back-to-classic-notebook-or-using-a-different-startup-command
+[switch_back]: #switching-back-to-the-classic-notebook-or-using-a-different-startup-command

--- a/docs/using/recipes.md
+++ b/docs/using/recipes.md
@@ -238,7 +238,7 @@ If you are mounting a host directory as `/home/jovyan/work` in your container an
 permission errors or connection errors when you create a notebook, be sure that the `jovyan` user
 (`UID=1000` by default) has read/write access to the directory on the host.
 Alternatively, specify the UID of the `jovyan` user on container startup using the `-e NB_UID` option described in the
-[Common Features, Docker Options section](../using/common.html#docker-options)
+[Common Features, Docker Options section](common.md#docker-options)
 
 Ref: <https://github.com/jupyter/docker-stacks/issues/199>
 

--- a/docs/using/running.md
+++ b/docs/using/running.md
@@ -121,7 +121,7 @@ See the
 You can configure JupyterHub to launcher Docker containers from the Jupyter Docker Stacks images.
 If you've been following the [Zero to JupyterHub with Kubernetes](https://zero-to-jupyterhub.readthedocs.io/en/latest/) guide,
 see the [Use an existing Docker image](https://zero-to-jupyterhub.readthedocs.io/en/latest/jupyterhub/customizing/user-environment.html#choose-and-use-an-existing-docker-image) section for details.
-If you have a custom JupyterHub deployment, see the [Picking or building a Docker image](https://github.com/jupyterhub/dockerspawner#picking-or-building-a-docker-image)
+If you have a custom JupyterHub deployment, see the [Picking or building a Docker image](https://jupyterhub-dockerspawner.readthedocs.io/en/latest/docker-image.html)
 instructions for the [dockerspawner](https://github.com/jupyterhub/dockerspawner) instead.
 
 ## Using Other Tools and Services

--- a/docs/using/selecting.md
+++ b/docs/using/selecting.md
@@ -113,7 +113,7 @@ It contains:
   [pytables](https://www.pytables.org/),
   [scikit-image](https://scikit-image.org),
   [scikit-learn](https://scikit-learn.org/stable/),
-  [scipy](https://www.scipy.org/),
+  [scipy](https://scipy.org/),
   [seaborn](https://seaborn.pydata.org/),
   [sqlalchemy](https://www.sqlalchemy.org/),
   [statsmodel](https://www.statsmodels.org/stable/index.html),
@@ -195,7 +195,7 @@ diagram](../images/inherit.svg)](http://interactive.blockdiag.com/?compression=d
 
 ### Builds
 
-Every Monday and whenever a pull request is merged, images are rebuilt and pushed to [the public container registry](https://hub.docker.com/r/jupyter).
+Every Monday and whenever a pull request is merged, images are rebuilt and pushed to [the public container registry](https://hub.docker.com/u/jupyter).
 
 ### Versioning via image tags
 
@@ -228,7 +228,7 @@ See the [contributing guide](../contributing/stacks.md) for information about ho
 | [kotlin]       | [![bb]][kotlin_b]       | [**Kotlin** kernel for Jupyter/IPython][kotlin_kernel] on top of the `base-notebook` image                |
 | [transformers] | [![bb]][transformers_b] | [**Transformers**][transformers_lib] and NLP libraries such as `Tensorflow`, `Keras`, `Jax` and `PyTorch` |
 
-[bb]: https://mybinder.org/badge_logo.svg
+[bb]: https://static.mybinder.org/badge_logo.svg
 [csharp]: https://github.com/tlinnet/csharp-notebook
 [csharp_b]: https://mybinder.org/v2/gh/tlinnet/csharp-notebook/master
 [education]: https://github.com/umsi-mads/education-notebook
@@ -259,5 +259,5 @@ See the [contributing guide](../contributing/stacks.md) for information about ho
 | [PRP-GPU][prp_gpu] | PRP (Pacific Research Platform) maintained [registry][prp_reg] for jupyter stack based on NVIDIA CUDA-enabled image. Added the PRP image with Pytorch and some other python packages and GUI Desktop notebook based on <https://github.com/jupyterhub/jupyter-remote-desktop-proxy>.                                                                     |
 
 [gpu]: https://github.com/iot-salzburg/gpu-jupyter
-[prp_gpu]: https://gitlab.nautilus.optiputer.net/prp/jupyter-stack/-/tree/prp
-[prp_reg]: https://gitlab.nautilus.optiputer.net/prp/jupyter-stack/container_registry
+[prp_gpu]: https://gitlab.nrp-nautilus.io/prp/jupyter-stack/-/tree/prp
+[prp_reg]: https://gitlab.nrp-nautilus.io/prp/jupyter-stack/container_registry

--- a/docs/using/troubleshooting.md
+++ b/docs/using/troubleshooting.md
@@ -4,7 +4,7 @@ When troubleshooting, you may see unexpected behaviors or receive an error messa
 This section provides advice on
 how to identify and fix some of the most commonly encountered issues.
 
-Most of the `docker run` flags used in this document are explained in detail in the [Common Features, Docker Options section](../using/common.html#docker-options) of the documentation.
+Most of the `docker run` flags used in this document are explained in detail in the [Common Features, Docker Options section](common.md#docker-options) of the documentation.
 
 ## Permission denied when mounting volumes
 
@@ -167,7 +167,7 @@ If you have also **created a new user**, you might be experiencing any of the fo
     In the example above, the `-v` flag is used to mount the local volume onto the new user's `/home` directory.
 
     However, if you are mounting a volume elsewhere, you also need to use the `-e CHOWN_EXTRA=<some-dir>` flag to avoid any permission
-    issues (see the section [Permission denied when mounting volumes](../using/troubleshooting.html#permission-denied-when-mounting-volumes) in this page).
+    issues (see the section [Permission denied when mounting volumes](#permission-denied-when-mounting-volumes) in this page).
    ```
 
 2. **Dynamically assign the user ID and GID**
@@ -263,7 +263,7 @@ You can install packages from other conda channels (e.g. bioconda) by disabling 
 conda install --no-channel-priority -c bioconda bioconductor-geoquery
 ```
 
-Additional details are provided in the [Using alternative channels](../using/common.html#using-alternative-channels) section of the [Common features](./common.md) page.
+Additional details are provided in the [Using alternative channels](../using/common.md#using-alternative-channels) section of the [Common features](common.md) page.
 
 ## Tokens are being rejected
 


### PR DESCRIPTION
I used sphinx link check (`sphinx-build -b linkcheck docs/ docs/_build/` or `make linkcheck-docs` in our Makefile) to get rid of broken links and redirects.