### PR TITLE
Fix HEALTHCHECK command for JupyterHub

### DIFF
--- a/base-notebook/Dockerfile
+++ b/base-notebook/Dockerfile
@@ -175,7 +175,7 @@ RUN sed -re "s/c.ServerApp/c.NotebookApp/g" \
 # This healtcheck works well for `lab`, `notebook`, `nbclassic`, `server` and `retro` jupyter commands
 # https://github.com/jupyter/docker-stacks/issues/915#issuecomment-1068528799
 HEALTHCHECK  --interval=15s --timeout=3s --start-period=5s --retries=3 \
-    CMD wget -O- --no-verbose --tries=1 http://localhost:8888/api || exit 1
+    CMD wget -O- --no-verbose --tries=1 http://localhost:8888${JUPYTERHUB_SERVICE_PREFIX:-/}api || exit 1
 
 # Switch back to jovyan to avoid accidental container runs as root
 USER ${NB_UID}


### PR DESCRIPTION
It seems that the HEALTHCHECK command accesses the wrong endpoint when running the image in JupyterHub.
Since JupyterHub adds a prefix (obtained by `JUPYTERHUB_SERVICE_PREFIX`) to the endpoint, I assume that adding this to the HEALTHCHECK command will allow HEALTHCHECK to work correctly with JupyterHub.

This PR may also fix the following: https://github.com/jupyter/docker-stacks/issues/915#issuecomment-1104230461