### PR TITLE
Don't default to US-specific locale settings

### DIFF
--- a/images/docker-stacks-foundation/Dockerfile
+++ b/images/docker-stacks-foundation/Dockerfile
@@ -38,6 +38,7 @@ RUN apt-get update --yes && \
     wget && \
     apt-get clean && rm -rf /var/lib/apt/lists/* && \
     echo "en_US.UTF-8 UTF-8" > /etc/locale.gen && \
+    echo "C.UTF-8 UTF-8" >> /etc/locale.gen && \
     locale-gen
 
 # Configure environment
@@ -46,9 +47,9 @@ ENV CONDA_DIR=/opt/conda \
     NB_USER="${NB_USER}" \
     NB_UID=${NB_UID} \
     NB_GID=${NB_GID} \
-    LC_ALL=en_US.UTF-8 \
-    LANG=en_US.UTF-8 \
-    LANGUAGE=en_US.UTF-8
+    LC_ALL=C.UTF-8 \
+    LANG=C.UTF-8 \
+    LANGUAGE=C.UTF-8
 ENV PATH="${CONDA_DIR}/bin:${PATH}" \
     HOME="/home/${NB_USER}"
 


### PR DESCRIPTION
## Describe your changes

I'd expect that if a user wants a particular locale settings they should set it explicitly for themselves. It feels US-centric to default to `en_US`. So let's still generate the `en_US` to make it easier in case people want to change it back, but default to the more standard `C`omputer [format](https://stackoverflow.com/q/55673886).

The `C` option is more sane with things like 24-hr times when running the `date` command.

## Issue ticket if applicable

<!-- Example - Fix: https://github.com/jupyter/docker-stacks/issues/0 -->

## Checklist (especially for first-time contributors)

- [X] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests
- [X] I will try not to use force-push to make the review process easier for reviewers
- [ ] I have updated the documentation for significant changes

<!-- markdownlint-disable-file MD041 -->
