### PR TITLE
jupyter_server_config.py: Listen on all interfaces (IPv4 and IPv6)

### DIFF
--- a/images/base-notebook/jupyter_server_config.py
+++ b/images/base-notebook/jupyter_server_config.py
@@ -9,7 +9,8 @@ from pathlib import Path
 from jupyter_core.paths import jupyter_data_dir
 
 c = get_config()  # noqa: F821
-c.ServerApp.ip = "0.0.0.0"
+# Listen on all interfaces (ipv4 and ipv6)
+c.ServerApp.ip = ""
 c.ServerApp.open_browser = False
 
 # to output both image/svg+xml and application/pdf plot formats in the notebook file


### PR DESCRIPTION
## Describe your changes
`c.ServerApp.ip = "0.0.0.0"` in `jupyter_server_config.py` configures jupyter-server to listen on all IPv4 interfaces. 

Setting it to `""` configures jupyter-server to listen on [all available (IPv4 and IPv6) interfaces](https://www.tornadoweb.org/en/stable/netutil.html#tornado.netutil.bind_sockets), ensuring these images work with IPv4, IPv6, and dual stack networks.

## Issue ticket if applicable

<!-- Example - Fix: https://github.com/jupyter/docker-stacks/issues/0 -->

## Checklist (especially for first-time contributors)

- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests
- [ ] I will try not to use force-push to make the review process easier for reviewers
- [ ] I have updated the documentation for significant changes

<!-- markdownlint-disable-file MD041 -->
