### PR TITLE
Healthcheck gives correct result even behind proxy

### DIFF
--- a/base-notebook/docker_healthcheck.py
+++ b/base-notebook/docker_healthcheck.py
@@ -17,8 +17,8 @@ url = json.loads(json_file.read_bytes())["url"]
 url = url + "api"
 
 proxies = {
-  "http": None,
-  "https": None,
+    "http": None,
+    "https": None,
 }
 
 r = requests.get(url, proxies=proxies, verify=False)  # request without SSL verification

--- a/base-notebook/docker_healthcheck.py
+++ b/base-notebook/docker_healthcheck.py
@@ -16,6 +16,11 @@ json_file = next(runtime_dir.glob("*server-*.json"))
 url = json.loads(json_file.read_bytes())["url"]
 url = url + "api"
 
-r = requests.get(url, verify=False)  # request without SSL verification
+proxies = {
+  "http": None,
+  "https": None,
+}
+
+r = requests.get(url, proxies=proxies, verify=False)  # request without SSL verification
 r.raise_for_status()
 print(r.content)

--- a/base-notebook/docker_healthcheck.py
+++ b/base-notebook/docker_healthcheck.py
@@ -17,8 +17,8 @@ url = json.loads(json_file.read_bytes())["url"]
 url = url + "api"
 
 proxies = {
-    "http": None,
-    "https": None,
+    "http": "",
+    "https": "",
 }
 
 r = requests.get(url, proxies=proxies, verify=False)  # request without SSL verification

--- a/tests/base-notebook/test_healthcheck.py
+++ b/tests/base-notebook/test_healthcheck.py
@@ -72,9 +72,19 @@ def test_health(
 @pytest.mark.parametrize(
     "env,cmd,user",
     [
-        (["HTTPS_PROXY=host.docker.internal", "HTTP_PROXY=host.docker.internal"], None, None),
         (
-            ["NB_USER=testuser", "CHOWN_HOME=1", "JUPYTER_PORT=8123", "HTTPS_PROXY=host.docker.internal", "HTTP_PROXY=host.docker.internal"],
+            ["HTTPS_PROXY=host.docker.internal", "HTTP_PROXY=host.docker.internal"],
+            None,
+            None,
+        ),
+        (
+            [
+                "NB_USER=testuser",
+                "CHOWN_HOME=1",
+                "JUPYTER_PORT=8123",
+                "HTTPS_PROXY=host.docker.internal",
+                "HTTP_PROXY=host.docker.internal",
+            ],
             ["start-notebook.sh", "--ServerApp.base_url=/test"],
             "root",
         ),


### PR DESCRIPTION
## Changes
For environments that use proxies, mostly corporate environments, the health check did not work. Proxies are not necessary for the health check so the proxies are disabled.
The health check runs in the docker container and makes a request to a specific address. If that request is routed through a proxy it leaves the docker container. This can cause two types of problems:
- The proxy does not know the ip address and thus the request never terminates
- Outside of the container the ports can change and the request will not reach the proper port.

## Issue ticket

Closed [1962](https://github.com/jupyter/docker-stacks/issues/1962)

## Checklist (especially for first-time contributors)

- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests
- [x] I will try not to use force-push to make the review process easier for reviewers
- [-] I have updated the documentation for significant changes

<!-- markdownlint-disable-file MD041 -->
