### PR TITLE
Improve performance of fix-permissions script

### DIFF
--- a/base-notebook/fix-permissions
+++ b/base-notebook/fix-permissions
@@ -23,13 +23,13 @@ for d in "$@"; do
             -group "${NB_GID}" \
             -a -perm -g+rwX \
         \) \
-        -exec chgrp "${NB_GID}" {} \; \
-        -exec chmod g+rwX {} \;
+        -exec chgrp "${NB_GID}" -- {} \+ \
+        -exec chmod g+rwX -- {} \+
     # setuid, setgid *on directories only*
     find "${d}" \
         \( \
             -type d \
             -a ! -perm -6000 \
         \) \
-        -exec chmod +6000 {} \;
+        -exec chmod +6000 -- {} \+
 done


### PR DESCRIPTION
## Describe your changes

Using the `-exec command {} +` (instead of `;`)  action of `find`, we can improve the performance of fix-permissions script significantly. The difference between the two is that the former (`+`) invokes a single process and passes all the files to it as arguments, whereas the latter (`;`) invokes one process per matched file resulting in thousands of `chmod` runs per build.

My benchmarks show about a 30 second improvement in steps that involve fix-permissions for the `build-all` target of `make`. More importantly for me, user defined Docker images, which use the fix-permissions script, will also show perf improvements.

## Issue ticket if applicable

n/a

## Checklist (especially for first-time contributors)

- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests
- [x] I will try not to use force-push to make the review process easier for reviewers
- [x] I have updated the documentation for significant changes

<!-- markdownlint-disable-file MD041 -->
