### PR TITLE
[FAST_BUILD] Fix Docker healthcheck when using custom runtime dirs

### DIFF
--- a/images/base-notebook/docker_healthcheck.py
+++ b/images/base-notebook/docker_healthcheck.py
@@ -2,8 +2,8 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 import json
-from pathlib import Path
 import warnings
+from pathlib import Path
 
 import requests
 

--- a/images/base-notebook/docker_healthcheck.py
+++ b/images/base-notebook/docker_healthcheck.py
@@ -11,12 +11,16 @@ import requests
 # Several operations below deliberately don't check for possible errors
 # As this is a healthcheck, it should succeed or raise an exception on error
 
+# Docker runs healtchecks using an exec
+# It uses the default user configured when running the image: root for the case of a custom NB_USER or jovyan for the case of the default image user.
+# We manually change HOME to make `jupyter --runtime-dir` report a correct path
+# More information: <https://github.com/jupyter/docker-stacks/pull/2074#issuecomment-1879778409>
 result = subprocess.run(
     ["jupyter", "--runtime-dir"],
     check=True,
     capture_output=True,
     text=True,
-    env=dict(os.environ) | {"HOME": str(Path("/home") / os.environ["NB_USER"])},
+    env=dict(os.environ) | {"HOME": "/home" + os.environ["NB_USER"]},
 )
 runtime_dir = Path(result.stdout.rstrip())
 

--- a/images/base-notebook/docker_healthcheck.py
+++ b/images/base-notebook/docker_healthcheck.py
@@ -20,7 +20,7 @@ result = subprocess.run(
     check=True,
     capture_output=True,
     text=True,
-    env=dict(os.environ) | {"HOME": "/home" + os.environ["NB_USER"]},
+    env=dict(os.environ) | {"HOME": "/home/" + os.environ["NB_USER"]},
 )
 runtime_dir = Path(result.stdout.rstrip())
 

--- a/images/base-notebook/docker_healthcheck.py
+++ b/images/base-notebook/docker_healthcheck.py
@@ -2,6 +2,7 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 import json
+import os
 import warnings
 from pathlib import Path
 
@@ -11,6 +12,10 @@ import requests
 with warnings.catch_warnings():
     warnings.filterwarnings("ignore", category=DeprecationWarning)
     from jupyter_core import paths
+
+# Set HOME according to the user in NB_USER
+# This is necessary for paths.jupyter_runtime_dir() to work correctly
+os.environ["HOME"] = str(Path("/home") / os.environ["NB_USER"])
 
 # Several operations below deliberately don't check for possible errors
 # As this is a healthcheck, it should succeed or raise an exception on error

--- a/images/base-notebook/docker_healthcheck.py
+++ b/images/base-notebook/docker_healthcheck.py
@@ -2,15 +2,20 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 import json
-import os
 from pathlib import Path
+import warnings
 
 import requests
+
+# Import Jupyter paths ignoring deprecation warning that does not affect this script
+with warnings.catch_warnings():
+    warnings.filterwarnings("ignore", category=DeprecationWarning)
+    from jupyter_core import paths
 
 # Several operations below deliberately don't check for possible errors
 # As this is a healthcheck, it should succeed or raise an exception on error
 
-runtime_dir = Path("/home/") / os.environ["NB_USER"] / ".local/share/jupyter/runtime/"
+runtime_dir = Path(paths.jupyter_runtime_dir())
 json_file = next(runtime_dir.glob("*server-*.json"))
 
 url = json.loads(json_file.read_bytes())["url"]

--- a/mypy.ini
+++ b/mypy.ini
@@ -24,9 +24,6 @@ ignore_missing_imports = True
 [mypy-docker.*]
 ignore_missing_imports = True
 
-[mypy-jupyter_core.*]
-ignore_missing_imports = True
-
 [mypy-matplotlib.*]
 ignore_missing_imports = True
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -24,6 +24,9 @@ ignore_missing_imports = True
 [mypy-docker.*]
 ignore_missing_imports = True
 
+[mypy-jupyter_core.*]
+ignore_missing_imports = True
+
 [mypy-matplotlib.*]
 ignore_missing_imports = True
 

--- a/tests/base-notebook/test_healthcheck.py
+++ b/tests/base-notebook/test_healthcheck.py
@@ -42,6 +42,7 @@ LOGGER = logging.getLogger(__name__)
             ["start-notebook.py", "--ServerApp.base_url=/test"],
             "root",
         ),
+        (["JUPYTER_RUNTIME_DIR=/jupyter-runtime"], ["start-notebook.sh"], None),
     ],
 )
 def test_health(

--- a/tests/base-notebook/test_healthcheck.py
+++ b/tests/base-notebook/test_healthcheck.py
@@ -43,6 +43,15 @@ LOGGER = logging.getLogger(__name__)
             "root",
         ),
         (["JUPYTER_RUNTIME_DIR=/tmp/jupyter-runtime"], ["start-notebook.sh"], None),
+        (
+            [
+                "NB_USER=testuser",
+                "CHOWN_HOME=1",
+                "JUPYTER_RUNTIME_DIR=/tmp/jupyter-runtime",
+            ],
+            ["start-notebook.sh"],
+            "root",
+        ),
     ],
 )
 def test_health(

--- a/tests/base-notebook/test_healthcheck.py
+++ b/tests/base-notebook/test_healthcheck.py
@@ -42,7 +42,7 @@ LOGGER = logging.getLogger(__name__)
             ["start-notebook.py", "--ServerApp.base_url=/test"],
             "root",
         ),
-        (["JUPYTER_RUNTIME_DIR=/jupyter-runtime"], ["start-notebook.sh"], None),
+        (["JUPYTER_RUNTIME_DIR=/tmp/jupyter-runtime"], ["start-notebook.sh"], None),
     ],
 )
 def test_health(


### PR DESCRIPTION
## Describe your changes

This PR fixes the Docker healthcheck script in `base-notebook` when using custom runtime dirs.

## Issue ticket if applicable

Fix #2073 

## Checklist (especially for first-time contributors)

- [X] I have performed a self-review of my code
- [X] If it is a core feature, I have added thorough tests
- [X] I will try not to use force-push to make the review process easier for reviewers
- [X] I have updated the documentation for significant changes

<!-- markdownlint-disable-file MD041 -->
