### PR TITLE
Test run_hooks when executables fail

### DIFF
--- a/images/docker-stacks-foundation/run-hooks.sh
+++ b/images/docker-stacks-foundation/run-hooks.sh
@@ -24,11 +24,19 @@ for f in "${1}/"*; do
             echo "Sourcing shell script: ${f}"
             # shellcheck disable=SC1090
             source "${f}"
+            # shellcheck disable=SC2181
+            if [ $? -ne 0 ] ; then
+                echo "${f} has failed, continuing execution"
+            fi
             ;;
         *)
             if [ -x "${f}" ] ; then
                 echo "Running executable: ${f}"
                 "${f}"
+                # shellcheck disable=SC2181
+                if [ $? -ne 0 ] ; then
+                    echo "${f} has failed, continuing execution"
+                fi
             else
                 echo "Ignoring non-executable: ${f}"
             fi

--- a/tests/docker-stacks-foundation/run-hooks-failures/a.sh
+++ b/tests/docker-stacks-foundation/run-hooks-failures/a.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+
+echo "Started: a.sh"
+
+export OTHER_VAR=456
+
+run-unknown-command
+
+echo "Finished: a.sh"

--- a/tests/docker-stacks-foundation/run-hooks-failures/b.py
+++ b/tests/docker-stacks-foundation/run-hooks-failures/b.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python3
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+import os
+import sys
+
+print("Started: b.py")
+print(f"OTHER_VAR={os.environ['OTHER_VAR']}")
+
+sys.exit(1)
+
+print("Finished: b.py")

--- a/tests/docker-stacks-foundation/run-hooks-failures/c.sh
+++ b/tests/docker-stacks-foundation/run-hooks-failures/c.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+
+echo "Started: c.sh"
+
+run-unknown-command

--- a/tests/docker-stacks-foundation/run-hooks-failures/d.sh
+++ b/tests/docker-stacks-foundation/run-hooks-failures/d.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+
+set -e
+
+echo "Started: d.sh"
+
+run-unknown-command
+
+echo "Finished: d.sh"


### PR DESCRIPTION
## Describe your changes

This is a thorough test what happens when startup hooks fail.

## Issue ticket if applicable

<!-- Example - Fix: https://github.com/jupyter/docker-stacks/issues/0 -->

## Checklist (especially for first-time contributors)

- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests
- [ ] I will try not to use force-push to make the review process easier for reviewers
- [ ] I have updated the documentation for significant changes

<!-- markdownlint-disable-file MD041 -->
