### PR TITLE
Remove JUPYTER_ENABLE_LAB variable warning

### DIFF
--- a/base-notebook/start-notebook.sh
+++ b/base-notebook/start-notebook.sh
@@ -18,9 +18,5 @@ if [[ "${RESTARTABLE}" == "yes" ]]; then
     wrapper="run-one-constantly"
 fi
 
-if [[ -v JUPYTER_ENABLE_LAB ]]; then
-    echo "WARNING: JUPYTER_ENABLE_LAB is ignored, use DOCKER_STACKS_JUPYTER_CMD if you want to change the command used to start the server"
-fi
-
 # shellcheck disable=SC1091,SC2086
 exec /usr/local/bin/start.sh ${wrapper} jupyter ${DOCKER_STACKS_JUPYTER_CMD} ${NOTEBOOK_ARGS} "$@"

--- a/tests/base-notebook/test_start_container.py
+++ b/tests/base-notebook/test_start_container.py
@@ -15,12 +15,6 @@ LOGGER = logging.getLogger(__name__)
 @pytest.mark.parametrize(
     "env,expected_command,expected_start,expected_warnings",
     [
-        (
-            ["JUPYTER_ENABLE_LAB=yes"],
-            "jupyter lab",
-            True,
-            ["WARNING: JUPYTER_ENABLE_LAB is ignored"],
-        ),
         (None, "jupyter lab", True, []),
         (["DOCKER_STACKS_JUPYTER_CMD=lab"], "jupyter lab", True, []),
         (["RESTARTABLE=yes"], "run-one-constantly jupyter lab", True, []),


### PR DESCRIPTION
This warning was there for more than 2 months.
Let's remove it, because I think everyone who wanted to change something, already did it.