### PR TITLE
Fix usage for -w in docs

### DIFF
--- a/docs/using/common.md
+++ b/docs/using/common.md
@@ -37,7 +37,7 @@ You do so by passing arguments to the `docker run` command.
   The default value is `jovyan`.
   Setting `NB_USER` refits the `jovyan` default user and ensures that the desired user has the correct file permissions
   for the new home directory created at `/home/<username>`.
-  For this option to take effect, you **must** run the container with `--user root`, set the working directory `-w "/home/${NB_USER}"`
+  For this option to take effect, you **must** run the container with `--user root`, set the working directory `-w "/home/<username>"`
   and set the environment variable `-e CHOWN_HOME=yes`.
 
   _Example usage:_
@@ -48,7 +48,7 @@ You do so by passing arguments to the `docker run` command.
       --user root \
       -e NB_USER="my-username" \
       -e CHOWN_HOME=yes \
-      -w "/home/${NB_USER}" \
+      -w "/home/my-username" \
       jupyter/base-notebook
   ```
 

--- a/docs/using/troubleshooting.md
+++ b/docs/using/troubleshooting.md
@@ -142,7 +142,7 @@ If you have also **created a new user**, you might be experiencing any of the fo
         -e NB_GID=1234 \
         -e CHOWN_HOME=yes \
         -e CHOWN_HOME_OPTS="-R" \
-        -w "/home/${NB_USER}" \
+        -w "/home/callisto" \
         -v "${PWD}"/test:/home/callisto/work \
         jupyter/minimal-notebook
 
@@ -162,7 +162,7 @@ If you have also **created a new user**, you might be experiencing any of the fo
    - `-e NB_UID=1234` and `-e NB_GID=1234`: will set the `UID` and `GID` of the new user (`callisto`) to `1234`
    - `-e CHOWN_HOME_OPTS="-R"` and `-e CHOWN_HOME=yes`: ensure that the new user is the owner of the `/home` directory and subdirectories
      (setting `CHOWN_HOME_OPTS="-R` will ensure this change is applied recursively)
-   - `-w "/home/${NB_USER}"` sets the working directory to be the new user's home
+   - `-w "/home/callisto"` sets the working directory to be the new user's home
 
    ```{admonition} Additional notes
     In the example above, the `-v` flag is used to mount the local volume onto the new user's `/home` directory.
@@ -185,7 +185,7 @@ If you have also **created a new user**, you might be experiencing any of the fo
        -e NB_GID="$(id -g)"  \
        -e CHOWN_HOME=yes \
        -e CHOWN_HOME_OPTS="-R" \
-       -w "/home/${NB_USER}" \
+       -w "/home/callisto" \
        -v "${PWD}"/test:/home/callisto/work \
        jupyter/minimal-notebook
    ```


### PR DESCRIPTION
## Describe your changes

`-w "/home/${NB_USER}"` never does what you think it will do.
`${NB_USER}` is interpreted by bash on the host machine, not inside the docker.
And this variable is (almost) never set on the host machine, so this line works as `-w "/home/"`, which is not what most people want.

## Issue ticket if applicable

<!-- Example - Fix: https://github.com/jupyter/docker-stacks/issues/0 -->

## Checklist (especially for first-time contributors)

- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests
- [ ] I will try not to use force-push to make the review process easier for reviewers
- [ ] I have updated the documentation for significant changes

<!-- markdownlint-disable-file MD041 -->
