### PR TITLE
Link to the rocker/binder image as an alternative

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,9 +125,9 @@ for information about how to contribute recipes, features, tests, and community-
 
 ## Alternatives
 
-- [rocker/binder](https://rocker-project.org/images/versioned/binder.html) - From the R
-  focused [rocker-project](https://rocker-project.org), lets you run both RStudio and Jupyter
-  either standalone or in a JupyterHub.
+- [rocker/binder](https://rocker-project.org/images/versioned/binder.html) -
+  From the R focused [rocker-project](https://rocker-project.org),
+  lets you run both RStudio and Jupyter either standalone or in a JupyterHub
 - [jupyter/repo2docker](https://github.com/jupyterhub/repo2docker) -
   Turn git repositories into Jupyter-enabled Docker Images
 - [openshift/source-to-image](https://github.com/openshift/source-to-image) -

--- a/README.md
+++ b/README.md
@@ -125,6 +125,9 @@ for information about how to contribute recipes, features, tests, and community-
 
 ## Alternatives
 
+- [rocker/binder](https://rocker-project.org/images/versioned/binder.html) - From the R
+  focused [rocker-project](https://rocker-project.org), lets you run both RStudio and Jupyter
+  either standalone or in a JupyterHub.
 - [jupyter/repo2docker](https://github.com/jupyterhub/repo2docker) -
   Turn git repositories into Jupyter-enabled Docker Images
 - [openshift/source-to-image](https://github.com/openshift/source-to-image) -


### PR DESCRIPTION
## Describe your changes

Link to the [rocker/binder](https://rocker-project.org/images/versioned/binder.html) image
as a potential alternative, maintained by the R focused [rocker-project](https://rocker-project.org).

I think of the rocker project as the R equivalent of jupyter/docker-stacks (they maintain
many images in that field!) and it would be good to crosslink.

## Checklist (especially for first-time contributors)

- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests
- [x] I will try not to use force-push to make the review process easier for reviewers
- [x] I have updated the documentation for significant changes

<!-- markdownlint-disable-file MD041 -->
