### PR TITLE
add recipe for installing ijavascript kernel

### DIFF
--- a/docs/using/recipes.md
+++ b/docs/using/recipes.md
@@ -569,7 +569,6 @@ docker run -it --rm \
     jupyter/minimal-notebook
 ```
 
-
 ## Add ijavascript kernel to container
 
 The example below is a Dockerfile to install the ijavascript kernel.

--- a/docs/using/recipes.md
+++ b/docs/using/recipes.md
@@ -577,11 +577,7 @@ The example below is a Dockerfile to install the [ijavascript kernel](https://gi
 # use one of the jupyter docker stacks images
 FROM jupyter/scipy-notebook:85f615d5cafa
 
-# configure where npm installs global packages & install ijavascript
-RUN npm config set prefix "${HOME}"
+# install ijavascript
 RUN npm install -g ijavascript
-RUN "${HOME}"/bin/ijsinstall
-
-# add the bin folder created by npm in $HOME to our $PATH
-ENV PATH "${HOME}/bin:${PATH}"
+RUN ijsinstall
 ```

--- a/docs/using/recipes.md
+++ b/docs/using/recipes.md
@@ -568,3 +568,21 @@ docker run -it --rm \
     -v /tmp/.X11-unix:/tmp/.X11-unix \
     jupyter/minimal-notebook
 ```
+
+
+## Add ijavascript kernel to container
+
+The example below is a Dockerfile to install the ijavascript kernel.
+
+```dockerfile
+# use one of the jupyter docker stacks images
+FROM jupyter/scipy-notebook:85f615d5cafa
+
+# configure where npm installs global packages & install ijavascript
+RUN npm config set prefix $HOME
+RUN npm install -g ijavascript
+RUN $HOME/bin/ijsinstall
+
+# add the bin folder created by npm in $HOME to our $PATH
+ENV PATH $HOME/bin:$PATH
+```

--- a/docs/using/recipes.md
+++ b/docs/using/recipes.md
@@ -578,10 +578,10 @@ The example below is a Dockerfile to install the ijavascript kernel.
 FROM jupyter/scipy-notebook:85f615d5cafa
 
 # configure where npm installs global packages & install ijavascript
-RUN npm config set prefix $HOME
+RUN npm config set prefix "${HOME}"
 RUN npm install -g ijavascript
-RUN $HOME/bin/ijsinstall
+RUN "${HOME}"/bin/ijsinstall
 
 # add the bin folder created by npm in $HOME to our $PATH
-ENV PATH $HOME/bin:$PATH
+ENV PATH "${HOME}/bin:${PATH}"
 ```

--- a/docs/using/recipes.md
+++ b/docs/using/recipes.md
@@ -571,7 +571,7 @@ docker run -it --rm \
 
 ## Add ijavascript kernel to container
 
-The example below is a Dockerfile to install the ijavascript kernel.
+The example below is a Dockerfile to install the [ijavascript kernel](https://github.com/n-riesco/ijavascript).
 
 ```dockerfile
 # use one of the jupyter docker stacks images


### PR DESCRIPTION
## Describe your changes
Add a recipe to the recipes section of the docs. This recipe is a simple `Dockerfile` that installs a working kernel for ijavascript. This allows node to be used in jupyter.

## Issue ticket if applicable

<!-- Example - Fix: https://github.com/jupyter/docker-stacks/issues/0 -->

## Checklist (especially for first-time contributors)

- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests
- [x] I will try not to use force-push to make the review process easier for reviewers
- [x] I have updated the documentation for significant changes

<!-- markdownlint-disable-file MD041 -->
