### PR TITLE
Downgrade to Julia 1.11.1

### DIFF
--- a/images/minimal-notebook/setup-scripts/setup_julia.py
+++ b/images/minimal-notebook/setup-scripts/setup_julia.py
@@ -47,6 +47,11 @@ def get_latest_julia_url() -> tuple[str, str]:
     triplet = unify_aarch64(platform.machine()) + "-linux-gnu"
     file_info = [vf for vf in latest_version_files if vf["triplet"] == triplet][0]
     LOGGER.info(f"Latest version: {file_info['version']} url: {file_info['url']}")
+    if file_info["version"] == "1.11.2":
+        LOGGER.warning(
+            "Not using Julia 1.11.2, because it hangs in GitHub self-hosted runners"
+        )
+        return file_info["url"].replace("1.11.2", "1.11.1"), "1.11.1"
     return file_info["url"], file_info["version"]
 
 


### PR DESCRIPTION
## Describe your changes

Julia `1.11.2` has just been released and it seems that it causes our self-hosted aarch64 runners to hang.

Previous build was using `1.11.1` and has been working fine: https://github.com/jupyter/docker-stacks/actions/runs/12123374006/job/33801780215

Let's try to downgrade to `1.11.1` and see if it helps.

## Issue ticket if applicable

<!-- Example - Fix: https://github.com/jupyter/docker-stacks/issues/0 -->

## Checklist (especially for first-time contributors)

- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests
- [ ] I will try not to use force-push to make the review process easier for reviewers
- [ ] I have updated the documentation for significant changes

<!-- markdownlint-disable-file MD041 -->
