### PR TITLE
Install nodejs >= 18.0

### DIFF
--- a/base-notebook/Dockerfile
+++ b/base-notebook/Dockerfile
@@ -38,7 +38,8 @@ WORKDIR /tmp
 RUN mamba install --yes \
     'notebook' \
     'jupyterhub' \
-    'jupyterlab' && \
+    'jupyterlab' \
+    'nodejs >= 18.0' && \
     jupyter notebook --generate-config && \
     mamba clean --all -f -y && \
     npm cache clean --force && \

--- a/base-notebook/Dockerfile
+++ b/base-notebook/Dockerfile
@@ -36,10 +36,12 @@ USER ${NB_UID}
 # files across image layers when the permissions change
 WORKDIR /tmp
 RUN mamba install --yes \
+    # NodeJS >= 18.0 is required for `jupyter lab build` command
+    # https://github.com/jupyter/docker-stacks/issues/1901
+    'nodejs >= 18.0' \
     'notebook' \
     'jupyterhub' \
-    'jupyterlab' \
-    'nodejs >= 18.0' && \
+    'jupyterlab' && \
     jupyter notebook --generate-config && \
     mamba clean --all -f -y && \
     npm cache clean --force && \

--- a/base-notebook/Dockerfile
+++ b/base-notebook/Dockerfile
@@ -38,7 +38,7 @@ WORKDIR /tmp
 RUN mamba install --yes \
     # NodeJS >= 18.0 is required for `jupyter lab build` command
     # https://github.com/jupyter/docker-stacks/issues/1901
-    'nodejs >= 18.0' \
+    'nodejs>=18.0' \
     'notebook' \
     'jupyterhub' \
     'jupyterlab' && \

--- a/tests/base-notebook/test_packages.py
+++ b/tests/base-notebook/test_packages.py
@@ -71,6 +71,7 @@ EXCLUDED_PACKAGES = [
     "hdf5",
     "jupyter_server[version='>",  # Temporary fix for: https://github.com/jupyter/docker-stacks/issues/1851
     "jupyterlab-git",
+    "nodejs[version='>",  # Temporary fix for: https://github.com/jupyter/docker-stacks/issues/1901
     "openssl",
     "protobuf",
     "python",


### PR DESCRIPTION
## Describe your changes

NodeJS >= 18.0 is installed in base-notebook image because `jupyter lab build` command requires it.

## Issue ticket if applicable

Fix: #1901 

## Checklist (especially for first-time contributors)

- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests
- [x] I will try not to use force-push to make the review process easier for reviewers
- [x] I have updated the documentation for significant changes

<!-- markdownlint-disable-file MD041 -->
