### PR TITLE
Do not compress images in `actions/upload-artifact`

### DIFF
--- a/.github/workflows/docker-build-test-upload.yml
+++ b/.github/workflows/docker-build-test-upload.yml
@@ -127,6 +127,7 @@ jobs:
           name: ${{ inputs.image }}-${{ inputs.platform }}-${{ inputs.variant }}
           path: /tmp/jupyter/images/${{ inputs.image }}-${{ inputs.platform }}-${{ inputs.variant }}.tar.zst
           retention-days: 3
+          compression-level: 0
 
       - name: Run tests ✅
         run: >


### PR DESCRIPTION
## Describe your changes

We already use zst to compress our images, so it shouldn't be necessary to compress on upload.
https://github.com/actions/upload-artifact?tab=readme-ov-file#inputs
`For large files that are not easily compressed, a value of 0 is recommended for significantly faster uploads.`

## Issue ticket if applicable

<!-- Example - Fix: https://github.com/jupyter/docker-stacks/issues/0 -->

## Checklist (especially for first-time contributors)

- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests
- [ ] I will try not to use force-push to make the review process easier for reviewers
- [ ] I have updated the documentation for significant changes

<!-- markdownlint-disable-file MD041 -->
