### PR TITLE
Add third option: Route container to another local port

### DIFF
--- a/docs/using/troubleshooting.md
+++ b/docs/using/troubleshooting.md
@@ -313,16 +313,16 @@ If you are a regular user of VSCode and the Jupyter extension, you might experie
 
 3. **Route container to another local port**
 
+   Instead of mapping Docker port `8888` to local port `8888` , map to another unused local port.
+   You can see an example of mapping to local port `8001`:
+
    ```
    docker run -p 8001:8888 jupyter/datascience-notebook
    ```
 
-   Instead of mapping local port 8888 to Docker port 8888, map to another unused local port (Suggested range: 8001-8009)
+   When the terminal provides the link to access Jupyter: <http://127.0.0.1:8888/lab?token=80d45d241a1ba4c2...>,
+   change the default port value of `8888` to the port value mapped with the `docker run` command.
 
-   When the terminal provides the link to access Jupyter: <http://127.0.0.1:8888/lab?token=80d45d241a1ba4c2>....
-
-   Change the default port value of 8888 to the port value mapped with the Docker run command
-
-   In this example we use 8001, so the edited link would be: <http://127.0.0.1:8001/lab?token=80d45d241a1ba4c2>....
+   In this example we use 8001, so the edited link would be: <http://127.0.0.1:8001/lab?token=80d45d241a1ba4c2...>.
 
    Note: Port mapping for Jupyter has other applications outside of Docker. For example, it can be used to allow multiple Jupyter instances when using SSH to control cloud devices.

--- a/docs/using/troubleshooting.md
+++ b/docs/using/troubleshooting.md
@@ -311,18 +311,18 @@ If you are a regular user of VSCode and the Jupyter extension, you might experie
 
    ![VSCode Preferences UI - Jupyter: Disable Jupyter Auto Start checkbox unchecked](../_static/using/troubleshooting/vscode-jupyter-settings.png)
 
-3. **Route container to another local port** 
+3. **Route container to another local port**
 
    ```
    docker run -p 8001:8888 jupyter/datascience-notebook
    ```
 
-    Instead of mapping local port 8888 to Docker port 8888, map to another unused local port (Suggested range: 8001-8009)
+   Instead of mapping local port 8888 to Docker port 8888, map to another unused local port (Suggested range: 8001-8009)
 
-    When the terminal provides the link to access Jupyter: http://127.0.0.1:8888/lab?token=80d45d241a1ba4c2....
+   When the terminal provides the link to access Jupyter: <http://127.0.0.1:8888/lab?token=80d45d241a1ba4c2>....
 
-    Change the default port value of 8888 to the port value mapped with the Docker run command 
+   Change the default port value of 8888 to the port value mapped with the Docker run command
 
-    In this example we use 8001, so the edited link would be: http://127.0.0.1:8001/lab?token=80d45d241a1ba4c2....
+   In this example we use 8001, so the edited link would be: <http://127.0.0.1:8001/lab?token=80d45d241a1ba4c2>....
 
-    Note: Port mapping for Jupyter has other applications outside of Docker. For example, it can be used to allow multiple Jupyter instances when using SSH to control cloud devices.
+   Note: Port mapping for Jupyter has other applications outside of Docker. For example, it can be used to allow multiple Jupyter instances when using SSH to control cloud devices.

--- a/docs/using/troubleshooting.md
+++ b/docs/using/troubleshooting.md
@@ -316,7 +316,7 @@ If you are a regular user of VSCode and the Jupyter extension, you might experie
    Instead of mapping Docker port `8888` to local port `8888` , map to another unused local port.
    You can see an example of mapping to local port `8001`:
 
-   ```
+   ```bash
    docker run -p 8001:8888 jupyter/datascience-notebook
    ```
 

--- a/docs/using/troubleshooting.md
+++ b/docs/using/troubleshooting.md
@@ -311,17 +311,17 @@ If you are a regular user of VSCode and the Jupyter extension, you might experie
 
    ![VSCode Preferences UI - Jupyter: Disable Jupyter Auto Start checkbox unchecked](../_static/using/troubleshooting/vscode-jupyter-settings.png)
 
-3. **Route container to another local port**
+3. **Route container to unused local port**
 
-   Instead of mapping Docker port `8888` to local port `8888` , map to another unused local port.
+   Instead of mapping Docker port `8888` to local port `8888`, map to another unused local port.
    You can see an example of mapping to local port `8001`:
 
    ```bash
-   docker run -p 8001:8888 jupyter/datascience-notebook
+   docker run -it --rm -p 8001:8888 jupyter/datascience-notebook
    ```
 
    When the terminal provides the link to access Jupyter: <http://127.0.0.1:8888/lab?token=80d45d241a1ba4c2...>,
-   change the default port value of `8888` to the port value mapped with the `docker run` command.
+   change the default port value of `8888` in the url to the port value mapped with the `docker run` command.
 
    In this example we use 8001, so the edited link would be: <http://127.0.0.1:8001/lab?token=80d45d241a1ba4c2...>.
 

--- a/docs/using/troubleshooting.md
+++ b/docs/using/troubleshooting.md
@@ -310,3 +310,19 @@ If you are a regular user of VSCode and the Jupyter extension, you might experie
    You can achieve this from the `Preferences > Jupyter` menu in VScode:
 
    ![VSCode Preferences UI - Jupyter: Disable Jupyter Auto Start checkbox unchecked](../_static/using/troubleshooting/vscode-jupyter-settings.png)
+
+3. **Route container to another local port** 
+
+   ```
+   docker run -p 8001:8888 jupyter/datascience-notebook
+   ```
+
+    Instead of mapping local port 8888 to Docker port 8888, map to another unused local port (Suggested range: 8001-8009)
+
+    When the terminal provides the link to access Jupyter: http://127.0.0.1:8888/lab?token=80d45d241a1ba4c2....
+
+    Change the default port value of 8888 to the port value mapped with the Docker run command 
+
+    In this example we use 8001, so the edited link would be: http://127.0.0.1:8001/lab?token=80d45d241a1ba4c2....
+
+    Note: Port mapping for Jupyter has other applications outside of Docker. For example, it can be used to allow multiple Jupyter instances when using SSH to control cloud devices.


### PR DESCRIPTION
Jupyter can have multiple local instances if the used ports don't overlap. Added this as a troubleshooting alternative for users who may want or need to have more than one Jupyter instance running.

## Describe your changes

## Issue ticket if applicable

<!-- Example - Fix: https://github.com/jupyter/docker-stacks/issues/0 -->

## Checklist (especially for first-time contributors)

- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests
- [x] I will try not to use force-push to make the review process easier for reviewers
- [x] I have updated the documentation for significant changes

<!-- markdownlint-disable-file MD041 -->
