### PR TITLE
Adding list of groups to `${NB_USER}`

### DIFF
--- a/base-notebook/Dockerfile
+++ b/base-notebook/Dockerfile
@@ -11,6 +11,7 @@ LABEL maintainer="Jupyter Project <jupyter@googlegroups.com>"
 ARG NB_USER="jovyan"
 ARG NB_UID="1000"
 ARG NB_GID="100"
+ARG NB_UNPRIVILEGED_GROUPS=""
 
 # Fix: https://github.com/hadolint/hadolint/wiki/DL4006
 # Fix: https://github.com/koalaman/shellcheck/wiki/SC3014
@@ -54,6 +55,7 @@ ENV CONDA_DIR=/opt/conda \
     NB_USER="${NB_USER}" \
     NB_UID=${NB_UID} \
     NB_GID=${NB_GID} \
+    NB_UNPRIVILEGED_GROUPS=${NB_UNPRIVILEGED_GROUPS} \
     LC_ALL=en_US.UTF-8 \
     LANG=en_US.UTF-8 \
     LANGUAGE=en_US.UTF-8

--- a/docs/using/common.md
+++ b/docs/using/common.md
@@ -76,10 +76,8 @@ You do so by passing arguments to the `docker run` command.
   You **must** run the container with `--user root` for this option to take effect.
   (The startup script will `su ${NB_USER}` after adjusting the group IDs.)
   You can add groups to the `${NB_USER}` by setting `NB_UNPRIVILEGED_GROUPS` (e.g., `-e NB_UNPRIVILEGED_GROUPS='104(input),124(kvm),126'`).
-  
 - `-e NB_GROUP=<name>` - The name used for `${NB_GID}`, which defaults to `${NB_USER}`.
   This group name is only used if `${NB_GID}` is specified and completely optional: there is only cosmetic effect.
-  
 - `--user 5000 --group-add users` - Launches the container with a specific user ID and adds that user to the `users` group so that it can modify files in the default home directory and `/opt/conda`.
   You can use these arguments as alternatives to setting `${NB_UID}` and `${NB_GID}`.
 

--- a/docs/using/common.md
+++ b/docs/using/common.md
@@ -70,6 +70,13 @@ You do so by passing arguments to the `docker run` command.
   The user is added to supplemental group `users` (gid 100) to grant write access to the home directory and `/opt/conda`.
   If you override the user/group logic, ensure the user stays in the group `users` if you want them to be able to modify files in the image.
 
+- `-e NB_UNPRIVILEGED_GROUPS=<numeric gid>(<name>),<numeric gid-2>` - Instructs the startup script to add the `${NB_USER}` to additional groups `${NB_UNPRIVILEGED_GROUPS}`
+  (the new groups are added with a name of `<numeric gid>(<name>)` if it is defined. Otherwise, the group is named `g_${<numeric gid>}`).
+  This feature is useful when mounting host volumes with multiple specific group permissions.
+  You **must** run the container with `--user root` for this option to take effect.
+  (The startup script will `su ${NB_USER}` after adjusting the group IDs.)
+  You can add groups to the `${NB_USER}` by setting `NB_UNPRIVILEGED_GROUPS` (e.g., `-e NB_UNPRIVILEGED_GROUPS='104(input),124(kvm),126'`).
+  
 - `-e NB_GROUP=<name>` - The name used for `${NB_GID}`, which defaults to `${NB_USER}`.
   This group name is only used if `${NB_GID}` is specified and completely optional: there is only cosmetic effect.
 

--- a/docs/using/common.md
+++ b/docs/using/common.md
@@ -76,6 +76,7 @@ You do so by passing arguments to the `docker run` command.
   You **must** run the container with `--user root` for this option to take effect.
   (The startup script will `su ${NB_USER}` after adjusting the group IDs.)
   You can add groups to the `${NB_USER}` by setting `NB_UNPRIVILEGED_GROUPS` (e.g., `-e NB_UNPRIVILEGED_GROUPS='104(input),124(kvm),126'`).
+  
 - `-e NB_GROUP=<name>` - The name used for `${NB_GID}`, which defaults to `${NB_USER}`.
   This group name is only used if `${NB_GID}` is specified and completely optional: there is only cosmetic effect.
 

--- a/docs/using/common.md
+++ b/docs/using/common.md
@@ -76,7 +76,6 @@ You do so by passing arguments to the `docker run` command.
   You **must** run the container with `--user root` for this option to take effect.
   (The startup script will `su ${NB_USER}` after adjusting the group IDs.)
   You can add groups to the `${NB_USER}` by setting `NB_UNPRIVILEGED_GROUPS` (e.g., `-e NB_UNPRIVILEGED_GROUPS='104(input),124(kvm),126'`).
-  
 - `-e NB_GROUP=<name>` - The name used for `${NB_GID}`, which defaults to `${NB_USER}`.
   This group name is only used if `${NB_GID}` is specified and completely optional: there is only cosmetic effect.
 

--- a/docs/using/common.md
+++ b/docs/using/common.md
@@ -76,9 +76,10 @@ You do so by passing arguments to the `docker run` command.
   You **must** run the container with `--user root` for this option to take effect.
   (The startup script will `su ${NB_USER}` after adjusting the group IDs.)
   You can add groups to the `${NB_USER}` by setting `NB_UNPRIVILEGED_GROUPS` (e.g., `-e NB_UNPRIVILEGED_GROUPS='104(input),124(kvm),126'`).
+  
 - `-e NB_GROUP=<name>` - The name used for `${NB_GID}`, which defaults to `${NB_USER}`.
   This group name is only used if `${NB_GID}` is specified and completely optional: there is only cosmetic effect.
-
+  
 - `--user 5000 --group-add users` - Launches the container with a specific user ID and adds that user to the `users` group so that it can modify files in the default home directory and `/opt/conda`.
   You can use these arguments as alternatives to setting `${NB_UID}` and `${NB_GID}`.
 

--- a/tests/base-notebook/test_container_options.py
+++ b/tests/base-notebook/test_container_options.py
@@ -83,12 +83,11 @@ def test_gid_change(container: TrackedContainer) -> None:
 
 def test_additional_groups_change(container: TrackedContainer) -> None:
     """Container should add additional groups to the default user."""
-    nb_user_groups = "104(input),125(render),124(kvm),107(messagebus),450,150(test)"
     logs = container.run_and_wait(
         timeout=10,
         tty=True,
         user="root",
-        environment=[f"NB_UNPRIVILEGED_GROUPS={nb_user_groups}"],
+        environment=["NB_UNPRIVILEGED_GROUPS=104(input),125(render),124(kvm),107(messagebus),450,150(test)"],
         command=["start.sh", "id"],
     )
     assert (

--- a/tests/base-notebook/test_container_options.py
+++ b/tests/base-notebook/test_container_options.py
@@ -82,11 +82,12 @@ def test_gid_change(container: TrackedContainer) -> None:
 
 def test_groups_change(container: TrackedContainer) -> None:
     """Container should change the GID of the default user."""
+    nb_user_groups = "104(input),125(render),124(kvm),107(messagebus),450,150(test)"
     logs = container.run_and_wait(
         timeout=10,
         tty=True,
         user="root",
-        environment=["NB_GID=110", "NB_UNPRIVILEGED_GROUPS='104(input),125(render),124(kvm),107(messagebus),450,150(test)'"],
+        environment=["NB_GID=110", f"NB_UNPRIVILEGED_GROUPS={nb_user_groups}"],
         command=["start.sh", "id"],
     )
     assert "gid=110(jovyan)" in logs

--- a/tests/base-notebook/test_container_options.py
+++ b/tests/base-notebook/test_container_options.py
@@ -81,7 +81,7 @@ def test_gid_change(container: TrackedContainer) -> None:
     assert "groups=110(jovyan),100(users)" in logs
 
 
-def test_groups_change(container: TrackedContainer) -> None:
+def test_additional_groups_change(container: TrackedContainer) -> None:
     """Container should add additional groups to the default user."""
     nb_user_groups = "104(input),125(render),124(kvm),107(messagebus),450,150(test)"
     logs = container.run_and_wait(

--- a/tests/base-notebook/test_container_options.py
+++ b/tests/base-notebook/test_container_options.py
@@ -88,12 +88,11 @@ def test_groups_change(container: TrackedContainer) -> None:
         timeout=10,
         tty=True,
         user="root",
-        environment=["NB_GID=110", f"NB_UNPRIVILEGED_GROUPS={nb_user_groups}"],
+        environment=[f"NB_UNPRIVILEGED_GROUPS={nb_user_groups}"],
         command=["start.sh", "id"],
     )
-    assert "gid=110(jovyan)" in logs
     assert (
-        "groups=110(jovyan),100(users),104(input),107(messagebus),124(kvm),125(render),150(test),450(g_450)"
+        "groups=100(users),104(input),107(messagebus),124(kvm),125(render),150(test),450(g_450)"
         in logs
     )
 

--- a/tests/base-notebook/test_container_options.py
+++ b/tests/base-notebook/test_container_options.py
@@ -87,7 +87,9 @@ def test_additional_groups_change(container: TrackedContainer) -> None:
         timeout=10,
         tty=True,
         user="root",
-        environment=["NB_UNPRIVILEGED_GROUPS=104(input),125(render),124(kvm),107(messagebus),450,150(test)"],
+        environment=[
+            "NB_UNPRIVILEGED_GROUPS=104(input),125(render),124(kvm),107(messagebus),450,150(test)"
+        ],
         command=["start.sh", "id"],
     )
     assert (

--- a/tests/base-notebook/test_container_options.py
+++ b/tests/base-notebook/test_container_options.py
@@ -80,6 +80,17 @@ def test_gid_change(container: TrackedContainer) -> None:
     assert "gid=110(jovyan)" in logs
     assert "groups=110(jovyan),100(users)" in logs
 
+def test_groups_change(container: TrackedContainer) -> None:
+    """Container should change the GID of the default user."""
+    logs = container.run_and_wait(
+        timeout=10,
+        tty=True,
+        user="root",
+        environment=["NB_GID=110", "NB_UNPRIVILEGED_GROUPS='104(input),125(render),124(kvm),107(messagebus),450,150(test)'"],
+        command=["start.sh", "id"],
+    )
+    assert "gid=110(jovyan)" in logs
+    assert "groups=110(jovyan),100(users),104(input),107(messagebus),124(kvm),125(render),150(test),450(g_450)" in logs
 
 def test_nb_user_change(container: TrackedContainer) -> None:
     """Container should change the username (`NB_USER`) of the default user."""

--- a/tests/base-notebook/test_container_options.py
+++ b/tests/base-notebook/test_container_options.py
@@ -82,7 +82,7 @@ def test_gid_change(container: TrackedContainer) -> None:
 
 
 def test_groups_change(container: TrackedContainer) -> None:
-    """Container should change the GID of the default user."""
+    """Container should add additional groups to the default user."""
     nb_user_groups = "104(input),125(render),124(kvm),107(messagebus),450,150(test)"
     logs = container.run_and_wait(
         timeout=10,


### PR DESCRIPTION
## Describe your changes
A useful feature for adding a list of groups to `${NB_USER}` in the case of needing to read multiple volumes with different access rights. For instance, it is handy to add a user to groups given from ActiveDirectory.
## Issue ticket if applicable

<!-- Example - Fix: https://github.com/jupyter/docker-stacks/issues/0 -->

## Checklist (especially for first-time contributors)

- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests
- [x] I will try not to use force-push to make the review process easier for reviewers
- [ ] I have updated the documentation for significant changes

<!-- markdownlint-disable-file MD041 -->
