### PR TITLE
Fix image tagging in hook/%

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,8 @@ linkcheck-docs: ## check broken links
 
 
 hook/%: ## run post-build hooks for an image
-	python3 -m tagging.tag_image --short-image-name "$(notdir $@)" --owner "$(OWNER)" && \
+	python3 -m tagging.write_tags_file --short-image-name "$(notdir $@)" --tags-dir /tmp/jupyter/tags/ --owner "$(OWNER)" && \
+	python3 -m tagging.apply_tags --short-image-name "$(notdir $@)" --tags-dir /tmp/jupyter/tags/ --platform "$(shell uname -m)" --owner "$(OWNER)" && \
 	python3 -m tagging.write_manifest --short-image-name "$(notdir $@)" --hist-line-dir /tmp/jupyter/hist_lines/ --manifest-dir /tmp/jupyter/manifests/ --owner "$(OWNER)"
 hook-all: $(foreach I, $(ALL_IMAGES), hook/$(I)) ## run post-build hooks for all images
 


### PR DESCRIPTION
## Describe your changes

The `hook/%` target refers to the script `tagging.tag_image` which does not exist anymore. This PR updates Makefile to use `tagging.write_tags_file` and `tagging.apply_tags` instead (identical to what is being done in Github Actions).

## Checklist (especially for first-time contributors)

- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests
- [x] I will try not to use force-push to make the review process easier for reviewers
- [ ] I have updated the documentation for significant changes

<!-- markdownlint-disable-file MD041 -->
