### PR TITLE
add the COPY_HOME option in start.sh

### DIFF
--- a/base-notebook/start.sh
+++ b/base-notebook/start.sh
@@ -76,6 +76,7 @@ if [ "$(id -u)" == 0 ] ; then
     # - NB_GID: a group id we want our user to belong to
     # - NB_GROUP: the groupname we want for the group
     # - GRANT_SUDO: a boolean ("1" or "yes") to grant the user sudo rights
+    # - COPY_HOME: a boolean ("1" or "yes") to copy the original home files
     # - CHOWN_HOME: a boolean ("1" or "yes") to chown the user's home folder
     # - CHOWN_EXTRA: a comma separated list of paths to chown
     # - CHOWN_HOME_OPTS / CHOWN_EXTRA_OPTS: arguments to the chown commands
@@ -108,9 +109,9 @@ if [ "$(id -u)" == 0 ] ; then
     # directory if it doesn't already exist, and update the current working
     # directory to the new location if needed.
     if [[ "${NB_USER}" != "jovyan" ]]; then
-        if [[ ! -e "/home/${NB_USER}" ]]; then
+        if [[ ! -e "/home/${NB_USER}"  ||  "${COPY_HOME}" == "yes" || "${COPY_HOME}" == "1" ]]; then
             _log "Attempting to copy /home/jovyan to /home/${NB_USER}..."
-            mkdir "/home/${NB_USER}"
+            mkdir -p "/home/${NB_USER}"
             if cp -a /home/jovyan/. "/home/${NB_USER}/"; then
                 _log "Success!"
             else

--- a/docs/using/troubleshooting.md
+++ b/docs/using/troubleshooting.md
@@ -141,6 +141,7 @@ If you have also **created a new user**, you might be experiencing any of the fo
         -e NB_GID=1234 \
         -e CHOWN_HOME=yes \
         -e CHOWN_HOME_OPTS="-R" \
+        -e COPY_HOME="yes" \
         -w "/home/${NB_USER}" \
         -v "${PWD}"/test:/home/callisto/work \
         jupyter/minimal-notebook
@@ -159,6 +160,7 @@ If you have also **created a new user**, you might be experiencing any of the fo
 
    - `-e NB_USER=callisto`: will create a new user `callisto` and automatically add it to the `users` group (does not delete jovyan)
    - `-e NB_UID=1234` and `-e NB_GID=1234`: will set the `UID` and `GID` of the new user (`callisto`) to `1234`
+   - `-e COPY_HOME=yes`: ensure that the new user will have the same files as the old user in its `/home` directory
    - `-e CHOWN_HOME_OPTS="-R"` and `-e CHOWN_HOME=yes`: ensure that the new user is the owner of the `/home` directory and subdirectories
      (setting `CHOWN_HOME_OPTS="-R` will ensure this change is applied recursively)
    - `-w "/home/${NB_USER}"` sets the working directory to be the new user's home


### PR DESCRIPTION
These changes make it possible to force the copy of the files of jovyan user to NB_USER 

With kubespawner and user who is not jovyan, volumes mounted in /home/${NB_USER} prevent copying home jovyan files.

With kubespawner and a configuration like bellow:

```
c.KubeSpawner.volume_mounts = [
    {
        'name': 'common',
        'mountPath': '/home/{username}/files',
    },
]
```

Kubespwner create `/home/{username}` to mount the declared volume.
So when we execute start.sh the directory `/home/{username}` already exist and there is no copy of jovyan files.

With this PR, the copy can now be force with the `COPY_HOME` environment variable.

Regards