### PR TITLE
[FAST_BUILD] Clean conda env

### DIFF
--- a/docs/using/recipe_code/custom_environment.dockerfile
+++ b/docs/using/recipe_code/custom_environment.dockerfile
@@ -33,16 +33,8 @@ RUN "${CONDA_DIR}/envs/${env_name}/bin/pip" install --no-cache-dir \
 # hadolint ignore=DL3059
 RUN /opt/setup-scripts/activate_notebook_custom_env.py "${env_name}"
 
-# Comment the line above and uncomment the section below instead to activate the custom environment by default
-# Note: uncommenting this section makes "${env_name}" default both for Jupyter Notebook and Terminals
+# Comment the line above and uncomment the line below instead
+# to activate the "${env_name}" custom environment default
+# both for Jupyter Notebook and Terminals
 # More information here: https://github.com/jupyter/docker-stacks/pull/2047
-# USER root
-# RUN \
-#     # This changes a startup hook, which will activate the custom environment for the process
-#     echo conda activate "${env_name}" >> /usr/local/bin/before-notebook.d/10activate-conda-env.sh && \
-#     # This makes the custom environment default in Jupyter Terminals for all users which might be created later
-#     echo conda activate "${env_name}" >> /etc/skel/.bashrc && \
-#     # This makes the custom environment default in Jupyter Terminals for already existing NB_USER
-#     echo conda activate "${env_name}" >> "/home/${NB_USER}/.bashrc"
-
-USER ${NB_UID}
+ENV DOCKER_STACKS_CONDA_ENV "${env_name}}"

--- a/docs/using/recipe_code/custom_environment.dockerfile
+++ b/docs/using/recipe_code/custom_environment.dockerfile
@@ -37,4 +37,4 @@ RUN /opt/setup-scripts/activate_notebook_custom_env.py "${env_name}"
 # to activate the "${env_name}" custom environment default
 # both for Jupyter Notebook and Terminals
 # More information here: https://github.com/jupyter/docker-stacks/pull/2047
-ENV DOCKER_STACKS_CONDA_ENV "${env_name}}"
+ENV DOCKER_STACKS_CONDA_ENV "${env_name}"

--- a/docs/using/recipe_code/custom_environment.dockerfile
+++ b/docs/using/recipe_code/custom_environment.dockerfile
@@ -34,7 +34,7 @@ RUN "${CONDA_DIR}/envs/${env_name}/bin/pip" install --no-cache-dir \
 RUN /opt/setup-scripts/activate_notebook_custom_env.py "${env_name}"
 
 # Comment the line above and uncomment the line below instead
-# to activate the "${env_name}" custom environment default
-# both for Jupyter Notebook and Terminals
+# to activate the "${env_name}" custom environment by default
+# for both Jupyter Notebook(s) and Terminal(s)
 # More information here: https://github.com/jupyter/docker-stacks/pull/2047
 ENV DOCKER_STACKS_CONDA_ENV "${env_name}"

--- a/images/docker-stacks-foundation/10activate-conda-env.sh
+++ b/images/docker-stacks-foundation/10activate-conda-env.sh
@@ -9,4 +9,6 @@
 # Instead, we activate "${DOCKER_STACKS_CONDA_ENV}" by default
 # This is done to provide cleaner environment when using custom conda environments
 eval "$(conda shell.bash hook | sed 's/conda activate base//g')"
+set +e
 conda activate "${DOCKER_STACKS_CONDA_ENV}"
+set -e

--- a/images/docker-stacks-foundation/10activate-conda-env.sh
+++ b/images/docker-stacks-foundation/10activate-conda-env.sh
@@ -5,7 +5,7 @@
 # This registers the initialization code for the conda shell code
 # It also activates default environment in the end, so we don't need to activate it manually
 # Documentation: https://docs.conda.io/projects/conda/en/latest/dev-guide/deep-dives/activation.html
-# Conda hook activates `base`` environment by default
+# Conda hook activates `base` environment by default
 # Instead, we activate "${DOCKER_STACKS_CONDA_ENV}" by default
 # This is done to provide cleaner environment when using custom conda environments
 eval "$(conda shell.bash hook | sed 's/conda activate base//g')"

--- a/images/docker-stacks-foundation/10activate-conda-env.sh
+++ b/images/docker-stacks-foundation/10activate-conda-env.sh
@@ -5,4 +5,8 @@
 # This registers the initialization code for the conda shell code
 # It also activates default environment in the end, so we don't need to activate it manually
 # Documentation: https://docs.conda.io/projects/conda/en/latest/dev-guide/deep-dives/activation.html
-eval "$(conda shell.bash hook)"
+# Conda hook activates `base`` environment by default
+# Instead, we activate "${DOCKER_STACKS_CONDA_ENV}" by default
+# This is done to provide cleaner environment when using custom conda environments
+eval "$(conda shell.bash hook | sed 's/conda activate base//g')"
+conda activate "${DOCKER_STACKS_CONDA_ENV}"

--- a/images/docker-stacks-foundation/Dockerfile
+++ b/images/docker-stacks-foundation/Dockerfile
@@ -64,7 +64,7 @@ COPY conda_env.bashrc /opt/
 RUN sed -i 's/^#force_color_prompt=yes/force_color_prompt=yes/' /etc/skel/.bashrc && \
     # More information in: https://github.com/jupyter/docker-stacks/pull/2047
     # and docs: https://docs.conda.io/projects/conda/en/latest/dev-guide/deep-dives/activation.html
-    cat /opy/conda_env.bashrc >> /etc/skel/.bashrc
+    cat /opt/conda_env.bashrc >> /etc/skel/.bashrc
 
 # Create NB_USER with name jovyan user with UID=1000 and in the 'users' group
 # and make sure these dirs are writable by the `users` group.
@@ -102,28 +102,28 @@ WORKDIR /tmp
 RUN set -x && \
     arch=$(uname -m) && \
     if [ "${arch}" = "x86_64" ]; then \
-    # Should be simpler, see <https://github.com/mamba-org/mamba/issues/1437>
-    arch="64"; \
+        # Should be simpler, see <https://github.com/mamba-org/mamba/issues/1437>
+        arch="64"; \
     fi && \
     wget --progress=dot:giga -O /tmp/micromamba.tar.bz2 \
-    "https://micromamba.snakepit.net/api/micromamba/linux-${arch}/latest" && \
+        "https://micromamba.snakepit.net/api/micromamba/linux-${arch}/latest" && \
     tar -xvjf /tmp/micromamba.tar.bz2 --strip-components=1 bin/micromamba && \
     rm /tmp/micromamba.tar.bz2 && \
     PYTHON_SPECIFIER="python=${PYTHON_VERSION}" && \
     if [[ "${PYTHON_VERSION}" == "default" ]]; then PYTHON_SPECIFIER="python"; fi && \
     # Install the packages
     ./micromamba install \
-    --root-prefix="${CONDA_DIR}" \
-    --prefix="${CONDA_DIR}" \
-    --yes \
-    "${PYTHON_SPECIFIER}" \
-    'mamba' \
-    'jupyter_core' && \
+        --root-prefix="${CONDA_DIR}" \
+        --prefix="${CONDA_DIR}" \
+        --yes \
+        "${PYTHON_SPECIFIER}" \
+        'mamba' \
+        'jupyter_core' && \
     rm micromamba && \
     # Temporary fix till mamba 1.5.5 is released
     # Download mamba.py after merged fix for `mamba clean`: https://github.com/mamba-org/mamba/pull/3040
     wget --progress=dot:giga https://raw.githubusercontent.com/mamba-org/mamba/cf9c063479c7bd32f1e6e8adfd04a1e15ba12981/mamba/mamba/mamba.py \
-        -O /opt/conda/lib/python3.11/site-packages/mamba/mamba.py && \
+        -O "/opt/conda/lib/python${PYTHON_VERSION}/site-packages/mamba/mamba.py" && \
     # Pin major.minor version of python
     mamba list python | grep '^python ' | tr -s ' ' | cut -d ' ' -f 1,2 >> "${CONDA_DIR}/conda-meta/pinned" && \
     mamba clean --all -f -y && \

--- a/images/docker-stacks-foundation/Dockerfile
+++ b/images/docker-stacks-foundation/Dockerfile
@@ -49,19 +49,22 @@ ENV CONDA_DIR=/opt/conda \
     LC_ALL=en_US.UTF-8 \
     LANG=en_US.UTF-8 \
     LANGUAGE=en_US.UTF-8
-ENV PATH="${CONDA_DIR}/bin:${PATH}" \
+ENV DOCKER_STACKS_CONDA_ENV=base \
+    PATH="${CONDA_DIR}/bin:${PATH}" \
     HOME="/home/${NB_USER}"
 
 # Copy a script that we will use to correct permissions after running certain commands
 COPY fix-permissions /usr/local/bin/fix-permissions
 RUN chmod a+rx /usr/local/bin/fix-permissions
 
+COPY conda_env.bashrc /opt/
+
 # Enable prompt color in the skeleton .bashrc before creating the default NB_USER
 # hadolint ignore=SC2016
 RUN sed -i 's/^#force_color_prompt=yes/force_color_prompt=yes/' /etc/skel/.bashrc && \
     # More information in: https://github.com/jupyter/docker-stacks/pull/2047
     # and docs: https://docs.conda.io/projects/conda/en/latest/dev-guide/deep-dives/activation.html
-    echo 'eval "$(conda shell.bash hook)"' >> /etc/skel/.bashrc
+    cat /opy/conda_env.bashrc >> /etc/skel/.bashrc
 
 # Create NB_USER with name jovyan user with UID=1000 and in the 'users' group
 # and make sure these dirs are writable by the `users` group.
@@ -99,28 +102,28 @@ WORKDIR /tmp
 RUN set -x && \
     arch=$(uname -m) && \
     if [ "${arch}" = "x86_64" ]; then \
-        # Should be simpler, see <https://github.com/mamba-org/mamba/issues/1437>
-        arch="64"; \
+    # Should be simpler, see <https://github.com/mamba-org/mamba/issues/1437>
+    arch="64"; \
     fi && \
     wget --progress=dot:giga -O /tmp/micromamba.tar.bz2 \
-        "https://micromamba.snakepit.net/api/micromamba/linux-${arch}/latest" && \
+    "https://micromamba.snakepit.net/api/micromamba/linux-${arch}/latest" && \
     tar -xvjf /tmp/micromamba.tar.bz2 --strip-components=1 bin/micromamba && \
     rm /tmp/micromamba.tar.bz2 && \
     PYTHON_SPECIFIER="python=${PYTHON_VERSION}" && \
     if [[ "${PYTHON_VERSION}" == "default" ]]; then PYTHON_SPECIFIER="python"; fi && \
     # Install the packages
     ./micromamba install \
-        --root-prefix="${CONDA_DIR}" \
-        --prefix="${CONDA_DIR}" \
-        --yes \
-        "${PYTHON_SPECIFIER}" \
-        'mamba' \
-        'jupyter_core' && \
+    --root-prefix="${CONDA_DIR}" \
+    --prefix="${CONDA_DIR}" \
+    --yes \
+    "${PYTHON_SPECIFIER}" \
+    'mamba' \
+    'jupyter_core' && \
     rm micromamba && \
     # Temporary fix till mamba 1.5.5 is released
     # Download mamba.py after merged fix for `mamba clean`: https://github.com/mamba-org/mamba/pull/3040
     wget --progress=dot:giga https://raw.githubusercontent.com/mamba-org/mamba/cf9c063479c7bd32f1e6e8adfd04a1e15ba12981/mamba/mamba/mamba.py \
-        -O /opt/conda/lib/python3.11/site-packages/mamba/mamba.py && \
+    -O /opt/conda/lib/python3.11/site-packages/mamba/mamba.py && \
     # Pin major.minor version of python
     mamba list python | grep '^python ' | tr -s ' ' | cut -d ' ' -f 1,2 >> "${CONDA_DIR}/conda-meta/pinned" && \
     mamba clean --all -f -y && \

--- a/images/docker-stacks-foundation/conda_env.bashrc
+++ b/images/docker-stacks-foundation/conda_env.bashrc
@@ -1,2 +1,4 @@
 eval "$(conda shell.bash hook | sed 's/conda activate base//g')"
+set +e
 conda activate "${DOCKER_STACKS_CONDA_ENV}"
+set -e

--- a/images/docker-stacks-foundation/conda_env.bashrc
+++ b/images/docker-stacks-foundation/conda_env.bashrc
@@ -1,0 +1,2 @@
+eval "$(conda shell.bash hook | sed 's/conda activate base//g')"
+conda activate "${DOCKER_STACKS_CONDA_ENV}"

--- a/images/minimal-notebook/setup-scripts/activate_notebook_custom_env.py
+++ b/images/minimal-notebook/setup-scripts/activate_notebook_custom_env.py
@@ -16,9 +16,8 @@ content["env"] = {
     "PATH": f"{CONDA_DIR}/envs/{env_name}/bin:$PATH",
     "CONDA_PREFIX": f"{CONDA_DIR}/envs/{env_name}",
     "CONDA_PROMPT_MODIFIER": f"({env_name}) ",
-    "CONDA_SHLVL": "2",
+    "CONDA_SHLVL": "1",
     "CONDA_DEFAULT_ENV": env_name,
-    "CONDA_PREFIX_1": CONDA_DIR,
 }
 
 file.write_text(json.dumps(content, indent=1))


### PR DESCRIPTION
## Describe your changes

Introduce the env variable which environment to activate by default.
This makes the custom env recipe smaller.
Also eliminates the problem of double activation in the case of a custom environment (if you call `bash` a few times, you will get a `base, custom, base, custom, base, custom...` chain).

## Issue ticket if applicable

<!-- Example - Fix: https://github.com/jupyter/docker-stacks/issues/0 -->

## Checklist (especially for first-time contributors)

- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests
- [ ] I will try not to use force-push to make the review process easier for reviewers
- [ ] I have updated the documentation for significant changes

<!-- markdownlint-disable-file MD041 -->
