### PR TITLE
generate-config prompts if a config exists, so remove first

### DIFF
--- a/base-notebook/Dockerfile
+++ b/base-notebook/Dockerfile
@@ -39,6 +39,7 @@ RUN mamba install --quiet --yes \
     'notebook' \
     'jupyterhub' \
     'jupyterlab' && \
+    rm -f "/home/${NB_USER}/.jupyter/jupyter_notebook_config.py" && \
     jupyter notebook --generate-config && \
     mamba clean --all -f -y && \
     npm cache clean --force && \


### PR DESCRIPTION
## Describe your changes

When I'm building with an ubuntu:20.04 base, the base-notebook build fails on `jupyter notebook --generate-config`, it appears there is an existing file and it prompts whether to overwrite it which halts the build. 

Simply removing the existing file before re-generating the config fixed our issue.
Using the "-f" flag prevents prompting or breaking things if the file doesn't already exist.

## Checklist (especially for first-time contributors)

- [x] I have performed a self-review of my code
- [ ] ~~If it is a core feature, I have added thorough tests~~
- [x] I will try not to use force-push to make the review process easier for reviewers
- [ ] ~~I have updated the documentation for significant changes~~

<!-- markdownlint-disable-file MD041 -->
