### PR TITLE
Rename: ROOT_CONTAINER->ROOT_IMAGE, BASE_CONTAINER->BASE_IMAGE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## 2024-10-09
+
+### Changed
+
+_This change might only breaking if you build your custom set of images._
+
+- **Breaking:** Rename: `ROOT_CONTAINER`->`ROOT_IMAGE`, `BASE_CONTAINER`->`BASE_IMAGE` ([#2154](https://github.com/jupyter/docker-stacks/pull/2154), [#2155](https://github.com/jupyter/docker-stacks/pull/2155))

--- a/Makefile
+++ b/Makefile
@@ -36,9 +36,9 @@ help:
 
 
 build/%: DOCKER_BUILD_ARGS?=
-build/%: ROOT_CONTAINER?=ubuntu:24.04
+build/%: ROOT_IMAGE?=ubuntu:24.04
 build/%: ## build the latest image for a stack using the system's architecture
-	docker build $(DOCKER_BUILD_ARGS) --rm --force-rm --tag "$(REGISTRY)/$(OWNER)/$(notdir $@):latest" "./images/$(notdir $@)" --build-arg REGISTRY="$(REGISTRY)" --build-arg OWNER="$(OWNER)" --build-arg ROOT_CONTAINER="$(ROOT_CONTAINER)"
+	docker build $(DOCKER_BUILD_ARGS) --rm --force-rm --tag "$(REGISTRY)/$(OWNER)/$(notdir $@):latest" "./images/$(notdir $@)" --build-arg REGISTRY="$(REGISTRY)" --build-arg OWNER="$(OWNER)" --build-arg ROOT_IMAGE="$(ROOT_IMAGE)"
 	@echo -n "Built image size: "
 	@docker images "$(REGISTRY)/$(OWNER)/$(notdir $@):latest" --format "{{.Size}}"
 build-all: $(foreach I, $(ALL_IMAGES), build/$(I)) ## build all stacks

--- a/binder/Dockerfile
+++ b/binder/Dockerfile
@@ -4,8 +4,8 @@
 # https://quay.io/repository/jupyter/base-notebook?tab=tags
 ARG REGISTRY=quay.io
 ARG OWNER=jupyter
-ARG BASE_CONTAINER=$REGISTRY/$OWNER/base-notebook:2024-10-07
-FROM $BASE_CONTAINER
+ARG BASE_IMAGE=$REGISTRY/$OWNER/base-notebook:2024-10-07
+FROM $BASE_IMAGE
 
 LABEL maintainer="Jupyter Project <jupyter@googlegroups.com>"
 

--- a/docs/using/custom-images.md
+++ b/docs/using/custom-images.md
@@ -15,9 +15,9 @@ please, [take a look at cookiecutter template](../contributing/stacks.md).
 
 Our repository provides several customization points:
 
-- `ROOT_CONTAINER` (docker argument) - the parent image for `docker-stacks-foundation` image
+- `ROOT_IMAGE` (docker argument) - the parent image for `docker-stacks-foundation` image
 - `PYTHON_VERSION` (docker argument) - the Python version to install in `docker-stacks-foundation` image
-- `REGISTRY`, `OWNER`, `BASE_CONTAINER` (docker arguments) - they allow to specify parent image for all the other images
+- `REGISTRY`, `OWNER`, `BASE_IMAGE` (docker arguments) - they allow to specify parent image for all the other images
 - `REGISTRY`, `OWNER` (part of `env` in some GitHub workflows) - these allow to properly tag and refer to images during following steps:
   [`build-test-upload`](https://github.com/jupyter/docker-stacks/blob/main/.github/workflows/docker-build-test-upload.yml),
   [`tag-push`](https://github.com/jupyter/docker-stacks/blob/main/.github/workflows/docker-tag-push.yml) and
@@ -50,8 +50,8 @@ then with a Dockerfile like:
 ```{code-block} Dockerfile
 :caption: Dockerfile
 
-ARG BASE_CONTAINER=minimal-notebook
-FROM $BASE_CONTAINER
+ARG BASE_IMAGE=minimal-notebook
+FROM $BASE_IMAGE
 ...
 ```
 

--- a/docs/using/recipe_code/docker-bake.python312.hcl
+++ b/docs/using/recipe_code/docker-bake.python312.hcl
@@ -16,7 +16,7 @@ target "base-notebook" {
         docker-stacks-foundation = "target:foundation"
     }
     args = {
-        BASE_CONTAINER = "docker-stacks-foundation"
+        BASE_IMAGE = "docker-stacks-foundation"
     }
     tags = ["base-notebook"]
 }
@@ -27,7 +27,7 @@ target "minimal-notebook" {
         base-notebook = "target:base-notebook"
     }
     args = {
-        BASE_CONTAINER = "base-notebook"
+        BASE_IMAGE = "base-notebook"
     }
     tags = ["minimal-notebook"]
 }
@@ -38,7 +38,7 @@ target "custom-notebook" {
         minimal-notebook = "target:minimal-notebook"
     }
     args = {
-        BASE_CONTAINER = "minimal-notebook"
+        BASE_IMAGE = "minimal-notebook"
     }
     tags = ["custom-jupyter"]
 }

--- a/images/all-spark-notebook/Dockerfile
+++ b/images/all-spark-notebook/Dockerfile
@@ -2,8 +2,8 @@
 # Distributed under the terms of the Modified BSD License.
 ARG REGISTRY=quay.io
 ARG OWNER=jupyter
-ARG BASE_CONTAINER=$REGISTRY/$OWNER/pyspark-notebook
-FROM $BASE_CONTAINER
+ARG BASE_IMAGE=$REGISTRY/$OWNER/pyspark-notebook
+FROM $BASE_IMAGE
 
 LABEL maintainer="Jupyter Project <jupyter@googlegroups.com>"
 

--- a/images/base-notebook/Dockerfile
+++ b/images/base-notebook/Dockerfile
@@ -2,8 +2,8 @@
 # Distributed under the terms of the Modified BSD License.
 ARG REGISTRY=quay.io
 ARG OWNER=jupyter
-ARG BASE_CONTAINER=$REGISTRY/$OWNER/docker-stacks-foundation
-FROM $BASE_CONTAINER
+ARG BASE_IMAGE=$REGISTRY/$OWNER/docker-stacks-foundation
+FROM $BASE_IMAGE
 
 LABEL maintainer="Jupyter Project <jupyter@googlegroups.com>"
 

--- a/images/datascience-notebook/Dockerfile
+++ b/images/datascience-notebook/Dockerfile
@@ -2,8 +2,8 @@
 # Distributed under the terms of the Modified BSD License.
 ARG REGISTRY=quay.io
 ARG OWNER=jupyter
-ARG BASE_CONTAINER=$REGISTRY/$OWNER/scipy-notebook
-FROM $BASE_CONTAINER
+ARG BASE_IMAGE=$REGISTRY/$OWNER/scipy-notebook
+FROM $BASE_IMAGE
 
 LABEL maintainer="Jupyter Project <jupyter@googlegroups.com>"
 

--- a/images/docker-stacks-foundation/Dockerfile
+++ b/images/docker-stacks-foundation/Dockerfile
@@ -3,9 +3,9 @@
 
 # Ubuntu 24.04 (noble)
 # https://hub.docker.com/_/ubuntu/tags?page=1&name=noble
-ARG ROOT_CONTAINER=ubuntu:24.04
+ARG ROOT_IMAGE=ubuntu:24.04
 
-FROM $ROOT_CONTAINER
+FROM $ROOT_IMAGE
 
 LABEL maintainer="Jupyter Project <jupyter@googlegroups.com>"
 ARG NB_USER="jovyan"

--- a/images/julia-notebook/Dockerfile
+++ b/images/julia-notebook/Dockerfile
@@ -2,8 +2,8 @@
 # Distributed under the terms of the Modified BSD License.
 ARG REGISTRY=quay.io
 ARG OWNER=jupyter
-ARG BASE_CONTAINER=$REGISTRY/$OWNER/minimal-notebook
-FROM $BASE_CONTAINER
+ARG BASE_IMAGE=$REGISTRY/$OWNER/minimal-notebook
+FROM $BASE_IMAGE
 
 LABEL maintainer="Jupyter Project <jupyter@googlegroups.com>"
 

--- a/images/minimal-notebook/Dockerfile
+++ b/images/minimal-notebook/Dockerfile
@@ -2,8 +2,8 @@
 # Distributed under the terms of the Modified BSD License.
 ARG REGISTRY=quay.io
 ARG OWNER=jupyter
-ARG BASE_CONTAINER=$REGISTRY/$OWNER/base-notebook
-FROM $BASE_CONTAINER
+ARG BASE_IMAGE=$REGISTRY/$OWNER/base-notebook
+FROM $BASE_IMAGE
 
 LABEL maintainer="Jupyter Project <jupyter@googlegroups.com>"
 

--- a/images/pyspark-notebook/Dockerfile
+++ b/images/pyspark-notebook/Dockerfile
@@ -2,8 +2,8 @@
 # Distributed under the terms of the Modified BSD License.
 ARG REGISTRY=quay.io
 ARG OWNER=jupyter
-ARG BASE_CONTAINER=$REGISTRY/$OWNER/scipy-notebook
-FROM $BASE_CONTAINER
+ARG BASE_IMAGE=$REGISTRY/$OWNER/scipy-notebook
+FROM $BASE_IMAGE
 
 LABEL maintainer="Jupyter Project <jupyter@googlegroups.com>"
 

--- a/images/pytorch-notebook/Dockerfile
+++ b/images/pytorch-notebook/Dockerfile
@@ -2,8 +2,8 @@
 # Distributed under the terms of the Modified BSD License.
 ARG REGISTRY=quay.io
 ARG OWNER=jupyter
-ARG BASE_CONTAINER=$REGISTRY/$OWNER/scipy-notebook
-FROM $BASE_CONTAINER
+ARG BASE_IMAGE=$REGISTRY/$OWNER/scipy-notebook
+FROM $BASE_IMAGE
 
 LABEL maintainer="Jupyter Project <jupyter@googlegroups.com>"
 

--- a/images/pytorch-notebook/cuda11/Dockerfile
+++ b/images/pytorch-notebook/cuda11/Dockerfile
@@ -2,8 +2,8 @@
 # Distributed under the terms of the Modified BSD License.
 ARG REGISTRY=quay.io
 ARG OWNER=jupyter
-ARG BASE_CONTAINER=$REGISTRY/$OWNER/scipy-notebook
-FROM $BASE_CONTAINER
+ARG BASE_IMAGE=$REGISTRY/$OWNER/scipy-notebook
+FROM $BASE_IMAGE
 
 LABEL maintainer="Jupyter Project <jupyter@googlegroups.com>"
 

--- a/images/pytorch-notebook/cuda12/Dockerfile
+++ b/images/pytorch-notebook/cuda12/Dockerfile
@@ -2,8 +2,8 @@
 # Distributed under the terms of the Modified BSD License.
 ARG REGISTRY=quay.io
 ARG OWNER=jupyter
-ARG BASE_CONTAINER=$REGISTRY/$OWNER/scipy-notebook
-FROM $BASE_CONTAINER
+ARG BASE_IMAGE=$REGISTRY/$OWNER/scipy-notebook
+FROM $BASE_IMAGE
 
 LABEL maintainer="Jupyter Project <jupyter@googlegroups.com>"
 

--- a/images/r-notebook/Dockerfile
+++ b/images/r-notebook/Dockerfile
@@ -2,8 +2,8 @@
 # Distributed under the terms of the Modified BSD License.
 ARG REGISTRY=quay.io
 ARG OWNER=jupyter
-ARG BASE_CONTAINER=$REGISTRY/$OWNER/minimal-notebook
-FROM $BASE_CONTAINER
+ARG BASE_IMAGE=$REGISTRY/$OWNER/minimal-notebook
+FROM $BASE_IMAGE
 
 LABEL maintainer="Jupyter Project <jupyter@googlegroups.com>"
 

--- a/images/scipy-notebook/Dockerfile
+++ b/images/scipy-notebook/Dockerfile
@@ -2,8 +2,8 @@
 # Distributed under the terms of the Modified BSD License.
 ARG REGISTRY=quay.io
 ARG OWNER=jupyter
-ARG BASE_CONTAINER=$REGISTRY/$OWNER/minimal-notebook
-FROM $BASE_CONTAINER
+ARG BASE_IMAGE=$REGISTRY/$OWNER/minimal-notebook
+FROM $BASE_IMAGE
 
 LABEL maintainer="Jupyter Project <jupyter@googlegroups.com>"
 

--- a/images/tensorflow-notebook/Dockerfile
+++ b/images/tensorflow-notebook/Dockerfile
@@ -2,8 +2,8 @@
 # Distributed under the terms of the Modified BSD License.
 ARG REGISTRY=quay.io
 ARG OWNER=jupyter
-ARG BASE_CONTAINER=$REGISTRY/$OWNER/scipy-notebook
-FROM $BASE_CONTAINER
+ARG BASE_IMAGE=$REGISTRY/$OWNER/scipy-notebook
+FROM $BASE_IMAGE
 
 LABEL maintainer="Jupyter Project <jupyter@googlegroups.com>"
 

--- a/images/tensorflow-notebook/cuda/Dockerfile
+++ b/images/tensorflow-notebook/cuda/Dockerfile
@@ -2,8 +2,8 @@
 # Distributed under the terms of the Modified BSD License.
 ARG REGISTRY=quay.io
 ARG OWNER=jupyter
-ARG BASE_CONTAINER=$REGISTRY/$OWNER/scipy-notebook
-FROM $BASE_CONTAINER
+ARG BASE_IMAGE=$REGISTRY/$OWNER/scipy-notebook
+FROM $BASE_IMAGE
 
 LABEL maintainer="Jupyter Project <jupyter@googlegroups.com>"
 


### PR DESCRIPTION
## Describe your changes

There is no such thing as parent (base/root) container, it's about images, so let's use proper naming

## Issue ticket if applicable

Fix: https://github.com/jupyter/docker-stacks/issues/2154

## Checklist (especially for first-time contributors)

- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests
- [ ] I will try not to use force-push to make the review process easier for reviewers
- [ ] I have updated the documentation for significant changes

<!-- markdownlint-disable-file MD041 -->
