### PR TITLE
Specify multiple architectures for Julia to precompile to

### DIFF
--- a/images/minimal-notebook/setup-scripts/setup-julia-packages.bash
+++ b/images/minimal-notebook/setup-scripts/setup-julia-packages.bash
@@ -20,11 +20,11 @@ set -exuo pipefail
 if [ "$(uname -m)" == "x86_64" ]; then
     # See https://github.com/JuliaCI/julia-buildkite/blob/70bde73f6cb17d4381b62236fc2d96b1c7acbba7/utilities/build_envs.sh#L24
     # for an explanation of these options
-    JULIA_CPU_TARGET="generic;sandybridge,-xsaveopt,clone_all;haswell,-rdrnd,base(1)"
+    export JULIA_CPU_TARGET="generic;sandybridge,-xsaveopt,clone_all;haswell,-rdrnd,base(1)"
 elif [ "$(uname -m)" == "aarch64" ]; then
     # See https://github.com/JuliaCI/julia-buildkite/blob/70bde73f6cb17d4381b62236fc2d96b1c7acbba7/utilities/build_envs.sh#L54
     # for an explanation of these options
-    JULIA_CPU_TARGET="generic;cortex-a57;thunderx2t99;carmel"
+    export JULIA_CPU_TARGET="generic;cortex-a57;thunderx2t99;carmel"
 fi
 
 # Install base Julia packages

--- a/images/minimal-notebook/setup-scripts/setup-julia-packages.bash
+++ b/images/minimal-notebook/setup-scripts/setup-julia-packages.bash
@@ -5,6 +5,20 @@ set -exuo pipefail
 # - The JULIA_PKGDIR environment variable is set
 # - Julia is already set up, with the setup-julia.bash command
 
+
+# For amd64 (x86_64), we should specify what specific targets the precompilation should be done for.
+# If we don't specify it, it's *only* done for the target of the host doing the compilation.
+# When the container runs on a host that's still x86_64, but a *different* generation of CPU
+# than what the build host was, the precompilation is useless and Julia takes a long long time
+# to start up. This specific multitarget comes from https://docs.julialang.org/en/v1/devdocs/sysimg/#Specifying-multiple-system-image-targets,
+# and is the same set of options that the official Julia x86_64 build is compiled with.
+# If the architecture the container runs on is different, precompilation may still have to be
+# re-done on first startup - but this *should* catch most of the issues.
+# See https://github.com/jupyter/docker-stacks/issues/2015 for more information
+if [ $(uname -m)== "x86_64" ]; then
+    export JULIA_CPU_TARGET="generic;sandybridge,-xsaveopt,clone_all;haswell,-rdrnd,base(1)"
+fi
+
 # Install base Julia packages
 julia -e '
 import Pkg;

--- a/images/minimal-notebook/setup-scripts/setup-julia-packages.bash
+++ b/images/minimal-notebook/setup-scripts/setup-julia-packages.bash
@@ -15,7 +15,7 @@ set -exuo pipefail
 # If the architecture the container runs on is different, precompilation may still have to be
 # re-done on first startup - but this *should* catch most of the issues.
 # See https://github.com/jupyter/docker-stacks/issues/2015 for more information
-if [ $(uname -m)== "x86_64" ]; then
+if [ "$(uname -m)" == "x86_64" ]; then
     export JULIA_CPU_TARGET="generic;sandybridge,-xsaveopt,clone_all;haswell,-rdrnd,base(1)"
 fi
 

--- a/images/minimal-notebook/setup-scripts/setup-julia-packages.bash
+++ b/images/minimal-notebook/setup-scripts/setup-julia-packages.bash
@@ -6,17 +6,25 @@ set -exuo pipefail
 # - Julia is already set up, with the setup-julia.bash command
 
 
-# For amd64 (x86_64), we should specify what specific targets the precompilation should be done for.
-# If we don't specify it, it's *only* done for the target of the host doing the compilation.
-# When the container runs on a host that's still x86_64, but a *different* generation of CPU
-# than what the build host was, the precompilation is useless and Julia takes a long long time
-# to start up. This specific multitarget comes from https://docs.julialang.org/en/v1/devdocs/sysimg/#Specifying-multiple-system-image-targets,
-# and is the same set of options that the official Julia x86_64 build is compiled with.
-# If the architecture the container runs on is different, precompilation may still have to be
-# re-done on first startup - but this *should* catch most of the issues.
-# See https://github.com/jupyter/docker-stacks/issues/2015 for more information
+# If we don't specify what CPUs the precompilation should be done for, it's
+# *only* done for the target of the host doing the compilation.  When the
+# container runs on a host that's the same architecture, but a *different*
+# generation of CPU than what the build host was, the precompilation is useless
+# and Julia takes a long long time to start up. This specific multitarget comes
+# from https://github.com/JuliaCI/julia-buildkite/blob/70bde73f6cb17d4381b62236fc2d96b1c7acbba7/utilities/build_envs.sh#L20-L76,
+# and may need to be updated as new CPU generations come out.
+# If the architecture the container runs on is different,
+# precompilation may still have to be re-done on first startup - but this
+# *should* catch most of the issues.  See
+# https://github.com/jupyter/docker-stacks/issues/2015 for more information
 if [ "$(uname -m)" == "x86_64" ]; then
-    export JULIA_CPU_TARGET="generic;sandybridge,-xsaveopt,clone_all;haswell,-rdrnd,base(1)"
+    # See https://github.com/JuliaCI/julia-buildkite/blob/70bde73f6cb17d4381b62236fc2d96b1c7acbba7/utilities/build_envs.sh#L24
+    # for an explanation of these options
+    JULIA_CPU_TARGET="generic;sandybridge,-xsaveopt,clone_all;haswell,-rdrnd,base(1)"
+elif [ "$(uname -m)" == "aarch64" ]; then
+    # See https://github.com/JuliaCI/julia-buildkite/blob/70bde73f6cb17d4381b62236fc2d96b1c7acbba7/utilities/build_envs.sh#L54
+    # for an explanation of these options
+    JULIA_CPU_TARGET="generic;cortex-a57;thunderx2t99;carmel"
 fi
 
 # Install base Julia packages


### PR DESCRIPTION
## Describe your changes

For amd64 (x86_64), we should specify what specific targets the precompilation should be done for.  If we don't specify it, it's *only* done for the target of the host doing the compilation. When the container runs on a host that's still x86_64, but a *different* generation of CPU than what the build host was, the precompilation is useless and Julia takes a long long time to start up. This specific multitarget comes from
https://docs.julialang.org/en/v1/devdocs/sysimg/#Specifying-multiple-system-image-targets, and is the same set of options that the official Julia x86_64 build is compiled with.  If the architecture the container runs on is different, precompilation may still have to be re-done on first startup - but this *should* catch most of the issues.

h/t to
https://discourse.julialang.org/t/is-it-possible-to-make-precompilation-portable-for-docker-images-built-with-a-different-cpu/95913 which helped point me towards `JULIA_CPU_TARGET`.





## Issue ticket if applicable

Fixes https://github.com/jupyter/docker-stacks/issues/2015 for more information

<!-- Example - Fix: https://github.com/jupyter/docker-stacks/issues/0 -->

## Checklist (especially for first-time contributors)

- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests
- [x] I will try not to use force-push to make the review process easier for reviewers
- [x] I have updated the documentation for significant changes

<!-- markdownlint-disable-file MD041 -->
