### PR TITLE
Add zip to the `minimal-notebook` image

### DIFF
--- a/docs/using/selecting.md
+++ b/docs/using/selecting.md
@@ -76,7 +76,8 @@ It contains:
   [git](https://git-scm.com/),
   [nano](https://www.nano-editor.org/) (actually `nano-tiny`),
   [tzdata](https://www.iana.org/time-zones),
-  [unzip](https://code.launchpad.net/ubuntu/+source/unzip)
+  [unzip](https://code.launchpad.net/ubuntu/+source/unzip),
+  [zip](https://code.launchpad.net/ubuntu/+source/zip)
   and [vi](https://www.vim.org) (actually `vim-tiny`),
 - [TeX Live](https://www.tug.org/texlive/) for notebook document conversion
 

--- a/images/minimal-notebook/Dockerfile
+++ b/images/minimal-notebook/Dockerfile
@@ -21,6 +21,7 @@ RUN apt-get update --yes && \
     nano-tiny \
     tzdata \
     unzip \
+    zip \
     vim-tiny \
     # git-over-ssh
     openssh-client \


### PR DESCRIPTION
## Describe your changes
The `minimal-notebook` image comes preinstalled with useful utilities, `unzip` being one of them. But it's missing its counterpart - `zip`.

This PR adds the `zip` package to the image.

## Issue ticket if applicable

<!-- Example - Fix: https://github.com/jupyter/docker-stacks/issues/0 -->

## Checklist (especially for first-time contributors)

- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests
- [x] I will try not to use force-push to make the review process easier for reviewers
- [x] I have updated the documentation for significant changes

<!-- markdownlint-disable-file MD041 -->
