### PR TITLE
Add --quiet to mamba info

### DIFF
--- a/tagging/manifests.py
+++ b/tagging/manifests.py
@@ -67,7 +67,7 @@ class CondaEnvironmentManifest(ManifestInterface):
                 "",
                 quoted_output(container, "python --version"),
                 "",
-                quoted_output(container, "mamba info"),
+                quoted_output(container, "mamba info --quiet"),
                 "",
                 quoted_output(container, "mamba list"),
             ]


### PR DESCRIPTION
This will reduce output we don't need, for example here: https://github.com/jupyter/docker-stacks/wiki/all-spark-notebook-068e3c5ddab0#python-packages