### PR TITLE
Adding community docker stack : scraper-notebook

### DIFF
--- a/docs/using/selecting.md
+++ b/docs/using/selecting.md
@@ -227,6 +227,8 @@ See the [contributing guide](../contributing/stacks.md) for information about ho
 | [cgspatial]    | [![bb]][cgspatial_b]    | Major **geospatial** Python & R libraries on top of the `datascience-notebook` image                      |
 | [kotlin]       | [![bb]][kotlin_b]       | [**Kotlin** kernel for Jupyter/IPython][kotlin_kernel] on top of the `base-notebook` image                |
 | [transformers] | [![bb]][transformers_b] | [**Transformers**][transformers_lib] and NLP libraries such as `Tensorflow`, `Keras`, `Jax` and `PyTorch` |
+| [scraper]      | [![bb]][scraper_b]      | **Scraper** tools (`selenium`, `chromedriver`, `beatifulsoup4`, `requests`) on `minimal-notebook` image   |
+
 
 [bb]: https://static.mybinder.org/badge_logo.svg
 [csharp]: https://github.com/tlinnet/csharp-notebook
@@ -250,6 +252,9 @@ See the [contributing guide](../contributing/stacks.md) for information about ho
 [transformers]: https://github.com/ToluClassics/transformers_notebook
 [transformers_b]: https://mybinder.org/v2/gh/ToluClassics/transformers_notebook/main
 [transformers_lib]: https://huggingface.co/docs/transformers/index
+[scraper]: https://github.com/rgriffogoes/scraper-notebook
+[scraper_b]: https://mybinder.org/v2/gh/rgriffogoes/scraper-notebook/main
+
 
 ### GPU enabled notebooks
 

--- a/docs/using/selecting.md
+++ b/docs/using/selecting.md
@@ -229,7 +229,6 @@ See the [contributing guide](../contributing/stacks.md) for information about ho
 | [transformers] | [![bb]][transformers_b] | [**Transformers**][transformers_lib] and NLP libraries such as `Tensorflow`, `Keras`, `Jax` and `PyTorch` |
 | [scraper]      | [![bb]][scraper_b]      | **Scraper** tools (`selenium`, `chromedriver`, `beatifulsoup4`, `requests`) on `minimal-notebook` image   |
 
-
 [bb]: https://static.mybinder.org/badge_logo.svg
 [csharp]: https://github.com/tlinnet/csharp-notebook
 [csharp_b]: https://mybinder.org/v2/gh/tlinnet/csharp-notebook/master
@@ -254,7 +253,6 @@ See the [contributing guide](../contributing/stacks.md) for information about ho
 [transformers_lib]: https://huggingface.co/docs/transformers/index
 [scraper]: https://github.com/rgriffogoes/scraper-notebook
 [scraper_b]: https://mybinder.org/v2/gh/rgriffogoes/scraper-notebook/main
-
 
 ### GPU enabled notebooks
 


### PR DESCRIPTION
Updating documentation for selecting docker image to include new community stack **scraper-notebook**

Based on the `minimal-notebook`, this new new image comes with pre-installed python libs for web scraping (`requests`,`beautifulsoup4`, `selenium`) and google chrome + chrome driver to use as the web driver.

