### PR TITLE
Update passwd function

### DIFF
--- a/docs/using/common.md
+++ b/docs/using/common.md
@@ -16,7 +16,7 @@ You can pass [Jupyter server options](https://jupyter-server.readthedocs.io/en/l
 
    ```bash
    docker run -it --rm -p 8888:8888 jupyter/base-notebook \
-       start-notebook.sh --NotebookApp.password='sha1:7cca89c48283:e3c1f9fbc06d1d2aa59555dfd5beed925e30dd2c'
+       start-notebook.sh --NotebookApp.password='argon2:$argon2id$v=19$m=10240,t=10,p=8$JdAN3fe9J45NvK/EPuGCvA$O/tbxglbwRpOFuBNTYrymAEH6370Q2z+eS1eF4GM6Do'
    ```
 
 2. To set the [base URL](https://jupyter-server.readthedocs.io/en/latest/operators/public-server.html#running-the-notebook-with-a-customized-url-prefix) of the notebook server, you can run the following:

--- a/docs/using/common.md
+++ b/docs/using/common.md
@@ -11,7 +11,7 @@ This page describes the options supported by the startup script and how to bypas
 You can pass [Jupyter server options](https://jupyter-server.readthedocs.io/en/latest/operators/public-server.html) to the `start-notebook.sh` script when launching the container.
 
 1. For example, to secure the Notebook server with a [custom password](https://jupyter-server.readthedocs.io/en/latest/operators/public-server.html#preparing-a-hashed-password)
-   hashed using `notebook.auth.security.passwd()` instead of the default token,
+   hashed using `jupyter_server.auth.security.passwd()` instead of the default token,
    you can run the following (this hash was generated for `my-password` password):
 
    ```bash

--- a/docs/using/common.md
+++ b/docs/using/common.md
@@ -10,7 +10,7 @@ This page describes the options supported by the startup script and how to bypas
 
 You can pass [Jupyter server options](https://jupyter-server.readthedocs.io/en/latest/operators/public-server.html) to the `start-notebook.sh` script when launching the container.
 
-1. For example, to secure the Notebook server with a custom password hashed using `IPython.lib.passwd()` instead of the default token,
+1. For example, to secure the Notebook server with a [custom password](https://jupyter-server.readthedocs.io/en/latest/operators/public-server.html#preparing-a-hashed-password) hashed using `notebook.auth.security.passwd()` instead of the default token,
    you can run the following (this hash was generated for `my-password` password):
 
    ```bash

--- a/docs/using/common.md
+++ b/docs/using/common.md
@@ -10,7 +10,8 @@ This page describes the options supported by the startup script and how to bypas
 
 You can pass [Jupyter server options](https://jupyter-server.readthedocs.io/en/latest/operators/public-server.html) to the `start-notebook.sh` script when launching the container.
 
-1. For example, to secure the Notebook server with a [custom password](https://jupyter-server.readthedocs.io/en/latest/operators/public-server.html#preparing-a-hashed-password) hashed using `notebook.auth.security.passwd()` instead of the default token,
+1. For example, to secure the Notebook server with a [custom password](https://jupyter-server.readthedocs.io/en/latest/operators/public-server.html#preparing-a-hashed-password) 
+hashed using `notebook.auth.security.passwd()` instead of the default token,
    you can run the following (this hash was generated for `my-password` password):
 
    ```bash

--- a/docs/using/common.md
+++ b/docs/using/common.md
@@ -10,8 +10,8 @@ This page describes the options supported by the startup script and how to bypas
 
 You can pass [Jupyter server options](https://jupyter-server.readthedocs.io/en/latest/operators/public-server.html) to the `start-notebook.sh` script when launching the container.
 
-1. For example, to secure the Notebook server with a [custom password](https://jupyter-server.readthedocs.io/en/latest/operators/public-server.html#preparing-a-hashed-password) 
-hashed using `notebook.auth.security.passwd()` instead of the default token,
+1. For example, to secure the Notebook server with a [custom password](https://jupyter-server.readthedocs.io/en/latest/operators/public-server.html#preparing-a-hashed-password)
+   hashed using `notebook.auth.security.passwd()` instead of the default token,
    you can run the following (this hash was generated for `my-password` password):
 
    ```bash


### PR DESCRIPTION
## Describe your changes

The use of `IPython.lib.passwd()` does not match with [Jupyter server documentation](https://jupyter-server.readthedocs.io/en/latest/operators/public-server.html#preparing-a-hashed-password) and may lead to confusion on how to import/use it.

## Checklist (especially for first-time contributors)

- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests
- [x] I will try not to use force-push to make the review process easier for reviewers
- [x] I have updated the documentation for significant changes

<!-- markdownlint-disable-file MD041 -->
