### PR TITLE
Updated header level to fit rest of the page

### DIFF
--- a/docs/using/selecting.md
+++ b/docs/using/selecting.md
@@ -16,7 +16,7 @@ This section provides details about the first.
 The Jupyter team maintains a set of Docker image definitions in the <https://github.com/jupyter/docker-stacks> GitHub repository.
 The following sections describe these images, including their contents, relationships, and versioning strategy.
 
-## CUDA enabled variant
+### CUDA enabled variant
 
 We provide CUDA accelerated version of `pytorch-notebook` and `tensorflow-notebook` images.
 Prepend a CUDA prefix (versioned prefix like `cuda12-` for `pytorch-notebook` or just `cuda-` for `tensorflow-notebook`) to the image tag


### PR DESCRIPTION
## Describe your changes

This is a minor change regarding the header levels. I believe the intent was to have levels:

Selecting an Image
- Core Stacks
  - CUDA Enabled Variant
  - jupyter/docker-stacks-foundation
  - jupyter/base-notebook
  - jupyter/minimal-notebook
  - ...
- ...

The current iteration seems to indicate that `jupyter/...` derives from the "CUDA Enabled Variant" header when really it is part of the core stack.

In general, I would propose a reorganization of this particular page for additional clarity (perhaps in a future pull request). Mainly I would suggest just moving certain things around and changing some of the header levels.

## Issue ticket if applicable

N/A

## Checklist (especially for first-time contributors)

- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests
- [x] I will try not to use force-push to make the review process easier for reviewers
- [ ] I have updated the documentation for significant changes

<!-- markdownlint-disable-file MD041 -->
