### PR TITLE
Don't override singleuser ip to 0.0.0.0

### DIFF
--- a/images/base-notebook/start-singleuser.py
+++ b/images/base-notebook/start-singleuser.py
@@ -8,9 +8,7 @@ import sys
 # Entrypoint is start.sh
 command = ["jupyterhub-singleuser"]
 
-# set default ip to 0.0.0.0
-if "--ip=" not in os.environ.get("NOTEBOOK_ARGS", ""):
-    command.append("--ip=0.0.0.0")
+# JupyterHub singleuser arguments are set using environment variables
 
 # Append any optional NOTEBOOK_ARGS we were passed in.
 # This is supposed to be multiple args passed on to the notebook command,


### PR DESCRIPTION
## Describe your changes

JupyterHub controls which interface(s) the singleuser server listens on.

The IP is set in the Spawner configuration, and passed to the singleuser server in the environment variable `JUPYTERHUB_SERVICE_URL`:
https://jupyterhub.readthedocs.io/en/latest/reference/spawners.html#note-on-ips-and-ports

Docker-stacks shouldn't override it. For example, if you configure a JupyterHub container spawner to use a docker-stacks image and use the default CMD it won't work with IPv6.

## Issue ticket if applicable

<!-- Example - Fix: https://github.com/jupyter/docker-stacks/issues/0 -->

## Checklist (especially for first-time contributors)

- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests
- [ ] I will try not to use force-push to make the review process easier for reviewers
- [ ] I have updated the documentation for significant changes

<!-- markdownlint-disable-file MD041 -->
