### PR TITLE
Put nvidia-smi on path for cuda image variants

### DIFF
--- a/images/pytorch-notebook/cuda11/Dockerfile
+++ b/images/pytorch-notebook/cuda11/Dockerfile
@@ -24,7 +24,7 @@ RUN pip install --no-cache-dir --extra-index-url=https://pypi.nvidia.com --index
 ENV NVIDIA_VISIBLE_DEVICES all
 ENV NVIDIA_DRIVER_CAPABILITIES compute,utility
 
-# Puts the nvidia-smi binary (system management interface) on path with
-# associated library files to execute it
+# Puts the nvidia-smi binary (system management interface) on path
+# with associated library files to execute it
 ENV PATH=${PATH}:/usr/local/nvidia/bin
 ENV LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/usr/local/nvidia/lib64

--- a/images/pytorch-notebook/cuda11/Dockerfile
+++ b/images/pytorch-notebook/cuda11/Dockerfile
@@ -23,3 +23,8 @@ RUN pip install --no-cache-dir --extra-index-url=https://pypi.nvidia.com --index
 # https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/docker-specialized.html#dockerfiles
 ENV NVIDIA_VISIBLE_DEVICES all
 ENV NVIDIA_DRIVER_CAPABILITIES compute,utility
+
+# Puts the nvidia-smi binary (system management interface) on path with
+# associated library files to execute it
+ENV PATH=${PATH}:/usr/local/nvidia/bin
+ENV LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/usr/local/nvidia/lib64

--- a/images/pytorch-notebook/cuda12/Dockerfile
+++ b/images/pytorch-notebook/cuda12/Dockerfile
@@ -24,7 +24,7 @@ RUN pip install --no-cache-dir --extra-index-url=https://pypi.nvidia.com --index
 ENV NVIDIA_VISIBLE_DEVICES all
 ENV NVIDIA_DRIVER_CAPABILITIES compute,utility
 
-# Puts the nvidia-smi binary (system management interface) on path with
-# associated library files to execute it
+# Puts the nvidia-smi binary (system management interface) on path
+# with associated library files to execute it
 ENV PATH=${PATH}:/usr/local/nvidia/bin
 ENV LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/usr/local/nvidia/lib64

--- a/images/pytorch-notebook/cuda12/Dockerfile
+++ b/images/pytorch-notebook/cuda12/Dockerfile
@@ -23,3 +23,8 @@ RUN pip install --no-cache-dir --extra-index-url=https://pypi.nvidia.com --index
 # https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/docker-specialized.html#dockerfiles
 ENV NVIDIA_VISIBLE_DEVICES all
 ENV NVIDIA_DRIVER_CAPABILITIES compute,utility
+
+# Puts the nvidia-smi binary (system management interface) on path with
+# associated library files to execute it
+ENV PATH=${PATH}:/usr/local/nvidia/bin
+ENV LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/usr/local/nvidia/lib64

--- a/images/tensorflow-notebook/cuda/Dockerfile
+++ b/images/tensorflow-notebook/cuda/Dockerfile
@@ -26,7 +26,7 @@ COPY --chown="${NB_UID}:${NB_GID}" nvidia-lib-dirs.sh "${CONDA_DIR}/etc/conda/ac
 ENV NVIDIA_VISIBLE_DEVICES="all" \
     NVIDIA_DRIVER_CAPABILITIES="compute,utility"
 
-# Puts the nvidia-smi binary (system management interface) on path with
-# associated library files to execute it
+# Puts the nvidia-smi binary (system management interface) on path
+# with associated library files to execute it
 ENV PATH=${PATH}:/usr/local/nvidia/bin
 ENV LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/usr/local/nvidia/lib64

--- a/images/tensorflow-notebook/cuda/Dockerfile
+++ b/images/tensorflow-notebook/cuda/Dockerfile
@@ -25,3 +25,8 @@ COPY --chown="${NB_UID}:${NB_GID}" nvidia-lib-dirs.sh "${CONDA_DIR}/etc/conda/ac
 # https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/docker-specialized.html#dockerfiles
 ENV NVIDIA_VISIBLE_DEVICES="all" \
     NVIDIA_DRIVER_CAPABILITIES="compute,utility"
+
+# Puts the nvidia-smi binary (system management interface) on path with
+# associated library files to execute it
+ENV PATH=${PATH}:/usr/local/nvidia/bin
+ENV LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/usr/local/nvidia/lib64

--- a/images/tensorflow-notebook/cuda/nvidia-lib-dirs.sh
+++ b/images/tensorflow-notebook/cuda/nvidia-lib-dirs.sh
@@ -2,8 +2,8 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 
-# This adds the NVIDIA libraries to the LD_LIBRARY_PATH. Workaround for
-# https://github.com/tensorflow/tensorflow/issues/63362
+# This adds NVIDIA Python package libraries to the LD_LIBRARY_PATH. Workaround
+# for https://github.com/tensorflow/tensorflow/issues/63362
 NVIDIA_DIR=$(dirname "$(python -c 'import nvidia;print(nvidia.__file__)')")
 LD_LIBRARY_PATH=$(echo "${NVIDIA_DIR}"/*/lib/ | sed -r 's/\s+/:/g')${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
 export LD_LIBRARY_PATH

--- a/images/tensorflow-notebook/cuda/nvidia-lib-dirs.sh
+++ b/images/tensorflow-notebook/cuda/nvidia-lib-dirs.sh
@@ -2,8 +2,8 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 
-# This adds NVIDIA Python package libraries to the LD_LIBRARY_PATH. Workaround
-# for https://github.com/tensorflow/tensorflow/issues/63362
+# This adds NVIDIA Python package libraries to the LD_LIBRARY_PATH.
+# Workaround for https://github.com/tensorflow/tensorflow/issues/63362
 NVIDIA_DIR=$(dirname "$(python -c 'import nvidia;print(nvidia.__file__)')")
 LD_LIBRARY_PATH=$(echo "${NVIDIA_DIR}"/*/lib/ | sed -r 's/\s+/:/g')${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
 export LD_LIBRARY_PATH


### PR DESCRIPTION
## Describe your changes

When using the tensorflow / pytorch images with cuda-variants I expect the ability to work with `nvidia-smi` (system management interface CLI) as in pangeo/pangeo-docker-images (https://github.com/pangeo-data/pangeo-docker-images/blob/09649eb48226cf851d2a8b1d714b850902faa26f/pytorch-notebook/Dockerfile#L8-L12). For this to work though, it needs to be put on PATH and misc library files put on LD_LIBRARY_PATH.

This PR makes that happen for the cuda variant images that prepares other things for work where nvidia drivers gets installed.

## Issue ticket if applicable

<!-- Example - Fix: https://github.com/jupyter/docker-stacks/issues/0 -->

## Checklist (especially for first-time contributors)

- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests
  > I'm not sure if this merits a test, if so it should be conditional to the cuda variants specifically to check for the environment variables.
- [x] I will try not to use force-push to make the review process easier for reviewers
- [ ] I have updated the documentation for significant changes
  > I considered this, but it seems that https://jupyter-docker-stacks.readthedocs.io/en/latest/using/selecting.html#cuda-enabled-variant doesn't merit update.

<!-- markdownlint-disable-file MD041 -->
