### PR TITLE
add grpcio grpcio_status to support spark connect

### DIFF
--- a/images/pyspark-notebook/Dockerfile
+++ b/images/pyspark-notebook/Dockerfile
@@ -75,7 +75,9 @@ USER ${NB_UID}
 # 2. Find the pandas version in the file spark/dev/infra/Dockerfile.
 RUN mamba install --yes \
     'pandas=2.0.3' \
-    'pyarrow' && \
+    'pyarrow' \
+    'grpcio' \
+    'grpcio_status' && \
     mamba clean --all -f -y && \
     fix-permissions "${CONDA_DIR}" && \
     fix-permissions "/home/${NB_USER}"


### PR DESCRIPTION
## Describe your changes

add grpcio and grpcio_status package in pyspark-notebook.

Before this pr, the pyspark-notebook:spark-3.5.0 will throw exception when connect to spark connect
![image](https://github.com/xieshuaihu/docker-stacks/assets/24190835/351a1e35-c29a-4206-9dd1-b2602838e453)

## Checklist (especially for first-time contributors)

- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests
- [ ] I will try not to use force-push to make the review process easier for reviewers
- [ ] I have updated the documentation for significant changes
