### PR TITLE
Remove --quiet flag when not needed

### DIFF
--- a/all-spark-notebook/Dockerfile
+++ b/all-spark-notebook/Dockerfile
@@ -27,7 +27,7 @@ RUN apt-get update --yes && \
 USER ${NB_UID}
 
 # R packages including IRKernel which gets installed globally.
-RUN mamba install --quiet --yes \
+RUN mamba install --yes \
     'r-base' \
     'r-ggplot2' \
     'r-irkernel' \

--- a/base-notebook/Dockerfile
+++ b/base-notebook/Dockerfile
@@ -35,7 +35,7 @@ USER ${NB_UID}
 # Do all this in a single RUN command to avoid duplicating all of the
 # files across image layers when the permissions change
 WORKDIR /tmp
-RUN mamba install --quiet --yes \
+RUN mamba install --yes \
     'notebook' \
     'jupyterhub' \
     'jupyterlab' && \

--- a/datascience-notebook/Dockerfile
+++ b/datascience-notebook/Dockerfile
@@ -61,7 +61,7 @@ USER ${NB_UID}
 
 # R packages including IRKernel which gets installed globally.
 # r-e1071: dependency of the caret R package
-RUN mamba install --quiet --yes \
+RUN mamba install --yes \
     'r-base' \
     'r-caret' \
     'r-crayon' \

--- a/docs/using/common.md
+++ b/docs/using/common.md
@@ -245,16 +245,16 @@ You can use either `mamba`, `pip` or `conda` (`mamba` is recommended) to install
 ```bash
 # install a package into the default (python 3.x) environment and cleanup it after
 # the installation
-mamba install --quiet --yes some-package && \
+mamba install --yes some-package && \
     mamba clean --all -f -y && \
     fix-permissions "${CONDA_DIR}" && \
     fix-permissions "/home/${NB_USER}"
 
-pip install --quiet --no-cache-dir some-package && \
+pip install --no-cache-dir some-package && \
     fix-permissions "${CONDA_DIR}" && \
     fix-permissions "/home/${NB_USER}"
 
-conda install --quiet --yes some-package && \
+conda install --yes some-package && \
     conda clean --all -f -y && \
     fix-permissions "${CONDA_DIR}" && \
     fix-permissions "/home/${NB_USER}"
@@ -274,7 +274,7 @@ mamba install --channel defaults humanize
 conda config --system --prepend channels defaults
 
 # install a package
-mamba install --quiet --yes humanize && \
+mamba install --yes humanize && \
     mamba clean --all -f -y && \
     fix-permissions "${CONDA_DIR}" && \
     fix-permissions "/home/${NB_USER}"

--- a/docs/using/recipes.md
+++ b/docs/using/recipes.md
@@ -31,7 +31,7 @@ Create a new Dockerfile like the one shown below.
 # Start from a core stack version
 FROM jupyter/datascience-notebook:2023-02-28
 # Install in the default python3 environment
-RUN pip install --quiet --no-cache-dir 'flake8==3.9.2' && \
+RUN pip install --no-cache-dir 'flake8==3.9.2' && \
     fix-permissions "${CONDA_DIR}" && \
     fix-permissions "/home/${NB_USER}"
 ```
@@ -51,7 +51,7 @@ Next, create a new Dockerfile like the one shown below.
 FROM jupyter/datascience-notebook:2023-02-28
 # Install from the requirements.txt file
 COPY --chown=${NB_UID}:${NB_GID} requirements.txt /tmp/
-RUN pip install --quiet --no-cache-dir --requirement /tmp/requirements.txt && \
+RUN pip install --no-cache-dir --requirement /tmp/requirements.txt && \
     fix-permissions "${CONDA_DIR}" && \
     fix-permissions "/home/${NB_USER}"
 ```
@@ -85,7 +85,7 @@ ARG conda_env=python37
 ARG py_ver=3.7
 
 # you can add additional libraries you want mamba to install by listing them below the first line and ending with "&& \"
-RUN mamba create --quiet --yes -p "${CONDA_DIR}/envs/${conda_env}" python=${py_ver} ipython ipykernel && \
+RUN mamba create --yes -p "${CONDA_DIR}/envs/${conda_env}" python=${py_ver} ipython ipykernel && \
     mamba clean --all -f -y
 
 # alternatively, you can comment out the lines above and uncomment those below
@@ -102,7 +102,7 @@ RUN "${CONDA_DIR}/envs/${conda_env}/bin/python" -m ipykernel install --user --na
     fix-permissions "/home/${NB_USER}"
 
 # any additional pip installs can be added by uncommenting the following line
-# RUN "${CONDA_DIR}/envs/${conda_env}/bin/pip" install --quiet --no-cache-dir
+# RUN "${CONDA_DIR}/envs/${conda_env}/bin/pip" install --no-cache-dir
 
 # if you want this environment to be the default one, uncomment the following line:
 # RUN echo "conda activate ${conda_env}" >> "${HOME}/.bashrc"
@@ -118,7 +118,7 @@ Create the Dockerfile as:
 FROM jupyter/scipy-notebook:latest
 
 # Install the Dask dashboard
-RUN pip install --quiet --no-cache-dir dask-labextension && \
+RUN pip install --no-cache-dir dask-labextension && \
     fix-permissions "${CONDA_DIR}" && \
     fix-permissions "/home/${NB_USER}"
 
@@ -160,7 +160,7 @@ notebooks, with no conversion, adding javascript Reveal.js:
 
 ```bash
 # Add Live slideshows with RISE
-RUN mamba install --quiet --yes -c damianavila82 rise && \
+RUN mamba install --yes -c damianavila82 rise && \
     mamba clean --all -f -y && \
     fix-permissions "${CONDA_DIR}" && \
     fix-permissions "/home/${NB_USER}"
@@ -175,12 +175,12 @@ You need to install conda-forge's gcc for Python xgboost to work correctly.
 Otherwise, you'll get an exception about libgomp.so.1 missing GOMP_4.0.
 
 ```bash
-mamba install --quiet --yes gcc && \
+mamba install --yes gcc && \
     mamba clean --all -f -y && \
     fix-permissions "${CONDA_DIR}" && \
     fix-permissions "/home/${NB_USER}"
 
-pip install --quiet --no-cache-dir xgboost && \
+pip install --no-cache-dir xgboost && \
     fix-permissions "${CONDA_DIR}" && \
     fix-permissions "/home/${NB_USER}"
 
@@ -284,7 +284,7 @@ version in the Hub itself.
 
 ```dockerfile
 FROM jupyter/base-notebook:2023-02-28
-RUN pip install --quiet --no-cache-dir jupyterhub==1.4.1 && \
+RUN pip install --no-cache-dir jupyterhub==1.4.1 && \
     fix-permissions "${CONDA_DIR}" && \
     fix-permissions "/home/${NB_USER}"
 ```
@@ -438,9 +438,9 @@ USER ${NB_UID}
 # - Dashboards
 # - PyDoop
 # - PyHive
-RUN pip install --quiet --no-cache-dir jupyter_dashboards faker && \
+RUN pip install --no-cache-dir jupyter_dashboards faker && \
     jupyter dashboards quick-setup --sys-prefix && \
-    pip2 install --quiet --no-cache-dir pyhive pydoop thrift sasl thrift_sasl faker && \
+    pip2 install --no-cache-dir pyhive pydoop thrift sasl thrift_sasl faker && \
     fix-permissions "${CONDA_DIR}" && \
     fix-permissions "/home/${NB_USER}"
 
@@ -496,7 +496,7 @@ FROM jupyter/minimal-notebook:latest
 
 USER ${NB_UID}
 
-RUN pip install --quiet --no-cache-dir jupyter_contrib_nbextensions && \
+RUN pip install --no-cache-dir jupyter_contrib_nbextensions && \
     jupyter contrib nbextension install --user && \
     # can modify or enable additional extensions here
     jupyter nbextension enable spellchecker/main --user && \
@@ -515,7 +515,7 @@ By adding the properties to `spark-defaults.conf`, the user no longer needs to e
 FROM jupyter/pyspark-notebook:latest
 
 ARG DELTA_CORE_VERSION="1.2.1"
-RUN pip install --quiet --no-cache-dir delta-spark==${DELTA_CORE_VERSION} && \
+RUN pip install --no-cache-dir delta-spark==${DELTA_CORE_VERSION} && \
      fix-permissions "${HOME}" && \
      fix-permissions "${CONDA_DIR}"
 
@@ -608,7 +608,7 @@ RUN apt-get update --yes && \
 # Switch back to jovyan to avoid accidental container runs as root
 USER ${NB_UID}
 
-RUN pip install --quiet --no-cache-dir pyodbc
+RUN pip install --no-cache-dir pyodbc
 ```
 
 You can now use `pyodbc` and `sqlalchemy` to interact with the database.

--- a/examples/docker-compose/notebook/Dockerfile
+++ b/examples/docker-compose/notebook/Dockerfile
@@ -13,4 +13,4 @@ USER ${NB_UID}
 
 # Switch back to jovyan to avoid accidental container runs as root
 # Add permanent mamba/pip/conda installs, data files, other user libs here
-# e.g., RUN pip install --quiet --no-cache-dir flake8
+# e.g., RUN pip install --no-cache-dir flake8

--- a/examples/make-deploy/Dockerfile
+++ b/examples/make-deploy/Dockerfile
@@ -13,4 +13,4 @@ USER ${NB_UID}
 
 # Switch back to jovyan to avoid accidental container runs as root
 # Add permanent mamba/pip/conda installs, data files, other user libs here
-# e.g., RUN pip install --quiet --no-cache-dir flake8
+# e.g., RUN pip install --no-cache-dir flake8

--- a/pyspark-notebook/Dockerfile
+++ b/pyspark-notebook/Dockerfile
@@ -65,7 +65,7 @@ RUN fix-permissions "/etc/ipython/"
 USER ${NB_UID}
 
 # Install pyarrow
-RUN mamba install --quiet --yes \
+RUN mamba install --yes \
     'pyarrow' && \
     mamba clean --all -f -y && \
     fix-permissions "${CONDA_DIR}" && \

--- a/r-notebook/Dockerfile
+++ b/r-notebook/Dockerfile
@@ -27,7 +27,7 @@ USER ${NB_UID}
 
 # R packages including IRKernel which gets installed globally.
 # r-e1071: dependency of the caret R package
-RUN mamba install --quiet --yes \
+RUN mamba install --yes \
     'r-base' \
     'r-caret' \
     'r-crayon' \

--- a/scipy-notebook/Dockerfile
+++ b/scipy-notebook/Dockerfile
@@ -26,7 +26,7 @@ RUN apt-get update --yes && \
 USER ${NB_UID}
 
 # Install Python 3 packages
-RUN mamba install --quiet --yes \
+RUN mamba install --yes \
     'altair' \
     'beautifulsoup4' \
     'bokeh' \

--- a/tensorflow-notebook/Dockerfile
+++ b/tensorflow-notebook/Dockerfile
@@ -11,7 +11,7 @@ LABEL maintainer="Jupyter Project <jupyter@googlegroups.com>"
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # Install Tensorflow
-RUN mamba install --quiet --yes \
+RUN mamba install --yes \
     'tensorflow' && \
     mamba clean --all -f -y && \
     fix-permissions "${CONDA_DIR}" && \


### PR DESCRIPTION
## Describe your changes

Removing `--quiet` flag from most commands.
It was added only because of Travis CI logs size, which we no longer use.
This flag makes it more difficult to analyze the logs when something (usually dependency solver) goes wrong.

## Issue ticket if applicable

<!-- Example - Fix: https://github.com/jupyter/docker-stacks/issues/0 -->

## Checklist (especially for first-time contributors)

- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests
- [ ] I will try not to use force-push to make the review process easier for reviewers
- [ ] I have updated the documentation for significant changes

<!-- markdownlint-disable-file MD041 -->
