### PR TITLE
Healthcheck url from json

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,7 +21,7 @@ repos:
 
   # Automatically sort python imports
   - repo: https://github.com/pycqa/isort
-    rev: 5.11.4
+    rev: 5.12.0
     hooks:
       - id: isort
         args: [--profile, black]

--- a/base-notebook/Dockerfile
+++ b/base-notebook/Dockerfile
@@ -56,7 +56,7 @@ CMD ["start-notebook.sh"]
 # Copy local files as late as possible to avoid cache busting
 COPY start-notebook.sh start-singleuser.sh /usr/local/bin/
 # Currently need to have both jupyter_notebook_config and jupyter_server_config to support classic and lab
-COPY jupyter_server_config.py /etc/jupyter/
+COPY jupyter_server_config.py docker_healthcheck.py /etc/jupyter/
 
 # Fix permissions on /etc/jupyter as root
 USER root
@@ -70,10 +70,7 @@ RUN sed -re "s/c.ServerApp/c.NotebookApp/g" \
 # This healtcheck works well for `lab`, `notebook`, `nbclassic`, `server` and `retro` jupyter commands
 # https://github.com/jupyter/docker-stacks/issues/915#issuecomment-1068528799
 HEALTHCHECK  --interval=5s --timeout=3s --start-period=5s --retries=3 \
-    CMD bash -c 'set -o pipefail; \
-    (cat /home/"${NB_USER}"/.local/share/jupyter/runtime/*.json | \
-    python -c '\''import sys, json; print(json.loads(sys.stdin.read())["url"]+"api");'\'' | \
-    wget -i - -O- --no-verbose --tries=1 --no-check-certificate) || exit 1'
+    CMD python /etc/jupyter/docker_healthcheck.py || exit 1
 
 # Switch back to jovyan to avoid accidental container runs as root
 USER ${NB_UID}

--- a/base-notebook/Dockerfile
+++ b/base-notebook/Dockerfile
@@ -70,9 +70,10 @@ RUN sed -re "s/c.ServerApp/c.NotebookApp/g" \
 # This healtcheck works well for `lab`, `notebook`, `nbclassic`, `server` and `retro` jupyter commands
 # https://github.com/jupyter/docker-stacks/issues/915#issuecomment-1068528799
 HEALTHCHECK  --interval=5s --timeout=3s --start-period=5s --retries=3 \
-    CMD cat /home/"${NB_USER}"/.local/share/jupyter/runtime/*.json | \
-    python -c 'import sys, json; print(json.loads(sys.stdin.read())["url"]+"api");' | \
-    wget -i - -O- --no-verbose --tries=1 --no-check-certificate || exit 1
+    CMD bash -c 'set -o pipefail; \
+    (cat /home/"${NB_USER}"/.local/share/jupyter/runtime/*.json | \
+    python -c '\''import sys, json; print(json.loads(sys.stdin.read())["url"]+"api");'\'' | \
+    wget -i - -O- --no-verbose --tries=1 --no-check-certificate) || exit 1'
 
 # Switch back to jovyan to avoid accidental container runs as root
 USER ${NB_UID}

--- a/base-notebook/Dockerfile
+++ b/base-notebook/Dockerfile
@@ -70,7 +70,7 @@ RUN sed -re "s/c.ServerApp/c.NotebookApp/g" \
 # This healtcheck works well for `lab`, `notebook`, `nbclassic`, `server` and `retro` jupyter commands
 # https://github.com/jupyter/docker-stacks/issues/915#issuecomment-1068528799
 HEALTHCHECK  --interval=5s --timeout=3s --start-period=5s --retries=3 \
-    CMD cat /home/${NB_USER}/.local/share/jupyter/runtime/*.json | \
+    CMD cat /home/"${NB_USER}"/.local/share/jupyter/runtime/*.json | \
     python -c 'import sys, json; print(json.loads(sys.stdin.read())["url"]+"api");' | \
     wget -i - -O- --no-verbose --tries=1 --no-check-certificate || exit 1
 

--- a/base-notebook/Dockerfile
+++ b/base-notebook/Dockerfile
@@ -70,8 +70,9 @@ RUN sed -re "s/c.ServerApp/c.NotebookApp/g" \
 # This healtcheck works well for `lab`, `notebook`, `nbclassic`, `server` and `retro` jupyter commands
 # https://github.com/jupyter/docker-stacks/issues/915#issuecomment-1068528799
 HEALTHCHECK  --interval=5s --timeout=3s --start-period=5s --retries=3 \
-    CMD wget -O- --no-verbose --tries=1 --no-check-certificate \
-    http${GEN_CERT:+s}://localhost:${JUPYTER_PORT}${JUPYTERHUB_SERVICE_PREFIX:-/}api || exit 1
+    CMD cat /home/${NB_USER}/.local/share/jupyter/runtime/*.json | \
+    python -c 'import sys, json; print(json.loads(sys.stdin.read())["url"]+"api");' | \
+    wget -i - -O- --no-verbose --tries=1 --no-check-certificate || exit 1
 
 # Switch back to jovyan to avoid accidental container runs as root
 USER ${NB_UID}

--- a/base-notebook/docker_healthcheck.py
+++ b/base-notebook/docker_healthcheck.py
@@ -1,0 +1,18 @@
+import json
+import os
+
+import requests
+
+# A number of operations below delibrately don't check for possible errors
+# As this is a healthcheck, it should succeed or raise an exception on error
+
+runtime_dir = "/home/" + os.environ["NB_USER"] + "/.local/share/jupyter/runtime/"
+file_list = os.listdir(runtime_dir)
+json_file = [s for s in file_list if s.endswith(".json")]
+
+url = json.load(open(runtime_dir + json_file[0]))["url"]
+url = url + "api"
+
+r = requests.get(url)
+r.raise_for_status()
+print(r.content)

--- a/base-notebook/docker_healthcheck.py
+++ b/base-notebook/docker_healthcheck.py
@@ -13,6 +13,6 @@ json_file = [s for s in file_list if s.endswith(".json")]
 url = json.load(open(runtime_dir + json_file[0]))["url"]
 url = url + "api"
 
-r = requests.get(url)
+r = requests.get(url, verify=False)  # request without SSL verification
 r.raise_for_status()
 print(r.content)

--- a/tests/base-notebook/test_healthcheck.py
+++ b/tests/base-notebook/test_healthcheck.py
@@ -66,6 +66,5 @@ def test_health(
         time_spent += wait_time
         if get_health(running_container) == "healthy":
             return
-    raise RuntimeError("container is still unhealthy")
 
     assert get_health(running_container) == "healthy"

--- a/tests/base-notebook/test_healthcheck.py
+++ b/tests/base-notebook/test_healthcheck.py
@@ -13,22 +13,48 @@ LOGGER = logging.getLogger(__name__)
 
 
 @pytest.mark.parametrize(
-    "env",
+    "env,cmd,workdir",
     [
-        None,
-        ["DOCKER_STACKS_JUPYTER_CMD=lab"],
-        ["DOCKER_STACKS_JUPYTER_CMD=notebook"],
-        ["DOCKER_STACKS_JUPYTER_CMD=server"],
-        ["DOCKER_STACKS_JUPYTER_CMD=nbclassic"],
-        ["RESTARTABLE=yes"],
-        ["JUPYTER_PORT=8171"],
-        ["JUPYTER_PORT=8117", "DOCKER_STACKS_JUPYTER_CMD=notebook"],
+        (None, None, None),
+        (["DOCKER_STACKS_JUPYTER_CMD=lab"], None, None),
+        (["DOCKER_STACKS_JUPYTER_CMD=notebook"], None, None),
+        (["DOCKER_STACKS_JUPYTER_CMD=server"], None, None),
+        (["DOCKER_STACKS_JUPYTER_CMD=nbclassic"], None, None),
+        (["RESTARTABLE=yes"], None, None),
+        (["JUPYTER_PORT=8171"], None, None),
+        (["JUPYTER_PORT=8117", "DOCKER_STACKS_JUPYTER_CMD=notebook"], None, None),
+        (None, ["start-notebook.sh", "--NotebookApp.base_url=/test"], None),
+        (None, ["start-notebook.sh", "--NotebookApp.base_url=/test/"], None),
+        (["GEN_CERT=1"], ["start-notebook.sh", "--NotebookApp.base_url=/test"], None),
+        (
+            ["GEN_CERT=1", "JUPYTER_PORT=7891"],
+            ["start-notebook.sh", "--NotebookApp.base_url=/test"],
+            None,
+        ),
+        (["NB_USER=testuser", "CHOWN_HOME=1"], None, "/home/testuser"),
+        (
+            ["NB_USER=testuser", "CHOWN_HOME=1"],
+            ["start-notebook.sh", "--NotebookApp.base_url=/test"],
+            "/home/testuser",
+        ),
+        (
+            ["NB_USER=testuser", "CHOWN_HOME=1", "JUPYTER_PORT=8123"],
+            ["start-notebook.sh", "--NotebookApp.base_url=/test"],
+            "/home/testuser",
+        ),
     ],
 )
-def test_health(container: TrackedContainer, env: Optional[list[str]]) -> None:
+def test_health(
+    container: TrackedContainer,
+    env: Optional[list[str]],
+    cmd: Optional[list[str]],
+    workdir: Optional[str],
+) -> None:
     running_container = container.run_detached(
         tty=True,
         environment=env,
+        command=cmd,
+        working_dir=workdir,
     )
     # sleeping some time to let the server start
     time.sleep(15)

--- a/tests/base-notebook/test_healthcheck.py
+++ b/tests/base-notebook/test_healthcheck.py
@@ -13,34 +13,31 @@ LOGGER = logging.getLogger(__name__)
 
 
 @pytest.mark.parametrize(
-    "env,cmd,workdir",
+    "env,cmd",
     [
-        (None, None, None),
-        (["DOCKER_STACKS_JUPYTER_CMD=lab"], None, None),
-        (["DOCKER_STACKS_JUPYTER_CMD=notebook"], None, None),
-        (["DOCKER_STACKS_JUPYTER_CMD=server"], None, None),
-        (["DOCKER_STACKS_JUPYTER_CMD=nbclassic"], None, None),
-        (["RESTARTABLE=yes"], None, None),
-        (["JUPYTER_PORT=8171"], None, None),
-        (["JUPYTER_PORT=8117", "DOCKER_STACKS_JUPYTER_CMD=notebook"], None, None),
-        (None, ["start-notebook.sh", "--NotebookApp.base_url=/test"], None),
-        (None, ["start-notebook.sh", "--NotebookApp.base_url=/test/"], None),
-        (["GEN_CERT=1"], ["start-notebook.sh", "--NotebookApp.base_url=/test"], None),
+        (None, None),
+        (["DOCKER_STACKS_JUPYTER_CMD=lab"], None),
+        (["DOCKER_STACKS_JUPYTER_CMD=notebook"], None),
+        (["DOCKER_STACKS_JUPYTER_CMD=server"], None),
+        (["DOCKER_STACKS_JUPYTER_CMD=nbclassic"], None),
+        (["RESTARTABLE=yes"], None),
+        (["JUPYTER_PORT=8171"], None),
+        (["JUPYTER_PORT=8117", "DOCKER_STACKS_JUPYTER_CMD=notebook"], None),
+        (None, ["start-notebook.sh", "--NotebookApp.base_url=/test"]),
+        (None, ["start-notebook.sh", "--NotebookApp.base_url=/test/"]),
+        (["GEN_CERT=1"], ["start-notebook.sh", "--NotebookApp.base_url=/test"]),
         (
             ["GEN_CERT=1", "JUPYTER_PORT=7891"],
             ["start-notebook.sh", "--NotebookApp.base_url=/test"],
-            None,
         ),
-        (["NB_USER=testuser", "CHOWN_HOME=1"], None, "/home/testuser"),
+        (["NB_USER=testuser", "CHOWN_HOME=1"], None),
         (
             ["NB_USER=testuser", "CHOWN_HOME=1"],
             ["start-notebook.sh", "--NotebookApp.base_url=/test"],
-            "/home/testuser",
         ),
         (
             ["NB_USER=testuser", "CHOWN_HOME=1", "JUPYTER_PORT=8123"],
             ["start-notebook.sh", "--NotebookApp.base_url=/test"],
-            "/home/testuser",
         ),
     ],
 )
@@ -48,13 +45,11 @@ def test_health(
     container: TrackedContainer,
     env: Optional[list[str]],
     cmd: Optional[list[str]],
-    workdir: Optional[str],
 ) -> None:
     running_container = container.run_detached(
         tty=True,
         environment=env,
         command=cmd,
-        working_dir=workdir,
     )
     # sleeping some time to let the server start
     time.sleep(15)

--- a/tests/base-notebook/test_healthcheck.py
+++ b/tests/base-notebook/test_healthcheck.py
@@ -58,7 +58,7 @@ def test_health(
     )
 
     # sleeping some time to let the server start
-    time_spent = 0
+    time_spent = 0.0
     wait_time = 0.1
     time_limit = 15
     while time_spent < time_limit:

--- a/tests/base-notebook/test_healthcheck.py
+++ b/tests/base-notebook/test_healthcheck.py
@@ -74,16 +74,10 @@ def test_health(
     "env,cmd,user",
     [
         (["NB_USER=testuser", "CHOWN_HOME=1"], None, None),
-        (["NB_USER='test user'", "CHOWN_HOME=1"], None, "root"),
         (
             ["NB_USER=testuser", "CHOWN_HOME=1"],
             ["start-notebook.sh", "--NotebookApp.base_url=/test"],
             None,
-        ),
-        (
-            ["NB_USER='test user'", "CHOWN_HOME=1"],
-            ["start-notebook.sh", "--NotebookApp.base_url=/test"],
-            "root",
         ),
         (
             ["NB_USER=testuser", "CHOWN_HOME=1", "JUPYTER_PORT=8123"],

--- a/tests/base-notebook/test_healthcheck.py
+++ b/tests/base-notebook/test_healthcheck.py
@@ -51,6 +51,15 @@ def test_health(
         environment=env,
         command=cmd,
     )
+
     # sleeping some time to let the server start
-    time.sleep(15)
+    timeSpent = 0
+    waitTime = 0.1
+    timeLimit = 15
+    while timeSpent < timeLimit:
+        time.sleep(waitTime)
+        timeSpent += waitTime
+        if get_health(running_container) == "healthy":
+            break
+
     assert get_health(running_container) == "healthy"

--- a/tests/base-notebook/test_healthcheck.py
+++ b/tests/base-notebook/test_healthcheck.py
@@ -13,36 +13,34 @@ LOGGER = logging.getLogger(__name__)
 
 
 @pytest.mark.parametrize(
-    "env,cmd",
+    "env,cmd,user",
     [
-        (None, None),
-        (["DOCKER_STACKS_JUPYTER_CMD=lab"], None),
-        (["DOCKER_STACKS_JUPYTER_CMD=notebook"], None),
-        (["DOCKER_STACKS_JUPYTER_CMD=server"], None),
-        (["DOCKER_STACKS_JUPYTER_CMD=nbclassic"], None),
-        (["RESTARTABLE=yes"], None),
-        (["JUPYTER_PORT=8171"], None),
-        (["JUPYTER_PORT=8117", "DOCKER_STACKS_JUPYTER_CMD=notebook"], None),
-        (None, ["start-notebook.sh", "--NotebookApp.base_url=/test"]),
-        (None, ["start-notebook.sh", "--NotebookApp.base_url=/test/"]),
-        (["GEN_CERT=1"], ["start-notebook.sh", "--NotebookApp.base_url=/test"]),
+        (None, None, None),
+        (["DOCKER_SfACKS_JUPYTER_CMD=lab"], None, None),
+        (["DOCKER_STACKS_JUPYTER_CMD=notebook"], None, None),
+        (["DOCKER_STACKS_JUPYTER_CMD=server"], None, None),
+        (["DOCKER_STACKS_JUPYTER_CMD=nbclassic"], None, None),
+        (["RESTARTABLE=yes"], None, None),
+        (["JUPYTER_PORT=8171"], None, None),
+        (["JUPYTER_PORT=8117", "DOCKER_STACKS_JUPYTER_CMD=notebook"], None, None),
+        (None, ["start-notebook.sh", "--NotebookApp.base_url=/test"], None),
+        (None, ["start-notebook.sh", "--NotebookApp.base_url=/test/"], None),
+        (["GEN_CERT=1"], ["start-notebook.sh", "--NotebookApp.base_url=/test"], None),
         (
             ["GEN_CERT=1", "JUPYTER_PORT=7891"],
             ["start-notebook.sh", "--NotebookApp.base_url=/test"],
+            None,
         ),
-        (["NB_USER=testuser", "CHOWN_HOME=1"], None),
-        (["NB_USER='test user'", "CHOWN_HOME=1"], None),
+        (["NB_USER=testuser", "CHOWN_HOME=1"], None, "root"),
         (
             ["NB_USER=testuser", "CHOWN_HOME=1"],
             ["start-notebook.sh", "--NotebookApp.base_url=/test"],
-        ),
-        (
-            ["NB_USER='test user'", "CHOWN_HOME=1"],
-            ["start-notebook.sh", "--NotebookApp.base_url=/test"],
+            "root",
         ),
         (
             ["NB_USER=testuser", "CHOWN_HOME=1", "JUPYTER_PORT=8123"],
             ["start-notebook.sh", "--NotebookApp.base_url=/test"],
+            "root",
         ),
     ],
 )
@@ -50,11 +48,13 @@ def test_health(
     container: TrackedContainer,
     env: Optional[list[str]],
     cmd: Optional[list[str]],
+    user: Optional[str],
 ) -> None:
     running_container = container.run_detached(
         tty=True,
         environment=env,
         command=cmd,
+        user=user,
     )
 
     # sleeping some time to let the server start
@@ -68,3 +68,51 @@ def test_health(
             return
 
     assert get_health(running_container) == "healthy"
+
+
+@pytest.mark.parametrize(
+    "env,cmd,user",
+    [
+        (["NB_USER=testuser", "CHOWN_HOME=1"], None, None),
+        (["NB_USER='test user'", "CHOWN_HOME=1"], None, "root"),
+        (
+            ["NB_USER=testuser", "CHOWN_HOME=1"],
+            ["start-notebook.sh", "--NotebookApp.base_url=/test"],
+            None,
+        ),
+        (
+            ["NB_USER='test user'", "CHOWN_HOME=1"],
+            ["start-notebook.sh", "--NotebookApp.base_url=/test"],
+            "root",
+        ),
+        (
+            ["NB_USER=testuser", "CHOWN_HOME=1", "JUPYTER_PORT=8123"],
+            ["start-notebook.sh", "--NotebookApp.base_url=/test"],
+            None,
+        ),
+    ],
+)
+def test_not_healthy(
+    container: TrackedContainer,
+    env: Optional[list[str]],
+    cmd: Optional[list[str]],
+    user: Optional[str],
+) -> None:
+    running_container = container.run_detached(
+        tty=True,
+        environment=env,
+        command=cmd,
+        user=user,
+    )
+
+    # sleeping some time to let the server start
+    time_spent = 0.0
+    wait_time = 0.1
+    time_limit = 15
+    while time_spent < time_limit:
+        time.sleep(wait_time)
+        time_spent += wait_time
+        if get_health(running_container) == "healthy":
+            raise RuntimeError("Container should not be healthy for these testcases.")
+
+    assert get_health(running_container) != "healthy"

--- a/tests/base-notebook/test_healthcheck.py
+++ b/tests/base-notebook/test_healthcheck.py
@@ -31,8 +31,13 @@ LOGGER = logging.getLogger(__name__)
             ["start-notebook.sh", "--NotebookApp.base_url=/test"],
         ),
         (["NB_USER=testuser", "CHOWN_HOME=1"], None),
+        (["NB_USER='test user'", "CHOWN_HOME=1"], None),
         (
             ["NB_USER=testuser", "CHOWN_HOME=1"],
+            ["start-notebook.sh", "--NotebookApp.base_url=/test"],
+        ),
+        (
+            ["NB_USER='test user'", "CHOWN_HOME=1"],
             ["start-notebook.sh", "--NotebookApp.base_url=/test"],
         ),
         (

--- a/tests/base-notebook/test_healthcheck.py
+++ b/tests/base-notebook/test_healthcheck.py
@@ -16,7 +16,7 @@ LOGGER = logging.getLogger(__name__)
     "env,cmd,user",
     [
         (None, None, None),
-        (["DOCKER_SfACKS_JUPYTER_CMD=lab"], None, None),
+        (["DOCKER_STACKS_JUPYTER_CMD=lab"], None, None),
         (["DOCKER_STACKS_JUPYTER_CMD=notebook"], None, None),
         (["DOCKER_STACKS_JUPYTER_CMD=server"], None, None),
         (["DOCKER_STACKS_JUPYTER_CMD=nbclassic"], None, None),

--- a/tests/base-notebook/test_healthcheck.py
+++ b/tests/base-notebook/test_healthcheck.py
@@ -58,13 +58,14 @@ def test_health(
     )
 
     # sleeping some time to let the server start
-    timeSpent = 0
-    waitTime = 0.1
-    timeLimit = 15
-    while timeSpent < timeLimit:
-        time.sleep(waitTime)
-        timeSpent += waitTime
+    time_spent = 0
+    wait_time = 0.1
+    time_limit = 15
+    while time_spent < time_limit:
+        time.sleep(wait_time)
+        time_spent += wait_time
         if get_health(running_container) == "healthy":
-            break
+            return
+    raise RuntimeError("container is still unhealthy")
 
     assert get_health(running_container) == "healthy"


### PR DESCRIPTION
## Describe your changes

This PR tries to implement the idea discussed on #1817. Obtain the URL where the jupyter server runs on from a json file located on `/home/$NB_USER/.local/share/jupyter/runtime` directory and use it for healthcheck. Parsing of the json file is done with minimal python currently written as a one-liner command. 

Would appreciate any feedback!

## Issue ticket if applicable

Intended as a solution for https://github.com/jupyter/docker-stacks/issues/1709
<!-- Example - Fix: https://github.com/jupyter/docker-stacks/issues/0 -->

## Checklist (especially for first-time contributors)

- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests
- [x] I will try not to use force-push to make the review process easier for reviewers
- [ ] I have updated the documentation for significant changes

<!-- markdownlint-disable-file MD041 -->
