### PR TITLE
Add healthcheck command to Dockerfile

### DIFF
--- a/base-notebook/Dockerfile
+++ b/base-notebook/Dockerfile
@@ -171,6 +171,9 @@ RUN sed -re "s/c.ServerApp/c.NotebookApp/g" \
     /etc/jupyter/jupyter_server_config.py > /etc/jupyter/jupyter_notebook_config.py && \
     fix-permissions /etc/jupyter/
 
+HEALTHCHECK  --interval=15s --timeout=3s \
+    CMD wget -O- --no-verbose --tries=1 http://localhost:8888/api || exit 1
+
 # Switch back to jovyan to avoid accidental container runs as root
 USER ${NB_UID}
 

--- a/base-notebook/Dockerfile
+++ b/base-notebook/Dockerfile
@@ -171,9 +171,10 @@ RUN sed -re "s/c.ServerApp/c.NotebookApp/g" \
     /etc/jupyter/jupyter_server_config.py > /etc/jupyter/jupyter_notebook_config.py && \
     fix-permissions /etc/jupyter/
 
+# HEALTHCHECK documentation: https://docs.docker.com/engine/reference/builder/#healthcheck
 # This healtcheck works well for `lab`, `notebook`, `nbclassic`, `server` and `retro` jupyter commands
 # https://github.com/jupyter/docker-stacks/issues/915#issuecomment-1068528799
-HEALTHCHECK  --interval=15s --timeout=3s \
+HEALTHCHECK  --interval=15s --timeout=3s --start-period=5s --retries=3 \
     CMD wget -O- --no-verbose --tries=1 http://localhost:8888/api || exit 1
 
 # Switch back to jovyan to avoid accidental container runs as root

--- a/base-notebook/Dockerfile
+++ b/base-notebook/Dockerfile
@@ -171,6 +171,8 @@ RUN sed -re "s/c.ServerApp/c.NotebookApp/g" \
     /etc/jupyter/jupyter_server_config.py > /etc/jupyter/jupyter_notebook_config.py && \
     fix-permissions /etc/jupyter/
 
+# This healtcheck works well for `lab`, `notebook`, `nbclassic`, `server` and `retro` jupyter commands
+# https://github.com/jupyter/docker-stacks/issues/915#issuecomment-1068528799
 HEALTHCHECK  --interval=15s --timeout=3s \
     CMD wget -O- --no-verbose --tries=1 http://localhost:8888/api || exit 1
 


### PR DESCRIPTION
Fix: https://github.com/jupyter/docker-stacks/issues/915

Some people would like to have HEALTCHECK working for their docker containers.
This is especially important to people using Docker Swarm, where the container might be "still working", but not actually responding, and so on.

Let's try to add this to the base image, actually.
If someone uses custom configuration, they can for sure do one of many things if a health check doesn't work for them:
- `HEALTHCHECK NONE`
- `HEALTHCHECK CMD custom-command
- `docker run --no-healthcheck`
- disable it in docker-compose

So, I think, we should be fine even for people who explicitly don't want this healthcheck.