### PR TITLE
Upgrade `Apache Spark` to 3.5.0

### DIFF
--- a/images/pyspark-notebook/Dockerfile
+++ b/images/pyspark-notebook/Dockerfile
@@ -73,7 +73,7 @@ USER ${NB_UID}
 # 1. Check out the Spark branch you are on.
 # 2. Find the pandas version in the file spark/dev/infra/Dockerfile.
 RUN mamba install --yes \
-    'pandas>=2.0.3,<2.0.4' \
+    'pandas=2.0.3' \
     'pyarrow' && \
     mamba clean --all -f -y && \
     fix-permissions "${CONDA_DIR}" && \

--- a/images/pyspark-notebook/Dockerfile
+++ b/images/pyspark-notebook/Dockerfile
@@ -66,7 +66,12 @@ RUN fix-permissions "/etc/ipython/"
 USER ${NB_UID}
 
 # Install pyarrow
-# Temporarily pin pandas to version 2.0.3, see: https://github.com/jupyter/docker-stacks/issues/1924
+# NOTE: It's important to ensure compatibility between Pandas versions.
+# The pandas version in this Dockerfile should match the version 
+# on which the Pandas API for Spark is built.
+# To find the right version:
+# 1. Check out the Spark branch you are on.
+# 2. Find the pandas version in the file spark/dev/infra/Dockerfile.
 RUN mamba install --yes \
     'pandas>=2.0.3,<2.0.4' \
     'pyarrow' && \

--- a/images/pyspark-notebook/Dockerfile
+++ b/images/pyspark-notebook/Dockerfile
@@ -15,10 +15,10 @@ USER root
 # Spark dependencies
 # Default values can be overridden at build time
 # (ARGS are in lower case to distinguish them from ENV)
-ARG spark_version="3.4.1"
+ARG spark_version="3.5.0"
 ARG hadoop_version="3"
 ARG scala_version
-ARG spark_checksum="5a21295b4c3d1d3f8fc85375c711c7c23e3eeb3ec9ea91778f149d8d321e3905e2f44cf19c69a28df693cffd536f7316706c78932e7e148d224424150f18b2c5"
+ARG spark_checksum="8883c67e0a138069e597f3e7d4edbbd5c3a565d50b28644aad02856a1ec1da7cb92b8f80454ca427118f69459ea326eaa073cf7b1a860c3b796f4b07c2101319"
 ARG openjdk_version="17"
 
 ENV APACHE_SPARK_VERSION="${spark_version}" \
@@ -66,9 +66,9 @@ RUN fix-permissions "/etc/ipython/"
 USER ${NB_UID}
 
 # Install pyarrow
-# Temporarily pin pandas to version 1.5.3, see: https://github.com/jupyter/docker-stacks/issues/1924
+# Temporarily pin pandas to version 2.0.3, see: https://github.com/jupyter/docker-stacks/issues/1924
 RUN mamba install --yes \
-    'pandas>=1.5.3,<2.0.0' \
+    'pandas>=2.0.3,<2.0.4' \
     'pyarrow' && \
     mamba clean --all -f -y && \
     fix-permissions "${CONDA_DIR}" && \

--- a/images/pyspark-notebook/Dockerfile
+++ b/images/pyspark-notebook/Dockerfile
@@ -67,7 +67,7 @@ USER ${NB_UID}
 
 # Install pyarrow
 # NOTE: It's important to ensure compatibility between Pandas versions.
-# The pandas version in this Dockerfile should match the version 
+# The pandas version in this Dockerfile should match the version
 # on which the Pandas API for Spark is built.
 # To find the right version:
 # 1. Check out the Spark branch you are on.

--- a/tests/pyspark-notebook/units/unit_pandas_version.py
+++ b/tests/pyspark-notebook/units/unit_pandas_version.py
@@ -2,4 +2,4 @@
 # Distributed under the terms of the Modified BSD License.
 import pandas
 
-assert pandas.__version__ == "1.5.3"
+assert pandas.__version__ == "2.0.3"


### PR DESCRIPTION
## Describe your changes
Upgrade `Apache Spark` from 3.4.1 to 3.5.0
[Release notes](https://spark.apache.org/releases/spark-release-3-5-0.html)

Pandas on Spark API are using 'pandas<=2.0.3' now. 
https://github.com/apache/spark/blob/9c0b803ba124a6e70762aec1e5559b0d66529f4d/dev/infra/Dockerfile#L67C40-L67C40

## Issue ticket if applicable

<!-- Example - Fix: https://github.com/jupyter/docker-stacks/issues/0 -->

## Checklist (especially for first-time contributors)

- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests
- [ ] I will try not to use force-push to make the review process easier for reviewers
- [ ] I have updated the documentation for significant changes

<!-- markdownlint-disable-file MD041 -->
