### PR TITLE
Exclude preview version from stable versions

### DIFF
--- a/images/pyspark-notebook/setup_spark.py
+++ b/images/pyspark-notebook/setup_spark.py
@@ -36,7 +36,7 @@ def get_latest_spark_version() -> str:
     stable_versions = [
         ref.removeprefix("spark-").removesuffix("/")
         for ref in all_refs
-        if ref.startswith("spark-") and "incubating" not in ref
+        if ref.startswith("spark-") and "incubating" not in ref and "preview" not in ref
     ]
 
     # Compare versions semantically


### PR DESCRIPTION
The current version of the script will select Spark 4.0 as the latest stable version even though the Spark maintainers themselves do not call these preview version stable (see [their statement](https://spark.apache.org/news/spark-4.0.0-preview2.html)).

## Describe your changes

Exclude preview version from stable versions.

## Checklist (especially for first-time contributors)

- [x] I have performed a self-review of my code
- [x] I will try not to use force-push to make the review process easier for reviewers

<!-- markdownlint-disable-file MD041 -->
