### PR TITLE
fix script crash when user is not jovyan, and fix spurious warnings when $HOME environment is not "/home/jovyan"

### DIFF
--- a/base-notebook/start.sh
+++ b/base-notebook/start.sh
@@ -259,8 +259,8 @@ else
     fi
 
     # Warn if the user isn't able to write files to ${HOME}
-    if [[ ! -w /home/jovyan ]]; then
-        _log "WARNING: no write access to /home/jovyan. Try starting the container with group 'users' (100), e.g. using \"--group-add=users\"."
+    if [[ ! -w ${HOME} ]]; then
+        _log "WARNING: no write access to ${HOME}. Try starting the container with group 'users' (100), e.g. using \"--group-add=users\"."
     fi
 
     # NOTE: This hook is run as the user we started the container as!

--- a/base-notebook/start.sh
+++ b/base-notebook/start.sh
@@ -53,6 +53,15 @@ unset_explicit_env_vars () {
     fi
 }
 
+get_user_id () {
+    id -u "${1}" 2>/dev/null
+    return 0
+}
+
+get_group_id () {
+    id -g "${1}" 2>/dev/null
+    return 0
+}
 
 # Default to starting bash if no command was specified
 if [ $# -eq 0 ]; then
@@ -204,8 +213,8 @@ else
         _log "WARNING: container must be started as root to grant sudo permissions!"
     fi
 
-    JOVYAN_UID="$(id -u jovyan 2>/dev/null)"  # The default UID for the jovyan user
-    JOVYAN_GID="$(id -g jovyan 2>/dev/null)"  # The default GID for the jovyan user
+    JOVYAN_UID="$(get_user_id jovyan)"  # The default UID for the jovyan user
+    JOVYAN_GID="$(get_group_id jovyan)"  # The default GID for the jovyan user
 
     # Attempt to ensure the user uid we currently run as has a named entry in
     # the /etc/passwd file, as it avoids software crashing on hard assumptions


### PR DESCRIPTION
Hi, I used to build my own docker image based on the `jupyter/base-notebook` image with a modified username (via `usermod ` command) previously. When I updated `base-notebook` to the latest version, I found that the jupyterlab failed to start without any error message.
I check the `start.sh` script, and I find `id -u jovyan 2>/dev/null` and `id -g jovyan 2>/dev/null` added in #1546 would return a non-zero value and then the `start.sh` would exit when `jovyan` user or `jovyan` group don't exist. So I define an additional function to call `id` command to avoid the main process geting a non-zero value.
In addition, I find there would be a warning message after I modify the $HOME environment variable. I find the code annotations describe checking the permission of the `$HOME` path, but the code uses a specified home path `/home/jovyan`. I don't know whether it is a mistake, and I also modify these code. Please correct me if my understanding is wrong.