### PR TITLE
Build images with ubuntu-20.04 and python-3.7

### DIFF
--- a/base-notebook/Dockerfile
+++ b/base-notebook/Dockerfile
@@ -1,9 +1,9 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 
-# Ubuntu 22.04 (jammy)
-# https://hub.docker.com/_/ubuntu/tags?page=1&name=jammy
-ARG ROOT_CONTAINER=ubuntu:22.04
+# Ubuntu 20.04 (focal)
+# https://hub.docker.com/_/ubuntu/tags?page=1&name=focal
+ARG ROOT_CONTAINER=ubuntu:20.04
 
 FROM $ROOT_CONTAINER
 
@@ -85,7 +85,7 @@ RUN echo "auth requisite pam_deny.so" >> /etc/pam.d/su && \
 USER ${NB_UID}
 
 # Pin python version here, or set it to "default"
-ARG PYTHON_VERSION=3.10
+ARG PYTHON_VERSION=3.7
 
 # Setup work directory for backward-compatibility
 RUN mkdir "/home/${NB_USER}/work" && \

--- a/tests/base-notebook/test_python.py
+++ b/tests/base-notebook/test_python.py
@@ -5,7 +5,7 @@ import logging
 from tests.conftest import TrackedContainer
 
 LOGGER = logging.getLogger(__name__)
-EXPECTED_PYTHON_VERSION = "3.10"
+EXPECTED_PYTHON_VERSION = "3.7"
 
 
 def test_python_version(container: TrackedContainer) -> None:


### PR DESCRIPTION
## Describe your changes

I think that our build system works well and doesn't have any known bugs and it finally supports both `x86_64` and `aarch64` and multi-arch images for these platforms properly.
I also think, some users still want to use old images (not all people can switch to the new ubuntu or python version quickly).

So, I had an idea to rebuild the images in this order:
- First, ubuntu-20.04 with python 3.7, 3.8, 3.9, 3.10
- Then, ubuntu-22.04 with python 3.7, 3.8, 3.9, 3.10 as well

After this, people will be able to choose the old version(s) if they want to.
And tags will work correctly for these images as well.
*This doesn't mean, that we will support these versions in the future.*

After all these rebuilds, the latest versions will be the same as they currently are.
But in the process, they will change and people who don't use fixed tags might get an unexpected downgrade.
I expect these rebuilds to be done in less than 2 days.

Recently, I also introduced a new tag `python-major.minor` (without patch). It makes sense because usually, people update the patch versions easily.

## Issue ticket if applicable

<!-- Example - Fix: https://github.com/jupyter/docker-stacks/issues/0 -->

## Checklist (especially for first-time contributors)

- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests
- [ ] I will try not to use force-push to make the review process easier for reviewers
- [ ] I have updated the documentation for significant changes

<!-- markdownlint-disable-file MD041 -->
