### PR TITLE
Remove information about Docker Hub images from READMEs

### DIFF
--- a/images/all-spark-notebook/README.md
+++ b/images/all-spark-notebook/README.md
@@ -1,11 +1,5 @@
 # Jupyter Notebook Python, R, Spark Stack
 
-> **Images hosted on Docker Hub are no longer updated. Please, use [quay.io image](https://quay.io/repository/jupyter/all-spark-notebook)**
-
-[![docker pulls](https://img.shields.io/docker/pulls/jupyter/all-spark-notebook.svg)](https://hub.docker.com/r/jupyter/all-spark-notebook/)
-[![docker stars](https://img.shields.io/docker/stars/jupyter/all-spark-notebook.svg)](https://hub.docker.com/r/jupyter/all-spark-notebook/)
-[![image size](https://img.shields.io/docker/image-size/jupyter/all-spark-notebook/latest)](https://hub.docker.com/r/jupyter/all-spark-notebook/ "jupyter/all-spark-notebook image size")
-
 GitHub Actions in the <https://github.com/jupyter/docker-stacks> project builds and pushes this image to the Registry.
 
 Please visit the project documentation site for help to use and contribute to this image and others.

--- a/images/base-notebook/README.md
+++ b/images/base-notebook/README.md
@@ -1,11 +1,5 @@
 # Base Jupyter Notebook Stack
 
-> **Images hosted on Docker Hub are no longer updated. Please, use [quay.io image](https://quay.io/repository/jupyter/base-notebook)**
-
-[![docker pulls](https://img.shields.io/docker/pulls/jupyter/base-notebook.svg)](https://hub.docker.com/r/jupyter/base-notebook/)
-[![docker stars](https://img.shields.io/docker/stars/jupyter/base-notebook.svg)](https://hub.docker.com/r/jupyter/base-notebook/)
-[![image size](https://img.shields.io/docker/image-size/jupyter/base-notebook/latest)](https://hub.docker.com/r/jupyter/base-notebook/ "jupyter/base-notebook image size")
-
 GitHub Actions in the <https://github.com/jupyter/docker-stacks> project builds and pushes this image to the Registry.
 
 Please visit the project documentation site for help to use and contribute to this image and others.

--- a/images/datascience-notebook/README.md
+++ b/images/datascience-notebook/README.md
@@ -1,11 +1,5 @@
 # Jupyter Notebook Data Science Stack
 
-> **Images hosted on Docker Hub are no longer updated. Please, use [quay.io image](https://quay.io/repository/jupyter/datascience-notebook)**
-
-[![docker pulls](https://img.shields.io/docker/pulls/jupyter/datascience-notebook.svg)](https://hub.docker.com/r/jupyter/datascience-notebook/)
-[![docker stars](https://img.shields.io/docker/stars/jupyter/datascience-notebook.svg)](https://hub.docker.com/r/jupyter/datascience-notebook/)
-[![image size](https://img.shields.io/docker/image-size/jupyter/datascience-notebook/latest)](https://hub.docker.com/r/jupyter/datascience-notebook/ "jupyter/datascience-notebook image size")
-
 GitHub Actions in the <https://github.com/jupyter/docker-stacks> project builds and pushes this image to the Registry.
 
 Please visit the project documentation site for help to use and contribute to this image and others.

--- a/images/docker-stacks-foundation/README.md
+++ b/images/docker-stacks-foundation/README.md
@@ -1,11 +1,5 @@
 # Foundation Jupyter Stack
 
-> **Images hosted on Docker Hub are no longer updated. Please, use [quay.io image](https://quay.io/repository/jupyter/docker-stacks-foundation)**
-
-[![docker pulls](https://img.shields.io/docker/pulls/jupyter/docker-stacks-foundation.svg)](https://hub.docker.com/r/jupyter/docker-stacks-foundation/)
-[![docker stars](https://img.shields.io/docker/stars/jupyter/docker-stacks-foundation.svg)](https://hub.docker.com/r/jupyter/docker-stacks-foundation/)
-[![image size](https://img.shields.io/docker/image-size/jupyter/docker-stacks-foundation/latest)](https://hub.docker.com/r/jupyter/docker-stacks-foundation/ "jupyter/docker-stacks-foundation image size")
-
 GitHub Actions in the <https://github.com/jupyter/docker-stacks> project builds and pushes this image to the Registry.
 
 Please visit the project documentation site for help to use and contribute to this image and others.

--- a/images/julia-notebook/README.md
+++ b/images/julia-notebook/README.md
@@ -1,11 +1,5 @@
 # Jupyter Notebook Julia Stack
 
-> **Images hosted on Docker Hub are no longer updated. Please, use [quay.io image](https://quay.io/repository/jupyter/julia-notebook)**
-
-[![docker pulls](https://img.shields.io/docker/pulls/jupyter/julia-notebook.svg)](https://hub.docker.com/r/jupyter/julia-notebook/)
-[![docker stars](https://img.shields.io/docker/stars/jupyter/julia-notebook.svg)](https://hub.docker.com/r/jupyter/julia-notebook/)
-[![image size](https://img.shields.io/docker/image-size/jupyter/julia-notebook/latest)](https://hub.docker.com/r/jupyter/julia-notebook/ "jupyter/julia-notebook image size")
-
 GitHub Actions in the <https://github.com/jupyter/docker-stacks> project builds and pushes this image to the Registry.
 
 Please visit the project documentation site for help to use and contribute to this image and others.

--- a/images/minimal-notebook/README.md
+++ b/images/minimal-notebook/README.md
@@ -1,11 +1,5 @@
 # Minimal Jupyter Notebook Stack
 
-> **Images hosted on Docker Hub are no longer updated. Please, use [quay.io image](https://quay.io/repository/jupyter/minimal-notebook)**
-
-[![docker pulls](https://img.shields.io/docker/pulls/jupyter/minimal-notebook.svg)](https://hub.docker.com/r/jupyter/minimal-notebook/)
-[![docker stars](https://img.shields.io/docker/stars/jupyter/minimal-notebook.svg)](https://hub.docker.com/r/jupyter/minimal-notebook/)
-[![image size](https://img.shields.io/docker/image-size/jupyter/minimal-notebook/latest)](https://hub.docker.com/r/jupyter/minimal-notebook/ "jupyter/minimal-notebook image size")
-
 GitHub Actions in the <https://github.com/jupyter/docker-stacks> project builds and pushes this image to the Registry.
 
 Please visit the project documentation site for help to use and contribute to this image and others.

--- a/images/pyspark-notebook/README.md
+++ b/images/pyspark-notebook/README.md
@@ -1,11 +1,5 @@
 # Jupyter Notebook Python, Spark Stack
 
-> **Images hosted on Docker Hub are no longer updated. Please, use [quay.io image](https://quay.io/repository/jupyter/pyspark-notebook)**
-
-[![docker pulls](https://img.shields.io/docker/pulls/jupyter/pyspark-notebook.svg)](https://hub.docker.com/r/jupyter/pyspark-notebook/)
-[![docker stars](https://img.shields.io/docker/stars/jupyter/pyspark-notebook.svg)](https://hub.docker.com/r/jupyter/pyspark-notebook/)
-[![image size](https://img.shields.io/docker/image-size/jupyter/pyspark-notebook/latest)](https://hub.docker.com/r/jupyter/pyspark-notebook/ "jupyter/pyspark-notebook image size")
-
 GitHub Actions in the <https://github.com/jupyter/docker-stacks> project builds and pushes this image to the Registry.
 
 Please visit the project documentation site for help to use and contribute to this image and others.

--- a/images/pytorch-notebook/README.md
+++ b/images/pytorch-notebook/README.md
@@ -1,4 +1,4 @@
-# Jupyter Notebook Deep Learning Stack
+# Jupyter Notebook PyTorch Deep Learning Stack
 
 GitHub Actions in the <https://github.com/jupyter/docker-stacks> project builds and pushes this image to the Registry.
 

--- a/images/r-notebook/README.md
+++ b/images/r-notebook/README.md
@@ -1,11 +1,5 @@
 # Jupyter Notebook R Stack
 
-> **Images hosted on Docker Hub are no longer updated. Please, use [quay.io image](https://quay.io/repository/jupyter/r-notebook)**
-
-[![docker pulls](https://img.shields.io/docker/pulls/jupyter/r-notebook.svg)](https://hub.docker.com/r/jupyter/r-notebook/)
-[![docker stars](https://img.shields.io/docker/stars/jupyter/r-notebook.svg)](https://hub.docker.com/r/jupyter/r-notebook/)
-[![image size](https://img.shields.io/docker/image-size/jupyter/r-notebook/latest)](https://hub.docker.com/r/jupyter/r-notebook/ "jupyter/r-notebook image size")
-
 GitHub Actions in the <https://github.com/jupyter/docker-stacks> project builds and pushes this image to the Registry.
 
 Please visit the project documentation site for help to use and contribute to this image and others.

--- a/images/scipy-notebook/README.md
+++ b/images/scipy-notebook/README.md
@@ -1,11 +1,5 @@
 # Jupyter Notebook Scientific Python Stack
 
-> **Images hosted on Docker Hub are no longer updated. Please, use [quay.io image](https://quay.io/repository/jupyter/scipy-notebook)**
-
-[![docker pulls](https://img.shields.io/docker/pulls/jupyter/scipy-notebook.svg)](https://hub.docker.com/r/jupyter/scipy-notebook/)
-[![docker stars](https://img.shields.io/docker/stars/jupyter/scipy-notebook.svg)](https://hub.docker.com/r/jupyter/scipy-notebook/)
-[![image size](https://img.shields.io/docker/image-size/jupyter/scipy-notebook/latest)](https://hub.docker.com/r/jupyter/scipy-notebook/ "jupyter/scipy-notebook image size")
-
 GitHub Actions in the <https://github.com/jupyter/docker-stacks> project builds and pushes this image to the Registry.
 
 Please visit the project documentation site for help to use and contribute to this image and others.

--- a/images/tensorflow-notebook/README.md
+++ b/images/tensorflow-notebook/README.md
@@ -1,10 +1,4 @@
-# Jupyter Notebook Deep Learning Stack
-
-> **Images hosted on Docker Hub are no longer updated. Please, use [quay.io image](https://quay.io/repository/jupyter/tensorflow-notebook)**
-
-[![docker pulls](https://img.shields.io/docker/pulls/jupyter/tensorflow-notebook.svg)](https://hub.docker.com/r/jupyter/tensorflow-notebook/)
-[![docker stars](https://img.shields.io/docker/stars/jupyter/tensorflow-notebook.svg)](https://hub.docker.com/r/jupyter/tensorflow-notebook/)
-[![image size](https://img.shields.io/docker/image-size/jupyter/tensorflow-notebook/latest)](https://hub.docker.com/r/jupyter/tensorflow-notebook/ "jupyter/tensorflow-notebook image size")
+# Jupyter Notebook TensorFlow Deep Learning Stack
 
 GitHub Actions in the <https://github.com/jupyter/docker-stacks> project builds and pushes this image to the Registry.
 


### PR DESCRIPTION
## Describe your changes

## Issue ticket if applicable

<!-- Example - Fix: https://github.com/jupyter/docker-stacks/issues/0 -->

## Checklist (especially for first-time contributors)

- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests
- [ ] I will try not to use force-push to make the review process easier for reviewers
- [ ] I have updated the documentation for significant changes

<!-- markdownlint-disable-file MD041 -->
