### PR TITLE
Clean overlay2 on each run in aarch64 runners

### DIFF
--- a/.github/workflows/docker-build-test-upload.yml
+++ b/.github/workflows/docker-build-test-upload.yml
@@ -67,6 +67,12 @@ jobs:
           docker rm $(docker ps --all --quiet) || true
           docker system prune --all --force
           rm -rf /tmp/jupyter/
+
+          # Unfortunately, steps above are not enough for docker to completely clean overlay2
+          # So, we remove it manually before each `docker build` run
+          sudo systemctl stop docker
+          sudo rm -rf /var/lib/docker
+          sudo systemctl start docker
         shell: bash
 
       - name: Load parent built image to Docker 📥


### PR DESCRIPTION
## Describe your changes

## Issue ticket if applicable

<!-- Example - Fix: https://github.com/jupyter/docker-stacks/issues/0 -->

## Checklist (especially for first-time contributors)

- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests
- [ ] I will try not to use force-push to make the review process easier for reviewers
- [ ] I have updated the documentation for significant changes

<!-- markdownlint-disable-file MD041 -->
