### PR TITLE
Don't create extra free space in runners for cuda images

### DIFF
--- a/.github/workflows/docker-build-test-upload.yml
+++ b/.github/workflows/docker-build-test-upload.yml
@@ -39,19 +39,6 @@ jobs:
     runs-on: ${{ inputs.runs-on }}
 
     steps:
-      # Image with CUDA needs extra disk space
-      - name: Free disk space 🧹
-        if: contains(inputs.variant, 'cuda') && runner.arch == 'X64'
-        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
-        with:
-          tool-cache: false
-          android: true
-          dotnet: true
-          haskell: true
-          large-packages: false
-          docker-images: false
-          swap-storage: false
-
       - name: Checkout Repo ⚡️
         uses: actions/checkout@v4
       - name: Create dev environment 📦

--- a/.github/workflows/docker-tag-push.yml
+++ b/.github/workflows/docker-tag-push.yml
@@ -31,19 +31,6 @@ jobs:
     runs-on: ubuntu-24.04
 
     steps:
-      # Image with CUDA needs extra disk space
-      - name: Free disk space 🧹
-        if: contains(inputs.variant, 'cuda') && runner.arch == 'X64'
-        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
-        with:
-          tool-cache: false
-          android: true
-          dotnet: true
-          haskell: true
-          large-packages: false
-          docker-images: false
-          swap-storage: false
-
       - name: Checkout Repo ⚡️
         uses: actions/checkout@v4
       - name: Create dev environment 📦

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Affected: all images.
 - **Non-breaking:** First upload artifacts and then run tests to make sure we can easily debug broken images ([#2214](https://github.com/jupyter/docker-stacks/pull/2214)).
 - **Breaking:** Pin some packages to fix `r-notebook` and `datascience-notebook` under aarch64 ([#2215](https://github.com/jupyter/docker-stacks/pull/2215)).
 - **Non-breaking:** Don't use matrix.image-variant, use 2 separate variables ([#2217](https://github.com/jupyter/docker-stacks/pull/2217)).
+- **Non-breaking:** Don't create extra free space in runners for cuda images ([#2218](https://github.com/jupyter/docker-stacks/pull/2218)).
 
 ## 2025-02-11
 


### PR DESCRIPTION
## Describe your changes

## Issue ticket if applicable

<!-- Example - Fix: https://github.com/jupyter/docker-stacks/issues/0 -->

## Checklist (especially for first-time contributors)

- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests
- [ ] I will try not to use force-push to make the review process easier for reviewers
- [ ] I have updated the documentation for significant changes

<!-- markdownlint-disable-file MD041 -->
