### PR TITLE
[FAST_BUILD] No sudo when run with rootless triplet

### DIFF
--- a/images/docker-stacks-foundation/start.sh
+++ b/images/docker-stacks-foundation/start.sh
@@ -155,11 +155,14 @@ if [ "$(id -u)" == 0 ]; then
     unset_explicit_env_vars
 
     _log "Running as ${NB_USER}:" "${cmd[@]}"
-    exec sudo --preserve-env --set-home --user "${NB_USER}" \
-        LD_LIBRARY_PATH="${LD_LIBRARY_PATH}" \
-        PATH="${PATH}" \
-        PYTHONPATH="${PYTHONPATH:-}" \
-        "${cmd[@]}"
+    if [ "${NB_USER}" = "root" ] && [ "${NB_UID}" = "$(id -u "${NB_USER}")" ] && [ "${NB_GID}" = "$(id -g "${NB_USER}")" ]; then
+        HOME="/home/root" exec "${cmd[@]}"
+    else
+        exec sudo --preserve-env --set-home --user "${NB_USER}" \
+            LD_LIBRARY_PATH="${LD_LIBRARY_PATH}" \
+            PATH="${PATH}" \
+            PYTHONPATH="${PYTHONPATH:-}" \
+            "${cmd[@]}"
         # Notes on how we ensure that the environment that this container is started
         # with is preserved (except vars listed in JUPYTER_ENV_VARS_TO_UNSET) when
         # we transition from running as root to running as NB_USER.
@@ -187,6 +190,7 @@ if [ "$(id -u)" == 0 ]; then
         #   above in /etc/sudoers.d/path. Thus PATH is irrelevant to how the above
         #   sudo command resolves the path of `${cmd[@]}`. The PATH will be relevant
         #   for resolving paths of any subprocesses spawned by `${cmd[@]}`.
+    fi
 
 # The container didn't start as the root user, so we will have to act as the
 # user we started as.

--- a/tests/docker-stacks-foundation/test_user_options.py
+++ b/tests/docker-stacks-foundation/test_user_options.py
@@ -305,3 +305,41 @@ def test_startsh_multiple_exec(container: TrackedContainer) -> None:
         "WARNING: start.sh is the default ENTRYPOINT, do not include it in CMD"
         in warnings[0]
     )
+
+
+def test_rootless_triplet_change(container: TrackedContainer) -> None:
+    """Container should change the username (`NB_USER`), the UID and the GID of the default user."""
+    logs = container.run_and_wait(
+        timeout=10,
+        tty=True,
+        user="root",
+        environment=["NB_USER=root", "NB_UID=0", "NB_GID=0"],
+        command=["id"],
+    )
+    assert "uid=0(root)" in logs
+    assert "gid=0(root)" in logs
+    assert "groups=0(root)" in logs
+
+
+def test_rootless_triplet_home(container: TrackedContainer) -> None:
+    """Container should change the home directory for triplet NB_USER=root, NB_UID=0, NB_GID=0."""
+    logs = container.run_and_wait(
+        timeout=10,
+        tty=True,
+        user="root",
+        environment=["NB_USER=root", "NB_UID=0", "NB_GID=0"],
+        command=["env"],
+    )
+    assert "HOME=/home/root" in logs
+
+
+def test_rootless_triplet_sudo(container: TrackedContainer) -> None:
+    """Container should not be started with sudo for triplet NB_USER=root, NB_UID=0, NB_GID=0."""
+    logs = container.run_and_wait(
+        timeout=10,
+        tty=True,
+        user="root",
+        environment=["NB_USER=root", "NB_UID=0", "NB_GID=0"],
+        command=["env"],
+    )
+    assert "SUDO" not in logs

--- a/tests/docker-stacks-foundation/test_user_options.py
+++ b/tests/docker-stacks-foundation/test_user_options.py
@@ -328,7 +328,7 @@ def test_rootless_triplet_home(container: TrackedContainer) -> None:
         tty=True,
         user="root",
         environment=["NB_USER=root", "NB_UID=0", "NB_GID=0"],
-        command=["echo HOME=${HOME} && getent passwd root"],
+        command=["bash", "-c", "echo HOME=${HOME} && getent passwd root"],
     )
     assert "HOME=/home/root" in logs
     assert "root:x:0:0:root:/home/root:/bin/bash" in logs

--- a/tests/docker-stacks-foundation/test_user_options.py
+++ b/tests/docker-stacks-foundation/test_user_options.py
@@ -328,9 +328,10 @@ def test_rootless_triplet_home(container: TrackedContainer) -> None:
         tty=True,
         user="root",
         environment=["NB_USER=root", "NB_UID=0", "NB_GID=0"],
-        command=["env"],
+        command=["echo HOME=${HOME} && getent passwd root"],
     )
     assert "HOME=/home/root" in logs
+    assert "root:x:0:0:root:/home/root:/bin/bash" in logs
 
 
 def test_rootless_triplet_sudo(container: TrackedContainer) -> None:


### PR DESCRIPTION
-  rootless triplet: `-e NB_USER=root` `-e NB_UID=0` `-e NB_GID=0`

## Issue ticket if applicable

<!-- Example - Fix: https://github.com/jupyter/docker-stacks/issues/0 -->

## Checklist (especially for first-time contributors)

- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests
- [x] I will try not to use force-push to make the review process easier for reviewers
- [ ] I have updated the documentation for significant changes

<!-- markdownlint-disable-file MD041 -->
