### PR TITLE
Add netbase to docker-stacks-foundation image - fixes #2128

### DIFF
--- a/images/docker-stacks-foundation/Dockerfile
+++ b/images/docker-stacks-foundation/Dockerfile
@@ -30,6 +30,7 @@ RUN apt-get update --yes && \
     bzip2 \
     ca-certificates \
     locales \
+    netbase \
     sudo \
     # - `tini` is installed as a helpful container entrypoint,
     #   that reaps zombie processes and such of the actual executable we want to start

--- a/images/docker-stacks-foundation/Dockerfile
+++ b/images/docker-stacks-foundation/Dockerfile
@@ -30,6 +30,9 @@ RUN apt-get update --yes && \
     bzip2 \
     ca-certificates \
     locales \
+    # - `netbase` provides /etc/{protocols,rpc,services}, part of POSIX
+    #   and required by various C functions like getservbyname and getprotobyname
+    #   https://github.com/jupyter/docker-stacks/pull/2129
     netbase \
     sudo \
     # - `tini` is installed as a helpful container entrypoint,


### PR DESCRIPTION
## Describe your changes

Add the [netbase Ubuntu package](https://ubuntu.pkgs.org/22.04/ubuntu-main-amd64/netbase_6.3_all.deb.html) to the docker-stacks-foundation image.

This could also go in base, or minimal, but as a part of POSIX it seems like this belongs in the foundation image. It also seems analogous to the locales package installed in the same spot.

## Issue ticket if applicable

Fix: https://github.com/jupyter/docker-stacks/issues/2128

## Checklist (especially for first-time contributors)

- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests
- [x] I will try not to use force-push to make the review process easier for reviewers
- [ ] I have updated the documentation for significant changes

<!-- markdownlint-disable-file MD041 -->
