### PR TITLE
Add inline comments about pytest-xdist

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -207,7 +207,7 @@ run-sudo-shell/%: ## run a bash in interactive mode as root in a stack
 
 test/%: ## run tests against a stack (only common tests or common tests + specific tests)
 	@echo "::group::test/$(OWNER)/$(notdir $@)"
-	@if [ ! -d "$(notdir $@)/test" ]; then TEST_IMAGE="$(OWNER)/$(notdir $@)" pytest -n auto -m "not info" test; \
-	else TEST_IMAGE="$(OWNER)/$(notdir $@)" pytest -n auto -m "not info" test $(notdir $@)/test; fi
+	@if [ ! -d "$(notdir $@)/test" ]; then TEST_IMAGE="$(OWNER)/$(notdir $@)" pytest --numprocesses=auto -m "not info" test; \
+	else TEST_IMAGE="$(OWNER)/$(notdir $@)" pytest --numprocesses=auto -m "not info" test $(notdir $@)/test; fi
 	@echo "::endgroup::"
 test-all: $(foreach I, $(ALL_IMAGES), test/$(I)) ## test all stacks

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,6 +3,8 @@ packaging
 plumbum
 pre-commit
 pytest
+# pytest-xdist is a plugin that provides the --numprocesses flag, allowing us to
+# run pytest tests in parallel.
 pytest-xdist
 requests
 tabulate


### PR DESCRIPTION
I ended up needing to google around a bit to learn about the `-n` flag that turned out to come from pytest-xdist, so I figured it was helpful to document it and provide the flag in its long form. This is a followup to https://github.com/jupyter/docker-stacks/pull/1624.