### PR TITLE
Use micromamba 2.0.5.rc0 in Dockerimage

### DIFF
--- a/images/docker-stacks-foundation/Dockerfile
+++ b/images/docker-stacks-foundation/Dockerfile
@@ -115,7 +115,7 @@ RUN set -x && \
     fi && \
     # https://mamba.readthedocs.io/en/latest/installation/micromamba-installation.html#linux-and-macos
     wget --progress=dot:giga -O - \
-        "https://micro.mamba.pm/api/micromamba/linux-${arch}/latest" | tar -xvj bin/micromamba && \
+        "https://micro.mamba.pm/api/micromamba/linux-${arch}/2.0.5.rc0" | tar -xvj bin/micromamba && \
     PYTHON_SPECIFIER="python=${PYTHON_VERSION}" && \
     if [[ "${PYTHON_VERSION}" == "default" ]]; then PYTHON_SPECIFIER="python"; fi && \
     # Install the packages

--- a/images/docker-stacks-foundation/Dockerfile
+++ b/images/docker-stacks-foundation/Dockerfile
@@ -120,12 +120,14 @@ RUN set -x && \
     if [[ "${PYTHON_VERSION}" == "default" ]]; then PYTHON_SPECIFIER="python"; fi && \
     # Install the packages
     ./bin/micromamba install \
+        -c conda-forge \
+        -c conda-forge/label/mamba_prerelease \
         --root-prefix="${CONDA_DIR}" \
         --prefix="${CONDA_DIR}" \
         --yes \
         'jupyter_core' \
         'conda' \
-        'mamba' \
+        'mamba=2.0.5.rc0' \
         "${PYTHON_SPECIFIER}" && \
     rm -rf /tmp/bin/ && \
     # Pin major.minor version of python

--- a/tests/package_helper.py
+++ b/tests/package_helper.py
@@ -86,6 +86,12 @@ class CondaPackageHelper:
                     CondaPackageHelper._conda_export_command(from_history=True)
                 )
             )
+            env = self._execute_command(
+                CondaPackageHelper._conda_export_command(from_history=True)
+            )
+            LOGGER.debug(env)
+            self.requested = CondaPackageHelper._parse_package_versions(env)
+            LOGGER.debug(self.requested)
         return self.requested
 
     def _execute_command(self, command: list[str]) -> str:

--- a/tests/package_helper.py
+++ b/tests/package_helper.py
@@ -81,11 +81,13 @@ class CondaPackageHelper:
         """Return the requested package (i.e. `mamba install <package>`)"""
         if self.requested is None:
             LOGGER.info("Grabbing the list of manually requested packages ...")
-            self.requested = CondaPackageHelper._parse_package_versions(
-                self._execute_command(
-                    CondaPackageHelper._conda_export_command(from_history=True)
-                )
-            )
+            # self.requested = CondaPackageHelper._parse_package_versions(
+            #     self._execute_command(
+            #         CondaPackageHelper._conda_export_command(from_history=True)
+            #     )
+            # )
+            vers = self._execute_command(["mamba", "--version"])
+            LOGGER.debug(vers)
             env = self._execute_command(
                 CondaPackageHelper._conda_export_command(from_history=True)
             )


### PR DESCRIPTION
This is just for testing the latest pre-release of micromamba (i.e. 2.0.5.rc0) before releasing for good. I don't know if this is enough, let me know if additional changes are required.
