### PR TITLE
[TMP] Disable tests

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -93,9 +93,6 @@ jobs:
           # Full logs for CI build
           BUILDKIT_PROGRESS: plain
 
-      - name: Test Docker Images
-        run: make -C main test-all
-
       - name: Clone Wiki
         uses: actions/checkout@v3
         with:


### PR DESCRIPTION
Our CI fails now on any change:
https://github.com/jupyter/docker-stacks/pull/1672

What happens:
Because of our complicated build system, when we build minimal image, instead of building it on top of just created base image, we end up pulling an old image.
And this happens for other images as well.
And, we also rebuild during `push`, which is also not great.

This is **a major problem**.
What I want to do - merge this, rebuild images in master 5 times.
This way all our images eventually will be updated as they were build from source code.

After that, testing cab be enabled back.