### PR TITLE
Parameterize healthcheck by internal port

### DIFF
--- a/base-notebook/Dockerfile
+++ b/base-notebook/Dockerfile
@@ -47,7 +47,8 @@ RUN mamba install --quiet --yes \
     fix-permissions "${CONDA_DIR}" && \
     fix-permissions "/home/${NB_USER}"
 
-EXPOSE 8888
+ENV JUPYTER_PORT=8888
+EXPOSE $JUPYTER_PORT
 
 # Configure container startup
 CMD ["start-notebook.sh"]
@@ -70,7 +71,7 @@ RUN sed -re "s/c.ServerApp/c.NotebookApp/g" \
 # https://github.com/jupyter/docker-stacks/issues/915#issuecomment-1068528799
 HEALTHCHECK  --interval=5s --timeout=3s --start-period=5s --retries=3 \
     CMD wget -O- --no-verbose --tries=1 --no-check-certificate \
-    http${GEN_CERT:+s}://localhost:8888${JUPYTERHUB_SERVICE_PREFIX:-/}api || exit 1
+    http${GEN_CERT:+s}://localhost:${JUPYTER_PORT}${JUPYTERHUB_SERVICE_PREFIX:-/}api || exit 1
 
 # Switch back to jovyan to avoid accidental container runs as root
 USER ${NB_UID}

--- a/base-notebook/jupyter_server_config.py
+++ b/base-notebook/jupyter_server_config.py
@@ -9,7 +9,6 @@ from jupyter_core.paths import jupyter_data_dir
 
 c = get_config()  # noqa: F821
 c.ServerApp.ip = "0.0.0.0"
-c.ServerApp.port = 8888
 c.ServerApp.open_browser = False
 
 # to output both image/svg+xml and application/pdf plot formats in the notebook file

--- a/docs/using/common.md
+++ b/docs/using/common.md
@@ -22,9 +22,12 @@ You can pass [Jupyter server options](https://jupyter-server.readthedocs.io/en/l
 2. To set the [base URL](https://jupyter-server.readthedocs.io/en/latest/operators/public-server.html#running-the-notebook-with-a-customized-url-prefix) of the notebook server, you can run the following:
 
    ```bash
-   docker run  -it --rm -p 8888:8888 jupyter/base-notebook \
+   docker run  -it --rm -p 8888:8888 --no-healthcheck jupyter/base-notebook \
        start-notebook.sh --NotebookApp.base_url=/customized/url/prefix/
    ```
+Note: We pass the `--no-healthcheck` parameter when setting a custom base_url for the Jupyter server, because our current implementation
+for doing healthcheck assumes the base_url to be the default `/`. Without using this parameter, the container may run but its state
+will be "unhealthy". Alternatively, you can [use your own command for healthcheck](https://docs.docker.com/engine/reference/run/#healthcheck) using the `--health-cmd` parameter.
 
 ## Docker Options
 
@@ -123,6 +126,7 @@ You do so by passing arguments to the `docker run` command.
   The variables are unset after the hooks have been executed but before the command provided to the startup script runs.
 - `-e NOTEBOOK_ARGS="--log-level='DEBUG' --dev-mode"` - Adds custom options to add to `jupyter` commands.
   This way, the user could use any option supported by `jupyter` subcommand.
+- `-e JUPYTER_PORT=8117` - Change the port that Jupyter is using to the value of the `$JUPYTER_PORT` environment variable. This maybe useful if you run multiple instances of Jupyter in swarm mode and want to use different port for each instance.
 
 ## Startup Hooks
 

--- a/docs/using/common.md
+++ b/docs/using/common.md
@@ -129,7 +129,8 @@ You do so by passing arguments to the `docker run` command.
   The variables are unset after the hooks have been executed but before the command provided to the startup script runs.
 - `-e NOTEBOOK_ARGS="--log-level='DEBUG' --dev-mode"` - Adds custom options to add to `jupyter` commands.
   This way, the user could use any option supported by `jupyter` subcommand.
-- `-e JUPYTER_PORT=8117` - Change the port that Jupyter is using to the value of the `$JUPYTER_PORT` environment variable. This maybe useful if you run multiple instances of Jupyter in swarm mode and want to use different port for each instance.
+- `-e JUPYTER_PORT=8117` - Changes the port in the container that Jupyter is using to the value of the `${JUPYTER_PORT}` environment variable.
+  This may be useful if you run multiple instances of Jupyter in swarm mode and want to use a different port for each instance.
 
 ## Startup Hooks
 

--- a/docs/using/common.md
+++ b/docs/using/common.md
@@ -26,9 +26,11 @@ You can pass [Jupyter server options](https://jupyter-server.readthedocs.io/en/l
        start-notebook.sh --NotebookApp.base_url=/customized/url/prefix/
    ```
 
-   Note: We pass the `--no-healthcheck` parameter when setting a custom base_url for the Jupyter server, because our current implementation
-   for doing healthcheck assumes the base_url to be the default `/`. Without using this parameter, the container may run but its state
-   will be "unhealthy". Alternatively, you can [use your own command for healthcheck](https://docs.docker.com/engine/reference/run/#healthcheck) using the `--health-cmd` parameter.
+   Note: We pass the `--no-healthcheck` parameter when setting a custom base_url for the Jupyter server,
+   because our current implementation for doing healthcheck assumes the base_url to be the default `/`.
+   Without using this parameter, the container may run but its state will be "unhealthy".
+   Alternatively, you can [use your own command for healthcheck](https://docs.docker.com/engine/reference/run/#healthcheck)
+   using the `--health-cmd` parameter.
 
 ## Docker Options
 

--- a/docs/using/common.md
+++ b/docs/using/common.md
@@ -26,9 +26,9 @@ You can pass [Jupyter server options](https://jupyter-server.readthedocs.io/en/l
        start-notebook.sh --NotebookApp.base_url=/customized/url/prefix/
    ```
 
-   Note: We pass the `--no-healthcheck` parameter when setting a custom base_url for the Jupyter server,
-   because our current implementation for doing healthcheck assumes the base_url to be the default `/`.
-   Without using this parameter, the container may run but its state will be "unhealthy".
+   Note: We pass the `--no-healthcheck` parameter when setting a custom `base_url` for the Jupyter server,
+   because our current implementation for doing healthcheck assumes the `base_url` to be `/` (the default).
+   Without using this parameter, the container may run, but it's state will be "unhealthy".
    Alternatively, you can [use your own command for healthcheck](https://docs.docker.com/engine/reference/run/#healthcheck)
    using the `--health-cmd` parameter.
 

--- a/docs/using/common.md
+++ b/docs/using/common.md
@@ -25,9 +25,10 @@ You can pass [Jupyter server options](https://jupyter-server.readthedocs.io/en/l
    docker run  -it --rm -p 8888:8888 --no-healthcheck jupyter/base-notebook \
        start-notebook.sh --NotebookApp.base_url=/customized/url/prefix/
    ```
-Note: We pass the `--no-healthcheck` parameter when setting a custom base_url for the Jupyter server, because our current implementation
-for doing healthcheck assumes the base_url to be the default `/`. Without using this parameter, the container may run but its state
-will be "unhealthy". Alternatively, you can [use your own command for healthcheck](https://docs.docker.com/engine/reference/run/#healthcheck) using the `--health-cmd` parameter.
+
+   Note: We pass the `--no-healthcheck` parameter when setting a custom base_url for the Jupyter server, because our current implementation
+   for doing healthcheck assumes the base_url to be the default `/`. Without using this parameter, the container may run but its state
+   will be "unhealthy". Alternatively, you can [use your own command for healthcheck](https://docs.docker.com/engine/reference/run/#healthcheck) using the `--health-cmd` parameter.
 
 ## Docker Options
 

--- a/tests/base-notebook/test_container_options.py
+++ b/tests/base-notebook/test_container_options.py
@@ -86,8 +86,7 @@ def test_unsigned_ssl(
         None,
         {"DOCKER_STACKS_JUPYTER_CMD": "notebook"},
         {"JUPYTER_PORT": 8171},
-        {"JUPYTER_PORT": 8117,
-         "DOCKER_STACKS_JUPYTER_CMD": "notebook"},
+        {"JUPYTER_PORT": 8117, "DOCKER_STACKS_JUPYTER_CMD": "notebook"},
     ],
 )
 def test_custom_internal_port(
@@ -96,7 +95,9 @@ def test_custom_internal_port(
     """Container should be accessible from the host
     when using custom internal port"""
     host_port = find_free_port()
-    internal_port = env["JUPYTER_PORT"] if (env and ("JUPYTER_PORT" in env.keys())) else 8888
+    internal_port = (
+        env["JUPYTER_PORT"] if (env and ("JUPYTER_PORT" in env.keys())) else 8888
+    )
     running_container = container.run_detached(
         command=["start-notebook.sh", "--NotebookApp.token=''"],
         environment=env,

--- a/tests/base-notebook/test_container_options.py
+++ b/tests/base-notebook/test_container_options.py
@@ -80,11 +80,13 @@ def test_unsigned_ssl(
     assert not warnings
 
 
-def test_custom_internal_port(container: TrackedContainer, http_client: requests.Session) -> None:
+def test_custom_internal_port(
+    container: TrackedContainer, http_client: requests.Session
+) -> None:
     """Container should be accessible from the host
     when using custom internal port"""
     host_port = find_free_port()
-    internal_port=8117
+    internal_port = 8117
     running_container = container.run_detached(
         command=["start-notebook.sh", "--NotebookApp.token=''"],
         environment={"JUPYTER_PORT", internal_port},

--- a/tests/base-notebook/test_container_options.py
+++ b/tests/base-notebook/test_container_options.py
@@ -83,21 +83,21 @@ def test_unsigned_ssl(
 @pytest.mark.parametrize(
     "env",
     [
-        None,
+        {},
         {"DOCKER_STACKS_JUPYTER_CMD": "notebook"},
         {"JUPYTER_PORT": 8171},
         {"JUPYTER_PORT": 8117, "DOCKER_STACKS_JUPYTER_CMD": "notebook"},
     ],
 )
 def test_custom_internal_port(
-    container: TrackedContainer, http_client: requests.Session
+    container: TrackedContainer,
+    http_client: requests.Session,
+    env: dict[str, str],
 ) -> None:
     """Container should be accessible from the host
     when using custom internal port"""
     host_port = find_free_port()
-    internal_port = (
-        env["JUPYTER_PORT"] if (env and ("JUPYTER_PORT" in env.keys())) else 8888
-    )
+    internal_port = env.get("JUPYTER_PORT", 8888)
     running_container = container.run_detached(
         command=["start-notebook.sh", "--NotebookApp.token=''"],
         environment=env,

--- a/tests/base-notebook/test_container_options.py
+++ b/tests/base-notebook/test_container_options.py
@@ -80,16 +80,26 @@ def test_unsigned_ssl(
     assert not warnings
 
 
+@pytest.mark.parametrize(
+    "env",
+    [
+        None,
+        {"DOCKER_STACKS_JUPYTER_CMD": "notebook"},
+        {"JUPYTER_PORT": 8171},
+        {"JUPYTER_PORT": 8117,
+         "DOCKER_STACKS_JUPYTER_CMD": "notebook"},
+    ],
+)
 def test_custom_internal_port(
     container: TrackedContainer, http_client: requests.Session
 ) -> None:
     """Container should be accessible from the host
     when using custom internal port"""
     host_port = find_free_port()
-    internal_port = 8117
+    internal_port = env["JUPYTER_PORT"] if (env and ("JUPYTER_PORT" in env.keys())) else 8888
     running_container = container.run_detached(
         command=["start-notebook.sh", "--NotebookApp.token=''"],
-        environment={"JUPYTER_PORT", internal_port},
+        environment=env,
         ports={internal_port: host_port},
     )
     resp = http_client.get(f"http://localhost:{host_port}")

--- a/tests/base-notebook/test_container_options.py
+++ b/tests/base-notebook/test_container_options.py
@@ -84,9 +84,13 @@ def test_unsigned_ssl(
     "env",
     [
         {},
-        {"DOCKER_STACKS_JUPYTER_CMD": "notebook"},
-        {"JUPYTER_PORT": 8171},
-        {"JUPYTER_PORT": 8117, "DOCKER_STACKS_JUPYTER_CMD": "notebook"},
+        {"JUPYTER_PORT": 1234, "DOCKER_STACKS_JUPYTER_CMD": "lab"},
+        {"JUPYTER_PORT": 2345, "DOCKER_STACKS_JUPYTER_CMD": "notebook"},
+        {"JUPYTER_PORT": 3456, "DOCKER_STACKS_JUPYTER_CMD": "server"},
+        {"JUPYTER_PORT": 4567, "DOCKER_STACKS_JUPYTER_CMD": "nbclassic"},
+        {"JUPYTER_PORT": 5678, "RESTARTABLE": "yes"},
+        {"JUPYTER_PORT": 6789},
+        {"JUPYTER_PORT": 7890, "DOCKER_STACKS_JUPYTER_CMD": "notebook"},
     ],
 )
 def test_custom_internal_port(

--- a/tests/base-notebook/test_container_options.py
+++ b/tests/base-notebook/test_container_options.py
@@ -78,3 +78,22 @@ def test_unsigned_ssl(
     assert "ERROR" not in logs
     warnings = TrackedContainer.get_warnings(logs)
     assert not warnings
+
+
+def test_custom_internal_port(container: TrackedContainer, http_client: requests.Session) -> None:
+    """Container should be accessible from the host
+    when using custom internal port"""
+    host_port = find_free_port()
+    internal_port=8117
+    running_container = container.run_detached(
+        command=["start-notebook.sh", "--NotebookApp.token=''"],
+        environment={"JUPYTER_PORT", internal_port},
+        ports={internal_port: host_port},
+    )
+    resp = http_client.get(f"http://localhost:{host_port}")
+    resp.raise_for_status()
+    logs = running_container.logs().decode("utf-8")
+    LOGGER.debug(logs)
+    assert "ERROR" not in logs
+    warnings = TrackedContainer.get_warnings(logs)
+    assert not warnings

--- a/tests/base-notebook/test_healthcheck.py
+++ b/tests/base-notebook/test_healthcheck.py
@@ -21,6 +21,8 @@ LOGGER = logging.getLogger(__name__)
         ["DOCKER_STACKS_JUPYTER_CMD=notebook"],
         ["DOCKER_STACKS_JUPYTER_CMD=server"],
         ["DOCKER_STACKS_JUPYTER_CMD=nbclassic"],
+        ["JUPYTER_PORT=8117"],
+        ["DOCKER_STACKS_JUPYTER_CMD=notebook","JUPYTER_PORT=8117"],
     ],
 )
 def test_health(container: TrackedContainer, env: Optional[list[str]]) -> None:

--- a/tests/base-notebook/test_healthcheck.py
+++ b/tests/base-notebook/test_healthcheck.py
@@ -17,12 +17,12 @@ LOGGER = logging.getLogger(__name__)
     [
         None,
         ["DOCKER_STACKS_JUPYTER_CMD=lab"],
-        ["RESTARTABLE=yes"],
         ["DOCKER_STACKS_JUPYTER_CMD=notebook"],
         ["DOCKER_STACKS_JUPYTER_CMD=server"],
         ["DOCKER_STACKS_JUPYTER_CMD=nbclassic"],
-        ["JUPYTER_PORT=8117"],
-        ["DOCKER_STACKS_JUPYTER_CMD=notebook", "JUPYTER_PORT=8117"],
+        ["RESTARTABLE=yes"],
+        ["JUPYTER_PORT=8171"],
+        ["JUPYTER_PORT=8117", "DOCKER_STACKS_JUPYTER_CMD=notebook"],
     ],
 )
 def test_health(container: TrackedContainer, env: Optional[list[str]]) -> None:

--- a/tests/base-notebook/test_healthcheck.py
+++ b/tests/base-notebook/test_healthcheck.py
@@ -22,7 +22,7 @@ LOGGER = logging.getLogger(__name__)
         ["DOCKER_STACKS_JUPYTER_CMD=server"],
         ["DOCKER_STACKS_JUPYTER_CMD=nbclassic"],
         ["JUPYTER_PORT=8117"],
-        ["DOCKER_STACKS_JUPYTER_CMD=notebook","JUPYTER_PORT=8117"],
+        ["DOCKER_STACKS_JUPYTER_CMD=notebook", "JUPYTER_PORT=8117"],
     ],
 )
 def test_health(container: TrackedContainer, env: Optional[list[str]]) -> None:


### PR DESCRIPTION
## Describe your changes

Opening PR intended to close #1817 

- [x] Let's remove port setting in config.
- [x] Add JUPYTER_PORT with default value 8888 to the root file
- [x] Add a test which changes the internal port
- [x] Fix the health check command to use this env variable
- [x] Add a health check test (both using the default port and not using it).
- [x] Document health check behaviour (including https://github.com/jupyter/docker-stacks/issues/1709)

## Issue ticket if applicable

Fix #1817 

## Checklist (especially for first-time contributors)

- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests
- [x] I will try not to use force-push to make the review process easier for reviewers
- [ ] I have updated the documentation for significant changes

<!-- markdownlint-disable-file MD041 -->
