### PR TITLE
base-notebook: stop installing nodejs from conda-forge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 This changelog only contains breaking and/or significant changes manually introduced to this repository (using Pull Requests).
 All image manifests can be found in [the wiki](https://github.com/jupyter/docker-stacks/wiki).
 
-## 2024-11-07
+## 2024-11-08
 
 Affected: all images except `docker-stacks-foundation`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 This changelog only contains breaking and/or significant changes manually introduced to this repository (using Pull Requests).
 All image manifests can be found in [the wiki](https://github.com/jupyter/docker-stacks/wiki).
 
-## 2024-11-??
+## 2024-11-07
 
 Affected: all images except `docker-stacks-foundation`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 This changelog only contains breaking and/or significant changes manually introduced to this repository (using Pull Requests).
 All image manifests can be found in [the wiki](https://github.com/jupyter/docker-stacks/wiki).
 
+## 2024-11-??
+
+Affected: all images except `docker-stacks-foundation`.
+
+- **Breaking:** base-notebook: stop installing nodejs from conda-forge ([#2172](https://github.com/jupyter/docker-stacks/pull/2172)).
+
+  Reason: It isn't a direct dependency on anything in the images any more, and increased the image size with ~150MB.
+
 ## 2024-11-06
 
 Affected: all images except `docker-stacks-foundation`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All image manifests can be found in [the wiki](https://github.com/jupyter/docker
 
 Affected: all images except `docker-stacks-foundation`.
 
-- **Breaking:** base-notebook: stop installing nodejs from conda-forge ([#2172](https://github.com/jupyter/docker-stacks/pull/2172)).
+- **Breaking:** `base-notebook`: stop installing `nodejs` from `conda-forge` ([#2172](https://github.com/jupyter/docker-stacks/pull/2172)).
 
   Reason: It isn't a direct dependency on anything in the images any more, and increased the image size with ~150MB.
 

--- a/docs/using/recipe_code/jupyterhub_version.dockerfile
+++ b/docs/using/recipe_code/jupyterhub_version.dockerfile
@@ -1,6 +1,6 @@
 FROM quay.io/jupyter/base-notebook
 
-RUN mamba install --yes 'jupyterhub-base==4.0.1' && \
+RUN mamba install --yes 'jupyterhub-singleuser==4.0.1' && \
     mamba clean --all -f -y && \
     fix-permissions "${CONDA_DIR}" && \
     fix-permissions "/home/${NB_USER}"

--- a/docs/using/selecting.md
+++ b/docs/using/selecting.md
@@ -54,7 +54,7 @@ It contains:
 
 - Everything in `jupyter/docker-stacks-foundation`
 - Minimally functional Server (e.g., no LaTeX support for saving notebooks as PDFs)
-- `notebook`, `jupyterhub-base`, and `jupyterlab` packages
+- `notebook`, `jupyterhub-singleuser`, and `jupyterlab` packages
 - A `start-notebook.py` script as the default command
 - A `start-singleuser.py` script useful for launching containers in JupyterHub
 - Options for a self-signed HTTPS certificate

--- a/docs/using/selecting.md
+++ b/docs/using/selecting.md
@@ -55,8 +55,6 @@ It contains:
 - Everything in `jupyter/docker-stacks-foundation`
 - Minimally functional Server (e.g., no LaTeX support for saving notebooks as PDFs)
 - `notebook`, `jupyterhub-base`, and `jupyterlab` packages
-  Note: we're also installing `nodejs` as it has historically been installed indirectly as a dependency of `jupyterhub` package, which was used before.
-  See more at: <https://github.com/jupyter/docker-stacks/pull/2171>
 - A `start-notebook.py` script as the default command
 - A `start-singleuser.py` script useful for launching containers in JupyterHub
 - Options for a self-signed HTTPS certificate

--- a/images/base-notebook/Dockerfile
+++ b/images/base-notebook/Dockerfile
@@ -42,12 +42,6 @@ RUN mamba install --yes \
     'jupyterhub-base' \
     'jupyterlab' \
     'nbclassic' \
-    # nodejs has historically been installed indirectly as a dependency.
-    # When it was no longer getting installed indirectly,
-    # we started installing it explicitly to avoid introducing a breaking change
-    # for users building on top of these images.
-    # See: https://github.com/jupyter/docker-stacks/pull/2171
-    'nodejs' \
     # Sometimes, when the new version of `jupyterlab` is released, latest `notebook` might not support it for some time
     # Old versions of `notebook` (<v7) didn't have a restriction on the `jupyterlab` version, and old `notebook` is getting installed
     # That's why we have to pin the minimum notebook version
@@ -55,7 +49,6 @@ RUN mamba install --yes \
     'notebook>=7.2.2' && \
     jupyter server --generate-config && \
     mamba clean --all -f -y && \
-    npm cache clean --force && \
     jupyter lab clean && \
     rm -rf "/home/${NB_USER}/.cache/yarn" && \
     fix-permissions "${CONDA_DIR}" && \

--- a/images/base-notebook/Dockerfile
+++ b/images/base-notebook/Dockerfile
@@ -39,7 +39,7 @@ USER ${NB_UID}
 # files across image layers when the permissions change
 WORKDIR /tmp
 RUN mamba install --yes \
-    'jupyterhub-base' \
+    'jupyterhub-singleuser' \
     'jupyterlab' \
     'nbclassic' \
     # Sometimes, when the new version of `jupyterlab` is released, latest `notebook` might not support it for some time

--- a/tests/base-notebook/test_npm_package_manager.py
+++ b/tests/base-notebook/test_npm_package_manager.py
@@ -1,9 +1,0 @@
-# Copyright (c) Jupyter Development Team.
-# Distributed under the terms of the Modified BSD License.
-from tests.conftest import TrackedContainer
-from tests.run_command import run_command
-
-
-def test_npm_package_manager(container: TrackedContainer) -> None:
-    """Test that npm is installed and runs."""
-    run_command(container, "npm --version")

--- a/tests/docker-stacks-foundation/test_packages.py
+++ b/tests/docker-stacks-foundation/test_packages.py
@@ -77,7 +77,6 @@ EXCLUDED_PACKAGES = [
     "jupyterhub-base",
     "jupyterlab-git",
     "mamba[version='<2.0.0']",
-    "nodejs",
     "notebook[version='>",
     "openssl",
     "pandas[version='>",

--- a/tests/docker-stacks-foundation/test_packages.py
+++ b/tests/docker-stacks-foundation/test_packages.py
@@ -74,7 +74,7 @@ EXCLUDED_PACKAGES = [
     "grpcio-status",
     "grpcio",
     "hdf5",
-    "jupyterhub-base",
+    "jupyterhub-singleuser",
     "jupyterlab-git",
     "mamba[version='<2.0.0']",
     "notebook[version='>",


### PR DESCRIPTION
## Describe your changes

nodejs was a conda dependency of jupyterhub, but by installing
jupyterhub-base we no longer need it and could opt to remove it.

By doing this, building base-notebook led to a reported size reduction
from 974MB to 828MB, which is a 146MB / 15% size reduction.

## Issue ticket if applicable

- closes https://github.com/jupyter/docker-stacks/issues/2170 which is related if its still open

## Checklist (especially for first-time contributors)

- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests
  I removed a test related to `npm`, dependency of `nodejs` conda-forge package.
- [x] I will try not to use force-push to make the review process easier for reviewers
- [x] I have updated the documentation for significant changes

<!-- markdownlint-disable-file MD041 -->
