### PR TITLE
Move from Docker Hub to quay.io

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -57,7 +57,7 @@ body:
         What complete docker command do you run to launch the container (omitting sensitive values)?
       placeholder: |
         Example:
-        `docker run -it --rm -p 8888:8888 docker.io/jupyter/base-notebook`
+        `docker run -it --rm -p 8888:8888 quay.io/jupyter/base-notebook`
     validations:
       required: true
 

--- a/.github/workflows/docker-build-test-upload.yml
+++ b/.github/workflows/docker-build-test-upload.yml
@@ -1,7 +1,7 @@
 name: Download parent image, build a new one and test it; then upload the image, tags and manifests to GitHub artifacts
 
 env:
-  REGISTRY: docker.io
+  REGISTRY: quay.io
   OWNER: ${{ github.repository_owner }}
 
 on:

--- a/.github/workflows/docker-merge-tags.yml
+++ b/.github/workflows/docker-merge-tags.yml
@@ -52,6 +52,7 @@ jobs:
         if: github.repository == 'jupyter/docker-stacks' && (github.ref == 'refs/heads/main' || github.event_name == 'schedule')
         uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d # v3.0.0
         with:
+          registry: quay.io
           username: ${{ secrets.REGISTRY_USERNAME }}
           password: ${{ secrets.REGISTRY_TOKEN }}
 

--- a/.github/workflows/docker-tag-push.yml
+++ b/.github/workflows/docker-tag-push.yml
@@ -1,7 +1,7 @@
 name: Download Docker image and its tags from GitHub artifacts, apply them and push the image to the Registry
 
 env:
-  REGISTRY: docker.io
+  REGISTRY: quay.io
   OWNER: ${{ github.repository_owner }}
 
 on:
@@ -42,6 +42,7 @@ jobs:
         if: github.repository == 'jupyter/docker-stacks' && (github.ref == 'refs/heads/main' || github.event_name == 'schedule')
         uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d # v3.0.0
         with:
+          registry: quay.io
           username: ${{ secrets.REGISTRY_USERNAME }}
           password: ${{ secrets.REGISTRY_TOKEN }}
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -248,8 +248,8 @@ jobs:
       platform: aarch64
       image: ${{ matrix.image }}
     secrets:
-      REGISTRY_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-      REGISTRY_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+      REGISTRY_USERNAME: ${{ secrets.QUAY_USERNAME }}
+      REGISTRY_TOKEN: ${{ secrets.QUAY_ROBOT_TOKEN }}
     strategy:
       matrix:
         image:
@@ -286,8 +286,8 @@ jobs:
       platform: x86_64
       image: ${{ matrix.image }}
     secrets:
-      REGISTRY_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-      REGISTRY_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+      REGISTRY_USERNAME: ${{ secrets.QUAY_USERNAME }}
+      REGISTRY_TOKEN: ${{ secrets.QUAY_ROBOT_TOKEN }}
     strategy:
       matrix:
         image:
@@ -322,8 +322,8 @@ jobs:
     with:
       image: ${{ matrix.image }}
     secrets:
-      REGISTRY_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-      REGISTRY_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+      REGISTRY_USERNAME: ${{ secrets.QUAY_USERNAME }}
+      REGISTRY_TOKEN: ${{ secrets.QUAY_ROBOT_TOKEN }}
     strategy:
       matrix:
         image:

--- a/.github/workflows/registry-overviews.yml
+++ b/.github/workflows/registry-overviews.yml
@@ -27,7 +27,7 @@ jobs:
         env:
           DOCKER_APIKEY: ${{ secrets.APIKEY__QUAY_IO }}
         with:
-          destination_container_repo: ${{ env.OWNER }}/${{ matrix.image }}
+          destination_container_repo: quay.io/${{ env.OWNER }}/${{ matrix.image }}
           provider: quay
           readme_file: images/${{ matrix.image }}/README.md
 

--- a/.github/workflows/registry-overviews.yml
+++ b/.github/workflows/registry-overviews.yml
@@ -16,7 +16,6 @@ on:
 jobs:
   update-overview:
     runs-on: ubuntu-latest
-    name: update-overview (${{matrix.image}})
     if: github.repository == 'jupyter/docker-stacks'
 
     steps:
@@ -26,34 +25,24 @@ jobs:
       - name: Push README to Registry 🐳
         uses: christian-korneck/update-container-description-action@d36005551adeaba9698d8d67a296bd16fa91f8e8 # v1
         env:
-          DOCKER_USER: ${{ secrets.DOCKERHUB_USERNAME }}
-          DOCKER_PASS: ${{ secrets.DOCKERHUB_TOKEN }}
+          DOCKER_APIKEY: ${{ secrets.APIKEY__QUAY_IO }}
         with:
           destination_container_repo: ${{ env.OWNER }}/${{ matrix.image }}
-          provider: dockerhub
-          short_description: ${{ matrix.description }}
+          provider: quay
           readme_file: images/${{ matrix.image }}/README.md
 
     strategy:
       matrix:
-        include:
-          - image: docker-stacks-foundation
-            description: "Tiny base image on which Jupyter apps can be built from https://github.com/jupyter/docker-stacks"
-          - image: base-notebook
-            description: "Base image for Jupyter Notebook stacks from https://github.com/jupyter/docker-stacks"
-          - image: minimal-notebook
-            description: "Minimal Jupyter Notebook Python Stack from https://github.com/jupyter/docker-stacks"
-          - image: scipy-notebook
-            description: "Scientific Jupyter Notebook Python Stack from https://github.com/jupyter/docker-stacks"
-          - image: r-notebook
-            description: "R Jupyter Notebook Stack from https://github.com/jupyter/docker-stacks"
-          - image: julia-notebook
-            description: "Julia Jupyter Notebook Stack from https://github.com/jupyter/docker-stacks"
-          - image: tensorflow-notebook
-            description: "Scientific Jupyter Notebook Python Stack w/ TensorFlow from https://github.com/jupyter/docker-stacks"
-          - image: datascience-notebook
-            description: "Data Science Jupyter Notebook Python Stack from https://github.com/jupyter/docker-stacks"
-          - image: pyspark-notebook
-            description: "Python and Spark Jupyter Notebook Stack from https://github.com/jupyter/docker-stacks"
-          - image: all-spark-notebook
-            description: "Python, Scala, R and Spark Jupyter Notebook Stack from https://github.com/jupyter/docker-stacks"
+        image:
+          [
+            docker-stacks-foundation,
+            base-notebook,
+            minimal-notebook,
+            scipy-notebook,
+            r-notebook,
+            julia-notebook,
+            tensorflow-notebook,
+            datascience-notebook,
+            pyspark-notebook,
+            all-spark-notebook,
+          ]

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 
 # Use bash for inline if-statements in arch_patch target
 SHELL:=bash
-REGISTRY?=docker.io
+REGISTRY?=quay.io
 OWNER?=jupyter
 
 # Need to list the images in build dependency order

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Discourse badge](https://img.shields.io/discourse/users.svg?color=%23f37626&server=https%3A%2F%2Fdiscourse.jupyter.org)](https://discourse.jupyter.org/ "Jupyter Discourse Forum")
 [![Binder badge](https://static.mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/jupyter/docker-stacks/main?urlpath=lab/tree/README.ipynb "Launch a jupyter/base-notebook container on mybinder.org")
 
-Jupyter Docker Stacks are a set of ready-to-run [Docker images](http://quay.io/organization/jupyter) containing Jupyter applications and interactive computing tools.
+Jupyter Docker Stacks are a set of ready-to-run [Docker images](https://quay.io/organization/jupyter) containing Jupyter applications and interactive computing tools.
 You can use a stack image to do any of the following (and more):
 
 - Start a personal Jupyter Server with the JupyterLab frontend (default)

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Discourse badge](https://img.shields.io/discourse/users.svg?color=%23f37626&server=https%3A%2F%2Fdiscourse.jupyter.org)](https://discourse.jupyter.org/ "Jupyter Discourse Forum")
 [![Binder badge](https://static.mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/jupyter/docker-stacks/main?urlpath=lab/tree/README.ipynb "Launch a jupyter/base-notebook container on mybinder.org")
 
-Jupyter Docker Stacks are a set of ready-to-run [Docker images](https://hub.docker.com/u/jupyter) containing Jupyter applications and interactive computing tools.
+Jupyter Docker Stacks are a set of ready-to-run [Docker images](http://quay.io/organization/jupyter) containing Jupyter applications and interactive computing tools.
 You can use a stack image to do any of the following (and more):
 
 - Start a personal Jupyter Server with the JupyterLab frontend (default)
@@ -26,11 +26,11 @@ The [User Guide on ReadTheDocs](https://jupyter-docker-stacks.readthedocs.io/en/
 
 ### Example 1
 
-This command pulls the `jupyter/scipy-notebook` image tagged `2023-09-25` from Docker Hub if it is not already present on the local host.
+This command pulls the `jupyter/scipy-notebook` image tagged `2023-09-25` from Quay.io if it is not already present on the local host.
 It then starts a container running a Jupyter Server with the JupyterLab frontend and exposes the container's internal port `8888` to port `10000` of the host machine:
 
 ```bash
-docker run -p 10000:8888 docker.io/jupyter/scipy-notebook:2023-09-25
+docker run -p 10000:8888 quay.io/jupyter/scipy-notebook:2023-09-25
 ```
 
 You can modify the port on which the container's port is exposed by [changing the value of the `-p` option](https://docs.docker.com/engine/reference/run/#expose-incoming-ports) to `-p 8888:8888`.
@@ -45,11 +45,11 @@ The container remains intact for restart after the Server exits.
 
 ### Example 2
 
-This command pulls the `jupyter/datascience-notebook` image tagged `2023-09-25` from Docker Hub if it is not already present on the local host.
+This command pulls the `jupyter/datascience-notebook` image tagged `2023-09-25` from Quay.io if it is not already present on the local host.
 It then starts an _ephemeral_ container running a Jupyter Server with the JupyterLab frontend and exposes the server on host port 10000.
 
 ```bash
-docker run -it --rm -p 10000:8888 -v "${PWD}":/home/jovyan/work docker.io/jupyter/datascience-notebook:2023-09-25
+docker run -it --rm -p 10000:8888 -v "${PWD}":/home/jovyan/work quay.io/jupyter/datascience-notebook:2023-09-25
 ```
 
 The use of the `-v` flag in the command mounts the current working directory on the host (`${PWD}` in the example command) as `/home/jovyan/work` in the container.
@@ -112,7 +112,7 @@ more information is available in the [documentation](https://jupyter-docker-stac
 - [Issue Tracker on GitHub](https://github.com/jupyter/docker-stacks/issues)
 - [Jupyter Discourse Forum](https://discourse.jupyter.org/)
 - [Jupyter Website](https://jupyter.org)
-- [Images on Docker Hub](https://hub.docker.com/u/jupyter)
+- [Images on Quay.io](https://quay.io/organization/jupyter)
 
 ## CPU Architectures
 

--- a/binder/Dockerfile
+++ b/binder/Dockerfile
@@ -1,8 +1,8 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 
-# https://hub.docker.com/r/jupyter/base-notebook/tags
-ARG REGISTRY=docker.io
+# https://quay.io/repository/jupyter/base-notebook?tab=tags
+ARG REGISTRY=quay.io
 ARG OWNER=jupyter
 ARG BASE_CONTAINER=$REGISTRY/$OWNER/base-notebook:2023-09-25
 FROM $BASE_CONTAINER

--- a/docs/contributing/stacks.md
+++ b/docs/contributing/stacks.md
@@ -8,7 +8,7 @@ Following these steps will:
 
 1. Set up a project on GitHub containing a Dockerfile based on any image we provide.
 2. Configure GitHub Actions to build and test your image when users submit pull requests to your repository.
-3. Configure Docker Hub to host your images for others to use.
+3. Configure Quay.io to host your images for others to use.
 4. Update the [list of community stacks](../using/selecting.md#community-stacks) in this documentation to include your image.
 
 This approach mirrors how we build and share the core stack images.
@@ -35,8 +35,8 @@ This will serve as both the git repository name and the part of the Docker image
 stack_name [my-jupyter-stack]:
 ```
 
-Enter the user or organization name under which this stack will reside on Docker Hub.
-You must have access to manage this Docker Hub organization to push images here.
+Enter the user or organization name under which this stack will reside on Quay.io.
+You must have access to manage this Quay.io organization to push images here.
 
 ```text
 stack_org [my-project]:

--- a/docs/contributing/stacks.md
+++ b/docs/contributing/stacks.md
@@ -89,6 +89,10 @@ git push -u origin main
 
 ## Configuring Docker Hub
 
+```{note}
+Jupyter Docker Stacks are hosted on Quay.io, but in this example, we show you how to host your image on Docker Hub.
+```
+
 Now, configure Docker Hub to build your stack image and push it to the Docker Hub repository whenever
 you merge a GitHub pull request to the main branch of your project.
 

--- a/docs/maintaining/tasks.md
+++ b/docs/maintaining/tasks.md
@@ -56,7 +56,7 @@ When there's a new stack definition, check before merging the PR:
 
 ## Adding a New Maintainer Account
 
-1. Visit <https://hub.docker.com/orgs/jupyter/teams/stacks/members>
+1. Visit <https://quay.io/organization/jupyter/teams/owners>
 2. Add the maintainer's username.
 3. Visit <https://github.com/orgs/jupyter/teams/docker-image-maintainers/members>
 4. Add the maintainer's GitHub username.

--- a/docs/using/common.md
+++ b/docs/using/common.md
@@ -15,14 +15,14 @@ You can pass [Jupyter Server options](https://jupyter-server.readthedocs.io/en/l
    you can run the following (this hash was generated for the `my-password` password):
 
    ```bash
-   docker run -it --rm -p 8888:8888 docker.io/jupyter/base-notebook \
+   docker run -it --rm -p 8888:8888 quay.io/jupyter/base-notebook \
        start-notebook.py --PasswordIdentityProvider.hashed_password='argon2:$argon2id$v=19$m=10240,t=10,p=8$JdAN3fe9J45NvK/EPuGCvA$O/tbxglbwRpOFuBNTYrymAEH6370Q2z+eS1eF4GM6Do'
    ```
 
 2. To set the [base URL](https://jupyter-server.readthedocs.io/en/latest/operators/public-server.html#running-the-notebook-with-a-customized-url-prefix) of the Jupyter Server, you can run the following:
 
    ```bash
-   docker run  -it --rm -p 8888:8888 docker.io/jupyter/base-notebook \
+   docker run  -it --rm -p 8888:8888 quay.io/jupyter/base-notebook \
        start-notebook.py --ServerApp.base_url=/customized/url/prefix/
    ```
 
@@ -49,7 +49,7 @@ You do so by passing arguments to the `docker run` command.
       -e NB_USER="my-username" \
       -e CHOWN_HOME=yes \
       -w "/home/my-username" \
-      docker.io/jupyter/base-notebook
+      quay.io/jupyter/base-notebook
   ```
 
 - `-e NB_UID=<numeric uid>` - Instructs the startup script to switch the numeric user ID of `${NB_USER}` to the given value.
@@ -146,7 +146,7 @@ For example, to mount a host folder containing a `notebook.key` and `notebook.cr
 ```bash
 docker run -it --rm -p 8888:8888 \
     -v /some/host/folder:/etc/ssl/notebook \
-    docker.io/jupyter/base-notebook \
+    quay.io/jupyter/base-notebook \
     start-notebook.py \
     --ServerApp.keyfile=/etc/ssl/notebook/notebook.key \
     --ServerApp.certfile=/etc/ssl/notebook/notebook.crt
@@ -158,7 +158,7 @@ For example:
 ```bash
 docker run -it --rm -p 8888:8888 \
     -v /some/host/folder/notebook.pem:/etc/ssl/notebook.pem \
-    docker.io/jupyter/base-notebook \
+    quay.io/jupyter/base-notebook \
     start-notebook.py \
     --ServerApp.certfile=/etc/ssl/notebook.pem
 ```
@@ -207,14 +207,14 @@ Example:
 docker run -it --rm \
     -p 8888:8888 \
     -e DOCKER_STACKS_JUPYTER_CMD=notebook \
-    docker.io/jupyter/base-notebook
+    quay.io/jupyter/base-notebook
 # Executing the command: jupyter notebook ...
 
 # Use Jupyter NBClassic frontend
 docker run -it --rm \
     -p 8888:8888 \
     -e DOCKER_STACKS_JUPYTER_CMD=nbclassic \
-    docker.io/jupyter/base-notebook
+    quay.io/jupyter/base-notebook
 # Executing the command: jupyter nbclassic ...
 ```
 
@@ -225,7 +225,7 @@ The `start.sh` script supports all the features described above but allows you t
 For example, to run the text-based `ipython` console in a container, do the following:
 
 ```bash
-docker run -it --rm docker.io/jupyter/base-notebook start.sh ipython
+docker run -it --rm quay.io/jupyter/base-notebook start.sh ipython
 ```
 
 This script is handy when you derive a new Dockerfile from this image and install additional Jupyter applications with subcommands like `jupyter console`, `jupyter kernelgateway`, etc.

--- a/docs/using/recipe_code/custom_environment.dockerfile
+++ b/docs/using/recipe_code/custom_environment.dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/jupyter/base-notebook
+FROM quay.io/jupyter/base-notebook
 
 # Name your environment and choose the python version
 ARG env_name=python310

--- a/docs/using/recipe_code/dask_jupyterlab.dockerfile
+++ b/docs/using/recipe_code/dask_jupyterlab.dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/jupyter/base-notebook
+FROM quay.io/jupyter/base-notebook
 
 # Install the Dask dashboard
 RUN mamba install --yes 'dask-labextension' && \

--- a/docs/using/recipe_code/jupyterhub_version.dockerfile
+++ b/docs/using/recipe_code/jupyterhub_version.dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/jupyter/base-notebook
+FROM quay.io/jupyter/base-notebook
 
 RUN mamba install --yes 'jupyterhub==4.0.1' && \
     mamba clean --all -f -y && \

--- a/docs/using/recipe_code/mamba_install.dockerfile
+++ b/docs/using/recipe_code/mamba_install.dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/jupyter/base-notebook
+FROM quay.io/jupyter/base-notebook
 
 RUN mamba install --yes 'flake8' && \
     mamba clean --all -f -y && \

--- a/docs/using/recipe_code/manpage_install.dockerfile
+++ b/docs/using/recipe_code/manpage_install.dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/jupyter/base-notebook
+FROM quay.io/jupyter/base-notebook
 
 # Fix: https://github.com/hadolint/hadolint/wiki/DL4006
 # Fix: https://github.com/koalaman/shellcheck/wiki/SC3014

--- a/docs/using/recipe_code/microsoft_odbc.dockerfile
+++ b/docs/using/recipe_code/microsoft_odbc.dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/jupyter/base-notebook
+FROM quay.io/jupyter/base-notebook
 
 # Fix: https://github.com/hadolint/hadolint/wiki/DL4006
 # Fix: https://github.com/koalaman/shellcheck/wiki/SC3014

--- a/docs/using/recipe_code/oracledb.dockerfile
+++ b/docs/using/recipe_code/oracledb.dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/jupyter/base-notebook
+FROM quay.io/jupyter/base-notebook
 
 USER root
 

--- a/docs/using/recipe_code/pip_install.dockerfile
+++ b/docs/using/recipe_code/pip_install.dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/jupyter/base-notebook
+FROM quay.io/jupyter/base-notebook
 
 # Install in the default python3 environment
 RUN pip install --no-cache-dir 'flake8' && \

--- a/docs/using/recipe_code/rise_jupyterlab.dockerfile
+++ b/docs/using/recipe_code/rise_jupyterlab.dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/jupyter/base-notebook
+FROM quay.io/jupyter/base-notebook
 
 RUN mamba install --yes 'jupyterlab_rise' && \
     mamba clean --all -f -y && \

--- a/docs/using/recipe_code/spellcheck_notebookv6.dockerfile
+++ b/docs/using/recipe_code/spellcheck_notebookv6.dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/jupyter/base-notebook:notebook-6.5.4
+FROM quay.io/jupyter/base-notebook:notebook-6.5.4
 
 RUN pip install --no-cache-dir 'jupyter_contrib_nbextensions' && \
     jupyter contrib nbextension install --user && \

--- a/docs/using/recipe_code/xgboost.dockerfile
+++ b/docs/using/recipe_code/xgboost.dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/jupyter/base-notebook
+FROM quay.io/jupyter/base-notebook
 
 RUN mamba install --yes 'py-xgboost' && \
     mamba clean --all -f -y && \

--- a/docs/using/recipes.md
+++ b/docs/using/recipes.md
@@ -17,7 +17,7 @@ For example:
 docker run -it --rm \
     --user root \
     -e GRANT_SUDO=yes \
-    docker.io/jupyter/base-notebook
+    quay.io/jupyter/base-notebook
 ```
 
 **You should only enable `sudo` if you trust the user and/or if the container is running on an isolated host.**
@@ -298,7 +298,7 @@ This recipe is not tested and might be broken.
 ```
 
 ```dockerfile
-FROM docker.io/jupyter/all-spark-notebook
+FROM quay.io/jupyter/all-spark-notebook
 
 # Set env vars for pydoop
 ENV HADOOP_HOME /usr/local/hadoop-2.7.3
@@ -381,7 +381,7 @@ For JupyterLab:
 
 ```bash
 docker run -it --rm \
-    docker.io/jupyter/base-notebook \
+    quay.io/jupyter/base-notebook \
     start-notebook.py --IdentityProvider.token=''
 ```
 
@@ -390,7 +390,7 @@ For Jupyter Notebook:
 ```bash
 docker run -it --rm \
     -e DOCKER_STACKS_JUPYTER_CMD=notebook \
-    docker.io/jupyter/base-notebook \
+    quay.io/jupyter/base-notebook \
     start-notebook.py --IdentityProvider.token=''
 ```
 
@@ -415,7 +415,7 @@ Please note that the [Delta Lake](https://delta.io/) packages are only available
 By adding the properties to `spark-defaults.conf`, the user no longer needs to enable Delta support in each notebook.
 
 ```dockerfile
-FROM docker.io/jupyter/pyspark-notebook
+FROM quay.io/jupyter/pyspark-notebook
 
 RUN mamba install --yes 'delta-spark' && \
     mamba clean --all -f -y && \
@@ -446,7 +446,7 @@ This recipe is not tested and might be broken.
 The example below is a Dockerfile to load Source Han Sans with normal weight, usually used for the web.
 
 ```dockerfile
-FROM docker.io/jupyter/scipy-notebook
+FROM quay.io/jupyter/scipy-notebook
 
 RUN PYV=$(ls "${CONDA_DIR}/lib" | grep ^python) && \
     MPL_DATA="${CONDA_DIR}/lib/${PYV}/site-packages/matplotlib/mpl-data" && \
@@ -477,7 +477,7 @@ and add these options when running `docker`: `-e DISPLAY -v /tmp/.X11-unix:/tmp/
 docker run -it --rm \
     -e DISPLAY \
     -v /tmp/.X11-unix:/tmp/.X11-unix \
-    docker.io/jupyter/minimal-notebook
+    quay.io/jupyter/minimal-notebook
 ```
 
 ## Add ijavascript kernel to container
@@ -489,7 +489,7 @@ This recipe is not tested and might be broken.
 The example below is a Dockerfile to install the [ijavascript kernel](https://github.com/n-riesco/ijavascript).
 
 ```dockerfile
-FROM docker.io/jupyter/scipy-notebook
+FROM quay.io/jupyter/scipy-notebook
 
 # install ijavascript
 RUN npm install -g ijavascript

--- a/docs/using/running.md
+++ b/docs/using/running.md
@@ -15,12 +15,12 @@ The following are some common patterns.
 
 ### Example 1
 
-This command pulls the `jupyter/scipy-notebook` image tagged `2023-09-25` from Docker Hub if it is not already present on the local host.
+This command pulls the `jupyter/scipy-notebook` image tagged `2023-09-25` from Quay.io if it is not already present on the local host.
 It then starts a container running Jupyter Server with the JupyterLab frontend and exposes the server on host port 8888.
 The server logs appear in the terminal and include a URL to the server.
 
 ```bash
-docker run -it -p 8888:8888 docker.io/jupyter/scipy-notebook:2023-09-25
+docker run -it -p 8888:8888 quay.io/jupyter/scipy-notebook:2023-09-25
 
 # Entered start.sh with args: jupyter lab
 
@@ -53,12 +53,12 @@ docker rm 221331c047c4
 
 ### Example 2
 
-This command pulls the `jupyter/r-notebook` image tagged `2023-09-25` from Docker Hub if it is not already present on the local host.
+This command pulls the `jupyter/r-notebook` image tagged `2023-09-25` from Quay.io if it is not already present on the local host.
 It then starts a container running Server and exposes the server on host port 10000.
 The server logs appear in the terminal and include a URL to the Server, but with the internal container port (8888) instead of the correct host port (10000).
 
 ```bash
-docker run -it --rm -p 10000:8888 -v "${PWD}":/home/jovyan/work docker.io/jupyter/r-notebook:2023-09-25
+docker run -it --rm -p 10000:8888 -v "${PWD}":/home/jovyan/work quay.io/jupyter/r-notebook:2023-09-25
 ```
 
 Pressing `Ctrl-C` twice shuts down the Server and immediately destroys the Docker container.
@@ -74,11 +74,11 @@ To change the default directory, you will need to specify `ServerApp.root_dir` b
 
 ### Example 3
 
-This command pulls the `jupyter/all-spark-notebook` image currently tagged `latest` from Docker Hub if an image tagged `latest` is not already present on the local host.
+This command pulls the `jupyter/all-spark-notebook` image currently tagged `latest` from Quay.io if an image tagged `latest` is not already present on the local host.
 It then starts a container named `notebook` running a JupyterLab server and exposes the server on a randomly selected port.
 
 ```bash
-docker run --detach -P --name notebook docker.io/jupyter/all-spark-notebook
+docker run --detach -P --name notebook quay.io/jupyter/all-spark-notebook
 ```
 
 where:
@@ -137,7 +137,7 @@ subuidSize=$(( $(podman info --format "{{ range .Host.IDMappings.UIDMap }}+{{.Si
 subgidSize=$(( $(podman info --format "{{ range .Host.IDMappings.GIDMap }}+{{.Size }}{{end }}" ) - 1 ))
 ```
 
-This command pulls the `docker.io/jupyter/r-notebook` image tagged `2023-09-25` from Docker Hub if it is not already present on the local host.
+This command pulls the `quay.io/jupyter/r-notebook` image tagged `2023-09-25` from Quay.io if it is not already present on the local host.
 It then starts a container running a Jupyter Server with the JupyterLab frontend and exposes the server on host port 10000.
 The server logs appear in the terminal and include a URL to the server, but with the internal container port (8888) instead of the correct host port (10000).
 
@@ -146,7 +146,7 @@ podman run -it --rm -p 10000:8888 \
     -v "${PWD}":/home/jovyan/work --user $uid:$gid \
     --uidmap $uid:0:1 --uidmap 0:1:$uid --uidmap $(($uid+1)):$(($uid+1)):$(($subuidSize-$uid)) \
     --gidmap $gid:0:1 --gidmap 0:1:$gid --gidmap $(($gid+1)):$(($gid+1)):$(($subgidSize-$gid)) \
-    docker.io/jupyter/r-notebook:2023-09-25
+    quay.io/jupyter/r-notebook:2023-09-25
 ```
 
 ```{warning}

--- a/docs/using/selecting.md
+++ b/docs/using/selecting.md
@@ -236,7 +236,7 @@ diagram](../images/inherit.svg)](http://interactive.blockdiag.com/?compression=d
 
 ### Builds
 
-Every Monday and whenever a pull request is merged, images are rebuilt and pushed to [the public container registry](http://quay.io/organization/jupyter).
+Every Monday and whenever a pull request is merged, images are rebuilt and pushed to [the public container registry](https://quay.io/organization/jupyter).
 
 ### Versioning via image tags
 

--- a/docs/using/selecting.md
+++ b/docs/using/selecting.md
@@ -20,7 +20,7 @@ The following sections describe these images, including their contents, relation
 
 [Source on GitHub](https://github.com/jupyter/docker-stacks/tree/main/images/docker-stacks-foundation) |
 [Dockerfile commit history](https://github.com/jupyter/docker-stacks/commits/main/images/docker-stacks-foundation/Dockerfile) |
-[Docker Hub image tags](https://hub.docker.com/r/jupyter/docker-stacks-foundation/tags/)
+[Quay.io image tags](https://quay.io/repository/jupyter/docker-stacks-foundation?tab=tags)
 
 `jupyter/docker-stacks-foundation` is a small image supporting a majority of [options common across all core stacks](common.md).
 It is the basis for all other stacks on which Jupyter-related applications can be built
@@ -46,7 +46,7 @@ It contains:
 
 [Source on GitHub](https://github.com/jupyter/docker-stacks/tree/main/images/base-notebook) |
 [Dockerfile commit history](https://github.com/jupyter/docker-stacks/commits/main/images/base-notebook/Dockerfile) |
-[Docker Hub image tags](https://hub.docker.com/r/jupyter/base-notebook/tags/)
+[Quay.io image tags](https://quay.io/repository/jupyter/base-notebook?tab=tags)
 
 `jupyter/base-notebook` adds base Jupyter Applications like JupyterLab, Jupyter Notebook, JupyterHub and NBClassic
 and serves as the basis for all other stacks besides `jupyter/docker-stacks-foundation`.
@@ -71,7 +71,7 @@ The shim `.sh` files will be removed at some future date.
 
 [Source on GitHub](https://github.com/jupyter/docker-stacks/tree/main/images/minimal-notebook) |
 [Dockerfile commit history](https://github.com/jupyter/docker-stacks/commits/main/images/minimal-notebook/Dockerfile) |
-[Docker Hub image tags](https://hub.docker.com/r/jupyter/minimal-notebook/tags/)
+[Quay.io image tags](https://quay.io/repository/jupyter/minimal-notebook?tab=tags)
 
 `jupyter/minimal-notebook` adds command-line tools useful when working in Jupyter applications.
 
@@ -91,7 +91,7 @@ It contains:
 
 [Source on GitHub](https://github.com/jupyter/docker-stacks/tree/main/images/r-notebook) |
 [Dockerfile commit history](https://github.com/jupyter/docker-stacks/commits/main/images/r-notebook/Dockerfile) |
-[Docker Hub image tags](https://hub.docker.com/r/jupyter/r-notebook/tags/)
+[Quay.io image tags](https://quay.io/repository/jupyter/t-notebook?tab=tags)
 
 `jupyter/r-notebook` includes popular packages from the R ecosystem listed below:
 
@@ -122,7 +122,7 @@ It contains:
 
 [Source on GitHub](https://github.com/jupyter/docker-stacks/tree/main/images/julia-notebook) |
 [Dockerfile commit history](https://github.com/jupyter/docker-stacks/commits/main/images/julia-notebook/Dockerfile) |
-[Docker Hub image tags](https://hub.docker.com/r/jupyter/julia-notebook/tags/)
+[Quay.io image tags](https://quay.io/repository/jupyter/julia-notebook?tab=tags)
 
 `jupyter/julia-notebook` includes popular packages from the Julia ecosystem listed below:
 
@@ -136,7 +136,7 @@ It contains:
 
 [Source on GitHub](https://github.com/jupyter/docker-stacks/tree/main/images/scipy-notebook) |
 [Dockerfile commit history](https://github.com/jupyter/docker-stacks/commits/main/images/scipy-notebook/Dockerfile) |
-[Docker Hub image tags](https://hub.docker.com/r/jupyter/scipy-notebook/tags/)
+[Quay.io image tags](https://quay.io/repository/jupyter/scipy-notebook?tab=tags)
 
 `jupyter/scipy-notebook` includes popular packages from the scientific Python ecosystem.
 
@@ -180,7 +180,7 @@ It contains:
 
 [Source on GitHub](https://github.com/jupyter/docker-stacks/tree/main/images/tensorflow-notebook) |
 [Dockerfile commit history](https://github.com/jupyter/docker-stacks/commits/main/images/tensorflow-notebook/Dockerfile) |
-[Docker Hub image tags](https://hub.docker.com/r/jupyter/tensorflow-notebook/tags/)
+[Quay.io image tags](https://quay.io/repository/jupyter/tensorflow-notebook?tab=tags)
 
 `jupyter/tensorflow-notebook` includes popular Python deep learning libraries.
 
@@ -191,7 +191,7 @@ It contains:
 
 [Source on GitHub](https://github.com/jupyter/docker-stacks/tree/main/images/datascience-notebook) |
 [Dockerfile commit history](https://github.com/jupyter/docker-stacks/commits/main/images/datascience-notebook/Dockerfile) |
-[Docker Hub image tags](https://hub.docker.com/r/jupyter/datascience-notebook/tags/)
+[Quay.io image tags](https://quay.io/repository/jupyter/datascience-notebook?tab=tags)
 
 `jupyter/datascience-notebook` includes libraries for data analysis from the Python, and R, and Julia communities.
 
@@ -203,7 +203,7 @@ It contains:
 
 [Source on GitHub](https://github.com/jupyter/docker-stacks/tree/main/images/pyspark-notebook) |
 [Dockerfile commit history](https://github.com/jupyter/docker-stacks/commits/main/images/pyspark-notebook/Dockerfile) |
-[Docker Hub image tags](https://hub.docker.com/r/jupyter/pyspark-notebook/tags/)
+[Quay.io image tags](https://quay.io/repository/jupyter/pyspark-notebook?tab=tags)
 
 `jupyter/pyspark-notebook` includes Python support for Apache Spark.
 
@@ -215,7 +215,7 @@ It contains:
 
 [Source on GitHub](https://github.com/jupyter/docker-stacks/tree/main/images/all-spark-notebook) |
 [Dockerfile commit history](https://github.com/jupyter/docker-stacks/commits/main/images/all-spark-notebook/Dockerfile) |
-[Docker Hub image tags](https://hub.docker.com/r/jupyter/all-spark-notebook/tags/)
+[Quay.io image tags](https://quay.io/repository/jupyter/all-spark-notebook?tab=tags)
 
 `jupyter/all-spark-notebook` includes Python and R support for Apache Spark.
 
@@ -236,7 +236,7 @@ diagram](../images/inherit.svg)](http://interactive.blockdiag.com/?compression=d
 
 ### Builds
 
-Every Monday and whenever a pull request is merged, images are rebuilt and pushed to [the public container registry](https://hub.docker.com/u/jupyter).
+Every Monday and whenever a pull request is merged, images are rebuilt and pushed to [the public container registry](http://quay.io/organization/jupyter).
 
 ### Versioning via image tags
 

--- a/docs/using/specifics.md
+++ b/docs/using/specifics.md
@@ -14,7 +14,7 @@ This page provides details about features specific to one or more images.
   Every new spark context that is created is put onto an incrementing port (i.e. 4040, 4041, 4042, etc.), and it might be necessary to open multiple ports.
   ```
 
-  For example: `docker run --detach -p 8888:8888 -p 4040:4040 -p 4041:4041 docker.io/jupyter/pyspark-notebook`.
+  For example: `docker run --detach -p 8888:8888 -p 4040:4040 -p 4041:4041 quay.io/jupyter/pyspark-notebook`.
 
 #### IPython low-level output capture and forward
 
@@ -72,7 +72,7 @@ docker build --rm --force-rm \
     --build-arg openjdk_version=11
 
 # Check the newly built image
-docker run -it --rm docker.io/jupyter/pyspark-notebook:spark-3.2.0 pyspark --version
+docker run -it --rm quay.io/jupyter/pyspark-notebook:spark-3.2.0 pyspark --version
 
 # Welcome to
 #       ____              __

--- a/docs/using/troubleshooting.md
+++ b/docs/using/troubleshooting.md
@@ -14,7 +14,7 @@ If you are running a Docker container while mounting a local volume or host dire
 docker run -it --rm \
     -p 8888:8888 \
     -v <my-vol>:<container-dir> \
-    docker.io/jupyter/minimal-notebook:latest
+    quay.io/jupyter/minimal-notebook:latest
 ```
 
 you might face permissions issues when trying to access the mounted volume:
@@ -48,7 +48,7 @@ The following sections cover a few of these scenarios and how to fix them.
        --user root \
        -e CHOWN_EXTRA="<container-dir>" \
        -e CHOWN_EXTRA_OPTS="-R" \
-       docker.io/jupyter/minimal-notebook
+       quay.io/jupyter/minimal-notebook
    ```
 
    where:
@@ -95,7 +95,7 @@ The following sections cover a few of these scenarios and how to fix them.
        -e NB_UID=1234 \
        -e NB_GID=5678 \
        -v "${PWD}"/test:/home/jovyan/work \
-       docker.io/jupyter/minimal-notebook:latest
+       quay.io/jupyter/minimal-notebook:latest
 
    # you should see an output similar to this
    # Update jovyan's UID:GID to 1234:5678
@@ -144,7 +144,7 @@ If you have also **created a new user**, you might be experiencing any of the fo
         -e CHOWN_HOME_OPTS="-R" \
         -w "/home/callisto" \
         -v "${PWD}"/test:/home/callisto/work \
-        docker.io/jupyter/minimal-notebook
+        quay.io/jupyter/minimal-notebook
 
     # Updated the jovyan user:
     # - username: jovyan       -> callisto
@@ -187,7 +187,7 @@ If you have also **created a new user**, you might be experiencing any of the fo
        -e CHOWN_HOME_OPTS="-R" \
        -w "/home/callisto" \
        -v "${PWD}"/test:/home/callisto/work \
-       docker.io/jupyter/minimal-notebook
+       quay.io/jupyter/minimal-notebook
    ```
 
    where:
@@ -214,7 +214,7 @@ If you have also **created a new user**, you might be experiencing any of the fo
   docker run -it --rm \
       -p 8888:8888 \
       --user "$(id -u)" --group-add users \
-      -v <my-vol>:/home/jovyan/work docker.io/jupyter/datascience-notebook
+      -v <my-vol>:/home/jovyan/work quay.io/jupyter/datascience-notebook
   ```
 
   This command will launch the container with a specific user UID and add that user to the `users` group to modify the files in the default `/home` and `/opt/conda` directories.
@@ -318,7 +318,7 @@ If you are a regular user of VSCode and the Jupyter extension, you might experie
    You can see an example of mapping to local port `8001`:
 
    ```bash
-   docker run -it --rm -p 8001:8888 docker.io/jupyter/datascience-notebook
+   docker run -it --rm -p 8001:8888 quay.io/jupyter/datascience-notebook
    ```
 
    When the terminal provides the link to access Jupyter: <http://127.0.0.1:8888/lab?token=80d45d241a1ba4c2...>,

--- a/examples/docker-compose/README.md
+++ b/examples/docker-compose/README.md
@@ -42,7 +42,7 @@ You can customize the docker-stack notebook image to deploy by modifying the `no
 For example, you can build and deploy a `jupyter/all-spark-notebook` by modifying the Dockerfile like so:
 
 ```dockerfile
-FROM docker.io/jupyter/all-spark-notebook
+FROM quay.io/jupyter/all-spark-notebook
 # Your RUN commands and so on
 ```
 

--- a/examples/docker-compose/notebook/Dockerfile
+++ b/examples/docker-compose/notebook/Dockerfile
@@ -2,7 +2,7 @@
 # Distributed under the terms of the Modified BSD License.
 
 # Pick your favorite docker-stacks image
-FROM docker.io/jupyter/minimal-notebook
+FROM quay.io/jupyter/minimal-notebook
 
 USER root
 

--- a/examples/make-deploy/Dockerfile
+++ b/examples/make-deploy/Dockerfile
@@ -2,7 +2,7 @@
 # Distributed under the terms of the Modified BSD License.
 
 # Pick your favorite docker-stacks image
-FROM docker.io/jupyter/minimal-notebook
+FROM quay.io/jupyter/minimal-notebook
 
 USER root
 

--- a/images/all-spark-notebook/Dockerfile
+++ b/images/all-spark-notebook/Dockerfile
@@ -1,6 +1,6 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
-ARG REGISTRY=docker.io
+ARG REGISTRY=quay.io
 ARG OWNER=jupyter
 ARG BASE_CONTAINER=$REGISTRY/$OWNER/pyspark-notebook
 FROM $BASE_CONTAINER

--- a/images/base-notebook/Dockerfile
+++ b/images/base-notebook/Dockerfile
@@ -1,6 +1,6 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
-ARG REGISTRY=docker.io
+ARG REGISTRY=quay.io
 ARG OWNER=jupyter
 ARG BASE_CONTAINER=$REGISTRY/$OWNER/docker-stacks-foundation
 FROM $BASE_CONTAINER

--- a/images/datascience-notebook/Dockerfile
+++ b/images/datascience-notebook/Dockerfile
@@ -1,6 +1,6 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
-ARG REGISTRY=docker.io
+ARG REGISTRY=quay.io
 ARG OWNER=jupyter
 ARG BASE_CONTAINER=$REGISTRY/$OWNER/scipy-notebook
 FROM $BASE_CONTAINER

--- a/images/julia-notebook/Dockerfile
+++ b/images/julia-notebook/Dockerfile
@@ -1,6 +1,6 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
-ARG REGISTRY=docker.io
+ARG REGISTRY=quay.io
 ARG OWNER=jupyter
 ARG BASE_CONTAINER=$REGISTRY/$OWNER/minimal-notebook
 FROM $BASE_CONTAINER

--- a/images/minimal-notebook/Dockerfile
+++ b/images/minimal-notebook/Dockerfile
@@ -1,6 +1,6 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
-ARG REGISTRY=docker.io
+ARG REGISTRY=quay.io
 ARG OWNER=jupyter
 ARG BASE_CONTAINER=$REGISTRY/$OWNER/base-notebook
 FROM $BASE_CONTAINER

--- a/images/pyspark-notebook/Dockerfile
+++ b/images/pyspark-notebook/Dockerfile
@@ -1,6 +1,6 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
-ARG REGISTRY=docker.io
+ARG REGISTRY=quay.io
 ARG OWNER=jupyter
 ARG BASE_CONTAINER=$REGISTRY/$OWNER/scipy-notebook
 FROM $BASE_CONTAINER

--- a/images/r-notebook/Dockerfile
+++ b/images/r-notebook/Dockerfile
@@ -1,6 +1,6 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
-ARG REGISTRY=docker.io
+ARG REGISTRY=quay.io
 ARG OWNER=jupyter
 ARG BASE_CONTAINER=$REGISTRY/$OWNER/minimal-notebook
 FROM $BASE_CONTAINER

--- a/images/scipy-notebook/Dockerfile
+++ b/images/scipy-notebook/Dockerfile
@@ -1,6 +1,6 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
-ARG REGISTRY=docker.io
+ARG REGISTRY=quay.io
 ARG OWNER=jupyter
 ARG BASE_CONTAINER=$REGISTRY/$OWNER/minimal-notebook
 FROM $BASE_CONTAINER

--- a/images/tensorflow-notebook/Dockerfile
+++ b/images/tensorflow-notebook/Dockerfile
@@ -1,6 +1,6 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
-ARG REGISTRY=docker.io
+ARG REGISTRY=quay.io
 ARG OWNER=jupyter
 ARG BASE_CONTAINER=$REGISTRY/$OWNER/scipy-notebook
 FROM $BASE_CONTAINER

--- a/tagging/README.md
+++ b/tagging/README.md
@@ -4,8 +4,8 @@ The main purpose of the source code in this folder is to properly tag all the im
 These two processes are closely related, so the source code is widely reused.
 
 A basic example of a tag is a `python` version tag.
-For example, an image `jupyter/base-notebook` with `python 3.10.5` will have a full image name `docker.io/jupyter/base-notebook:python-3.10.5`.
-This tag (and all the other tags) are pushed to Docker Hub.
+For example, an image `jupyter/base-notebook` with `python 3.10.5` will have a full image name `quay.io/jupyter/base-notebook:python-3.10.5`.
+This tag (and all the other tags) are pushed to Quay.io.
 
 Manifest is a description of some important part of the image in a `markdown`.
 For example, we dump all the `conda` packages, including their versions.


### PR DESCRIPTION
## Describe your changes

Fix: http://github.com/jupyterhub/team-compass/issues/688

```[tasklist]
### Tasks
- [x] Adapt existing code to be able to customise the registry relatively easily
- [x] Create repos on quay.io: http://quay.io/organization/jupyter/
- [x] Add a robot to be able to be able to push images automatically
- [x] Add a token to be able to update overviews automatically
- [x] Test that changes work in my fork
- [ ] Fix badges for image stars, pulls and sizes
- [x] Get rid of all irrelevant `Docker Hub` or `hub.docker.com` mentions
- [x] Merge https://github.com/jupyter/docker-stacks/pull/2009
```

## Issue ticket if applicable

<!-- Example - Fix: https://github.com/jupyter/docker-stacks/issues/0 -->

## Checklist (especially for first-time contributors)

- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests
- [ ] I will try not to use force-push to make the review process easier for reviewers
- [ ] I have updated the documentation for significant changes

<!-- markdownlint-disable-file MD041 -->
