### PR TITLE
Fix `max(stable_versions)` on Julia version finding

### DIFF
--- a/images/minimal-notebook/setup-scripts/setup_julia.py
+++ b/images/minimal-notebook/setup-scripts/setup_julia.py
@@ -37,8 +37,7 @@ def get_latest_julia_url() -> tuple[str, str]:
     ).json()
     stable_versions = {k: v for k, v in versions.items() if v["stable"]}
     latest_stable_version = max(
-        stable_versions,
-        key=lambda ver: [int(sub_ver) for sub_ver in ver.split(".")]
+        stable_versions, key=lambda ver: [int(sub_ver) for sub_ver in ver.split(".")]
     )
     latest_version_files = stable_versions[latest_stable_version]["files"]
     triplet = unify_aarch64(platform.machine()) + "-linux-gnu"

--- a/images/minimal-notebook/setup-scripts/setup_julia.py
+++ b/images/minimal-notebook/setup-scripts/setup_julia.py
@@ -36,10 +36,12 @@ def get_latest_julia_url() -> tuple[str, str]:
         "https://julialang-s3.julialang.org/bin/versions.json"
     ).json()
     stable_versions = {k: v for k, v in versions.items() if v["stable"]}
-    version_keys = {tuple(map(int, key.split("."))) for key in stable_versions.keys()}
-    latest_version = max(version_keys)
-    latest_version_str = ".".join(map(str, latest_version))
-    latest_version_files = stable_versions[latest_version_str]["files"]
+    latest_version_files = stable_versions[
+        max(
+            stable_versions,
+            key=lambda ver: [int(sub_ver) for sub_ver in ver.split(".")],
+        )
+    ]
     triplet = unify_aarch64(platform.machine()) + "-linux-gnu"
     file_info = [vf for vf in latest_version_files if vf["triplet"] == triplet][0]
     return file_info["url"], file_info["version"]

--- a/images/minimal-notebook/setup-scripts/setup_julia.py
+++ b/images/minimal-notebook/setup-scripts/setup_julia.py
@@ -41,7 +41,7 @@ def get_latest_julia_url() -> tuple[str, str]:
             stable_versions,
             key=lambda ver: [int(sub_ver) for sub_ver in ver.split(".")],
         )
-    ]
+    ]["files"]
     triplet = unify_aarch64(platform.machine()) + "-linux-gnu"
     file_info = [vf for vf in latest_version_files if vf["triplet"] == triplet][0]
     return file_info["url"], file_info["version"]

--- a/images/minimal-notebook/setup-scripts/setup_julia.py
+++ b/images/minimal-notebook/setup-scripts/setup_julia.py
@@ -36,12 +36,11 @@ def get_latest_julia_url() -> tuple[str, str]:
         "https://julialang-s3.julialang.org/bin/versions.json"
     ).json()
     stable_versions = {k: v for k, v in versions.items() if v["stable"]}
-    latest_version_files = stable_versions[
-        max(
-            stable_versions,
-            key=lambda ver: [int(sub_ver) for sub_ver in ver.split(".")],
-        )
-    ]["files"]
+    latest_stable_version = max(
+        stable_versions,
+        key=lambda ver: [int(sub_ver) for sub_ver in ver.split(".")]
+    )
+    latest_version_files = stable_versions[latest_stable_version]["files"]
     triplet = unify_aarch64(platform.machine()) + "-linux-gnu"
     file_info = [vf for vf in latest_version_files if vf["triplet"] == triplet][0]
     return file_info["url"], file_info["version"]

--- a/images/minimal-notebook/setup-scripts/setup_julia.py
+++ b/images/minimal-notebook/setup-scripts/setup_julia.py
@@ -36,7 +36,10 @@ def get_latest_julia_url() -> tuple[str, str]:
         "https://julialang-s3.julialang.org/bin/versions.json"
     ).json()
     stable_versions = {k: v for k, v in versions.items() if v["stable"]}
-    latest_version_files = stable_versions[max(stable_versions)]["files"]
+    version_keys = {tuple(map(int, key.split("."))) for key in stable_versions.keys()}
+    latest_version = max(version_keys)
+    latest_version_str = ".".join(map(str, latest_version))
+    latest_version_files = stable_versions[latest_version_str]["files"]
     triplet = unify_aarch64(platform.machine()) + "-linux-gnu"
     file_info = [vf for vf in latest_version_files if vf["triplet"] == triplet][0]
     return file_info["url"], file_info["version"]


### PR DESCRIPTION
## Describe your changes

Since the keys are semantic version strings, that means that `"1.9.4" > "1.10.0"`, which we know isn't true. 🙂

I just added some code to convert the string to tuples, find the max, then convert back to a string.

I first noticed this on the `2024-01-05` build of the `datascience-notebook`, since Julia 1.10.0 was released ~2 weeks ago: https://github.com/JuliaLang/julia/releases/tag/v1.10.0.

## Issue ticket if applicable

<!-- Example - Fix: https://github.com/jupyter/docker-stacks/issues/0 -->

## Checklist (especially for first-time contributors)

- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests
- [x] I will try not to use force-push to make the review process easier for reviewers
- [ ] I have updated the documentation for significant changes

<!-- markdownlint-disable-file MD041 -->
