### PR TITLE
Fix cython in scipy-notebook

### DIFF
--- a/scipy-notebook/Dockerfile
+++ b/scipy-notebook/Dockerfile
@@ -8,9 +8,15 @@ LABEL maintainer="Jupyter Project <jupyter@googlegroups.com>"
 
 USER root
 
-# ffmpeg for matplotlib anim & dvipng+cm-super for latex labels
 RUN apt-get update --yes && \
-    apt-get install --yes --no-install-recommends ffmpeg dvipng cm-super && \
+    apt-get install --yes --no-install-recommends \
+    # for cython: https://cython.readthedocs.io/en/latest/src/quickstart/install.html
+    build-essential \
+    # for latex labels
+    cm-super \
+    dvipng \
+    # for matplotlib anim
+    ffmpeg && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 
 USER ${NB_UID}

--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -1,7 +1,7 @@
 [pytest]
 addopts = -ra --color=yes
 log_cli = 1
-log_cli_level = INFO
+log_cli_level = DEBUG
 log_cli_format = %(asctime)s [%(levelname)8s] %(message)s (%(filename)s:%(lineno)s)
 log_cli_date_format=%Y-%m-%d %H:%M:%S
 markers =

--- a/tests/scipy-notebook/data/cython/helloworld.pyx
+++ b/tests/scipy-notebook/data/cython/helloworld.pyx
@@ -1,0 +1,1 @@
+print("Hello World")

--- a/tests/scipy-notebook/data/cython/setup.py
+++ b/tests/scipy-notebook/data/cython/setup.py
@@ -1,0 +1,9 @@
+from setuptools import setup
+from Cython.Build import cythonize
+from pathlib import Path
+
+
+THIS_DIR = Path(__file__).parent.resolve()
+
+
+setup(ext_modules=cythonize(str(THIS_DIR / "helloworld.pyx")))

--- a/tests/scipy-notebook/data/cython/setup.py
+++ b/tests/scipy-notebook/data/cython/setup.py
@@ -1,9 +1,4 @@
 from setuptools import setup
 from Cython.Build import cythonize
-from pathlib import Path
 
-
-THIS_DIR = Path(__file__).parent.resolve()
-
-
-setup(ext_modules=cythonize(str(THIS_DIR / "helloworld.pyx")))
+setup(ext_modules=cythonize("helloworld.pyx"))

--- a/tests/scipy-notebook/test_cython.py
+++ b/tests/scipy-notebook/test_cython.py
@@ -1,0 +1,36 @@
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+
+import logging
+from pathlib import Path
+import shutil
+import tempfile
+
+from conftest import TrackedContainer
+
+LOGGER = logging.getLogger(__name__)
+THIS_DIR = Path(__file__).parent.resolve()
+
+
+def test_cython(container: TrackedContainer) -> None:
+    data_dir = THIS_DIR / "data/cython"
+
+    with tempfile.TemporaryDirectory() as host_data_dir:
+        """We create temporary dir with the same content to mount it as a writeable folder
+        This allows to run this test in parallel many times
+        """
+        shutil.copy(data_dir / "helloworld.pyx", host_data_dir)
+        shutil.copy(data_dir / "setup.py", host_data_dir)
+
+        cont_data_dir = "/home/jovyan/data"
+        command = "sleep infinity"
+
+        running_container = container.run_detached(
+            volumes={str(host_data_dir): {"bind": cont_data_dir, "mode": "rw"}},
+            tty=True,
+            command=["start.sh", "bash", "-c", command],
+        )
+        command = f"python {cont_data_dir}/setup.py build_ext --inplace"
+        cmd = running_container.exec_run(command)
+        LOGGER.debug(cmd.output.decode("utf-8"))
+        assert cmd.exit_code == 0, f"Command {command} failed"

--- a/tests/scipy-notebook/test_cython.py
+++ b/tests/scipy-notebook/test_cython.py
@@ -22,6 +22,7 @@ def test_cython(container: TrackedContainer) -> None:
             "start.sh",
             "bash",
             "-c",
+            # We copy our data to temporary folder to be able to modify the directory
             f"cp -r {cont_data_dir}/ /tmp/test/ && cd /tmp/test && python3 setup.py build_ext",
         ],
     )

--- a/tests/scipy-notebook/test_cython.py
+++ b/tests/scipy-notebook/test_cython.py
@@ -1,12 +1,10 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 
-import logging
 from pathlib import Path
 
 from conftest import TrackedContainer
 
-LOGGER = logging.getLogger(__name__)
 THIS_DIR = Path(__file__).parent.resolve()
 
 


### PR DESCRIPTION
Fix: https://github.com/jupyter/docker-stacks/issues/1625
Follows: https://github.com/jupyter/docker-stacks/pull/1383

I added the test, that cython works properly (it didn't before this fix).
Image size increase: 2.68GB -> 2.82GB (checked under arm)
As we provide cython, we should make sure it works fine, that's why we have to install `build-essential` in `scipy-notebook`.
This also fixes the recent issue with absent `make` command.
