### PR TITLE
Update docker_healthcheck.py

### DIFF
--- a/base-notebook/docker_healthcheck.py
+++ b/base-notebook/docker_healthcheck.py
@@ -11,7 +11,7 @@ import requests
 # As this is a healthcheck, it should succeed or raise an exception on error
 
 runtime_dir = Path("/home/") / os.environ["NB_USER"] / ".local/share/jupyter/runtime/"
-json_file = next(runtime_dir.glob("*.json"))
+json_file = next(runtime_dir.glob("jpserver*.json"))
 
 url = json.loads(json_file.read_bytes())["url"]
 url = url + "api"

--- a/base-notebook/docker_healthcheck.py
+++ b/base-notebook/docker_healthcheck.py
@@ -11,7 +11,7 @@ import requests
 # As this is a healthcheck, it should succeed or raise an exception on error
 
 runtime_dir = Path("/home/") / os.environ["NB_USER"] / ".local/share/jupyter/runtime/"
-json_file = next(runtime_dir.glob("jpserver*.json"))
+json_file = next(runtime_dir.glob("jpserver-*.json"))
 
 url = json.loads(json_file.read_bytes())["url"]
 url = url + "api"

--- a/base-notebook/docker_healthcheck.py
+++ b/base-notebook/docker_healthcheck.py
@@ -11,7 +11,7 @@ import requests
 # As this is a healthcheck, it should succeed or raise an exception on error
 
 runtime_dir = Path("/home/") / os.environ["NB_USER"] / ".local/share/jupyter/runtime/"
-json_file = next(runtime_dir.glob("jpserver-*.json"))
+json_file = next(runtime_dir.glob("*server-*.json"))
 
 url = json.loads(json_file.read_bytes())["url"]
 url = url + "api"


### PR DESCRIPTION
This does not (always) work. Sometimes, other JSON files appear in the directory, like this kernel-xxx file

jpserver-6.json
jpserver-6-open.html
kernel-374f4977-29fc-43e0-8a48-231f6980fdab.json

changing the glob expression to something like "jpserver*.json" instead of simply "*.json" should solve the problem (at least in my case, I checked with a quick patch on a live container, the healthcheck immediately turned 'healthy' again...)

## Describe your changes

## Issue ticket if applicable

<!-- Example - Fix: https://github.com/jupyter/docker-stacks/issues/0 -->

## Checklist (especially for first-time contributors)

- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests
- [x] I will try not to use force-push to make the review process easier for reviewers
- [ ] I have updated the documentation for significant changes

<!-- markdownlint-disable-file MD041 -->
