### PR TITLE
Switch the default to Jupyter Server configuration file

### DIFF
--- a/base-notebook/Dockerfile
+++ b/base-notebook/Dockerfile
@@ -165,7 +165,7 @@ COPY jupyter_server_config.py /etc/jupyter/
 # Fix permissions on /etc/jupyter as root
 USER root
 
-# Legacy for Jupyter Notebook Server #1205
+# Legacy for Jupyter Notebook Server, see: [#1205](https://github.com/jupyter/docker-stacks/issues/1205)
 RUN sed -re "s/c.ServerApp/c.NotebookApp/g" \
     /etc/jupyter/jupyter_server_config.py > /etc/jupyter/jupyter_notebook_config.py && \
     fix-permissions /etc/jupyter/

--- a/base-notebook/Dockerfile
+++ b/base-notebook/Dockerfile
@@ -160,14 +160,14 @@ CMD ["start-notebook.sh"]
 # Copy local files as late as possible to avoid cache busting
 COPY start.sh start-notebook.sh start-singleuser.sh /usr/local/bin/
 # Currently need to have both jupyter_notebook_config and jupyter_server_config to support classic and lab
-COPY jupyter_notebook_config.py /etc/jupyter/
+COPY jupyter_server_config.py /etc/jupyter/
 
 # Fix permissions on /etc/jupyter as root
 USER root
 
-# Prepare upgrade to JupyterLab V3.0 #1205
-RUN sed -re "s/c.NotebookApp/c.ServerApp/g" \
-    /etc/jupyter/jupyter_notebook_config.py > /etc/jupyter/jupyter_server_config.py && \
+# Legacy for Jupyter Notebook Server #1205
+RUN sed -re "s/c.ServerApp/c.NotebookApp/g" \
+    /etc/jupyter/jupyter_server_config.py > /etc/jupyter/jupyter_notebook_config.py && \
     fix-permissions /etc/jupyter/
 
 # Switch back to jovyan to avoid accidental container runs as root

--- a/base-notebook/jupyter_server_config.py
+++ b/base-notebook/jupyter_server_config.py
@@ -8,9 +8,9 @@ import stat
 
 
 c = get_config()  # noqa: F821
-c.NotebookApp.ip = "0.0.0.0"
-c.NotebookApp.port = 8888
-c.NotebookApp.open_browser = False
+c.ServerApp.ip = "0.0.0.0"
+c.ServerApp.port = 8888
+c.ServerApp.open_browser = False
 
 # https://github.com/jupyter/notebook/issues/3130
 c.FileContentsManager.delete_to_trash = False
@@ -49,7 +49,7 @@ if "GEN_CERT" in os.environ:
     )
     # Restrict access to the file
     os.chmod(pem_file, stat.S_IRUSR | stat.S_IWUSR)
-    c.NotebookApp.certfile = pem_file
+    c.ServerApp.certfile = pem_file
 
 # Change default umask for all subprocesses of the notebook server if set in
 # the environment

--- a/docs/using/common.md
+++ b/docs/using/common.md
@@ -8,7 +8,7 @@ This page describes the options supported by the startup script and how to bypas
 
 ## Jupyter Server Options
 
-You can pass [Jupyter server options](https://jupyter-notebook.readthedocs.io/en/stable/public_server.html) to the `start-notebook.sh` script when launching the container.
+You can pass [Jupyter server options](https://jupyter-server.readthedocs.io/en/latest/operators/public-server.html) to the `start-notebook.sh` script when launching the container.
 
 1. For example, to secure the Notebook server with a custom password hashed using `IPython.lib.passwd()` instead of the default token,
    you can run the following (this hash was generated for `my-password` password):
@@ -18,7 +18,7 @@ You can pass [Jupyter server options](https://jupyter-notebook.readthedocs.io/en
        start-notebook.sh --NotebookApp.password='sha1:7cca89c48283:e3c1f9fbc06d1d2aa59555dfd5beed925e30dd2c'
    ```
 
-2. To set the [base URL](https://jupyter-notebook.readthedocs.io/en/stable/public_server.html#running-the-notebook-with-a-customized-url-prefix) of the notebook server, you can run the following:
+2. To set the [base URL](https://jupyter-server.readthedocs.io/en/latest/operators/public-server.html#running-the-notebook-with-a-customized-url-prefix) of the notebook server, you can run the following:
 
    ```bash
    docker run  -it --rm -p 8888:8888 jupyter/base-notebook \
@@ -165,10 +165,13 @@ The certificate file or PEM may contain one or more certificates (e.g., server, 
 
 For additional information about using SSL, see the following:
 
-- The [docker-stacks/examples](https://github.com/jupyter/docker-stacks/tree/master/examples) for information about how to use
+- The [docker-stacks/examples](https://github.com/jupyter/docker-stacks/tree/master/examples)
+  for information about how to use
   [Let's Encrypt](https://letsencrypt.org/) certificates when you run these stacks on a publicly visible domain.
-- The [jupyter_notebook_config.py](https://github.com/jupyter/docker-stacks/blob/master/base-notebook/jupyter_notebook_config.py) file for how this Docker image generates a self-signed certificate.
-- The [Jupyter Notebook documentation](https://jupyter-notebook.readthedocs.io/en/latest/public_server.html#securing-a-notebook-server) for best practices about securing a public notebook server in general.
+- The [`jupyter_server_config.py`](https://github.com/jupyter/docker-stacks/blob/master/base-notebook/jupyter_server_config.py)
+  file for how this Docker image generates a self-signed certificate.
+- The [Jupyter Server documentation](https://jupyter-server.readthedocs.io/en/latest/operators/public-server.html#securing-a-jupyter-server)
+  for best practices about securing a public notebook server in general.
 
 ## Alternative Commands
 

--- a/examples/openshift/README.md
+++ b/examples/openshift/README.md
@@ -155,12 +155,12 @@ If you want to set any custom configuration for the notebook, you can edit the c
 oc edit configmap/mynotebook-cfg
 ```
 
-The `data` field of the config map contains Python code used as the `jupyter_notebook_config.py` file.
+The `data` field of the config map contains Python code used as the `jupyter_server_config.py` file.
 
 If you are using a persistent volume, you can also create a configuration file at:
 
 ```lang-none
-/home/jovyan/.jupyter/jupyter_notebook_config.py
+/home/jovyan/.jupyter/jupyter_server_config.py
 ```
 
 This will be merged at the end of the configuration from the config map.
@@ -209,7 +209,7 @@ oc set env dc/mynotebook JUPYTER_NOTEBOOK_PASSWORD=mypassword
 
 This will trigger a new deployment so ensure you have downloaded any work if not using a persistent volume.
 
-If using a persistent volume, you could instead setup a password in the file `/home/jovyan/.jupyter/jupyter_notebook_config.py` as per guidelines in <https://jupyter-notebook.readthedocs.io/en/stable/public_server.html>.
+If using a persistent volume, you could instead setup a password in the file `/home/jovyan/.jupyter/jupyter_server_config.py` as per guidelines in <https://jupyter-server.readthedocs.io/en/latest/operators/public-server.html>.
 
 ## Deploying from a Custom Image
 

--- a/examples/openshift/templates.json
+++ b/examples/openshift/templates.json
@@ -38,7 +38,7 @@
         }
       },
       "data": {
-        "jupyter_notebook_config.py": "import os\n\npassword = os.environ.get('JUPYTER_NOTEBOOK_PASSWORD')\n\nif password:\n    import notebook.auth\n    c.NotebookApp.password = notebook.auth.passwd(password)\n    del password\n    del os.environ['JUPYTER_NOTEBOOK_PASSWORD']\n\nimage_config_file = '/home/jovyan/.jupyter/jupyter_notebook_config.py'\n\nif os.path.exists(image_config_file):\n    with open(image_config_file) as fp:\n        exec(compile(fp.read(), image_config_file, 'exec'), globals())\n"
+        "jupyter_server_config.py": "import os\n\npassword = os.environ.get('JUPYTER_NOTEBOOK_PASSWORD')\n\nif password:\n    import notebook.auth\n    c.NotebookApp.password = notebook.auth.passwd(password)\n    del password\n    del os.environ['JUPYTER_NOTEBOOK_PASSWORD']\n\nimage_config_file = '/home/jovyan/.jupyter/jupyter_server_config.py'\n\nif os.path.exists(image_config_file):\n    with open(image_config_file) as fp:\n        exec(compile(fp.read(), image_config_file, 'exec'), globals())\n"
       }
     },
     {
@@ -81,7 +81,7 @@
                 "image": "${NOTEBOOK_IMAGE}",
                 "command": [
                   "start-notebook.sh",
-                  "--config=/etc/jupyter/openshift/jupyter_notebook_config.py",
+                  "--config=/etc/jupyter/openshift/jupyter_server_config.py",
                   "--no-browser",
                   "--ip=0.0.0.0"
                 ],

--- a/examples/source-to-image/templates.json
+++ b/examples/source-to-image/templates.json
@@ -221,7 +221,7 @@
             }
           },
           "data": {
-            "jupyter_notebook_config.py": "import os\n\npassword = os.environ.get('JUPYTER_NOTEBOOK_PASSWORD')\n\nif password:\n    import notebook.auth\n    c.NotebookApp.password = notebook.auth.passwd(password)\n    del password\n    del os.environ['JUPYTER_NOTEBOOK_PASSWORD']\n\nimage_config_file = '/home/jovyan/.jupyter/jupyter_notebook_config.py'\n\nif os.path.exists(image_config_file):\n    with open(image_config_file) as fp:\n        exec(compile(fp.read(), image_config_file, 'exec'), globals())\n"
+            "jupyter_server_config.py": "import os\n\npassword = os.environ.get('JUPYTER_NOTEBOOK_PASSWORD')\n\nif password:\n    import notebook.auth\n    c.NotebookApp.password = notebook.auth.passwd(password)\n    del password\n    del os.environ['JUPYTER_NOTEBOOK_PASSWORD']\n\nimage_config_file = '/home/jovyan/.jupyter/jupyter_server_config.py'\n\nif os.path.exists(image_config_file):\n    with open(image_config_file) as fp:\n        exec(compile(fp.read(), image_config_file, 'exec'), globals())\n"
           }
         },
         {
@@ -275,7 +275,7 @@
                     "image": "${APPLICATION_NAME}:latest",
                     "command": [
                       "start-notebook.sh",
-                      "--config=/etc/jupyter/openshift/jupyter_notebook_config.py",
+                      "--config=/etc/jupyter/openshift/jupyter_server_config.py",
                       "--no-browser",
                       "--ip=0.0.0.0"
                     ],


### PR DESCRIPTION
Hello,

This is a follow-on to the PR #1575 in the frame of the issue #1217 aiming to switch to Jupyter Lab by default.
Since [Jupyter Server](https://jupyter-server.readthedocs.io/en/latest/index.html) is now the default backend, I think it's better to maintain it's configuration file `jupyter_server_config.py` instead of the Jupyter Notebook one `jupyter_notebook_config.py`.

- I've simply inverted  in the Dockerfile the transformation between the two files. 
- I've tried to update all the references in the doc, however I may have forgotten some.
- I've basically updated (search & replace)  the files in the directory [`examples/openshift`](https://github.com/jupyter/docker-stacks/tree/master/examples/openshift), however I'm not sure they are sill working 😕.

Best :cake: