### PR TITLE
Allow mamba ssl ca store to be set

### DIFF
--- a/images/base-notebook/Dockerfile
+++ b/images/base-notebook/Dockerfile
@@ -7,7 +7,7 @@ FROM $BASE_IMAGE
 
 # mamba doesn't respect and of the normal TLS environment variables REQUESTS_CA_BUNDLE, SSL_CERT_FILE, CURL_CA_BUNDLE
 # This causes a problem when building images behind a corporate proxy even when the images have the certificates installed
-# mamba config set ssl_verify "$SSL_CERT_FILE"; needs to be called. 
+# mamba config set ssl_verify "$SSL_CERT_FILE"; needs to be called.
 ARG SSL_CERT_FILE
 
 LABEL maintainer="Jupyter Project <jupyter@googlegroups.com>"

--- a/images/base-notebook/Dockerfile
+++ b/images/base-notebook/Dockerfile
@@ -5,6 +5,11 @@ ARG OWNER=jupyter
 ARG BASE_IMAGE=$REGISTRY/$OWNER/docker-stacks-foundation
 FROM $BASE_IMAGE
 
+# mamba doesn't respect and of the normal TLS environment variables REQUESTS_CA_BUNDLE, SSL_CERT_FILE, CURL_CA_BUNDLE
+# This causes a problem when building images behind a corporate proxy even when the images have the certificates installed
+# mamba config set ssl_verify "$SSL_CERT_FILE"; needs to be called. 
+ARG SSL_CERT_FILE
+
 LABEL maintainer="Jupyter Project <jupyter@googlegroups.com>"
 
 # Fix: https://github.com/hadolint/hadolint/wiki/DL4006
@@ -38,7 +43,10 @@ USER ${NB_UID}
 # Do all this in a single RUN command to avoid duplicating all of the
 # files across image layers when the permissions change
 WORKDIR /tmp
-RUN mamba install --yes \
+RUN if [ -n "$SSL_CERT_FILE" ]; then \
+        mamba config set ssl_verify "$SSL_CERT_FILE"; \
+    fi && \
+    mamba install --yes \
     'jupyterhub-singleuser' \
     'jupyterlab' \
     'nbclassic' \


### PR DESCRIPTION
## Describe your changes

mamba doesn't respect the normal SSL configuration environment variables.  This allows the configuration of this
at build time. This way someone building behind a corporate proxy doesn't need to intject and intermediate image
between the docker-stacks-foundation image and the base-notebook image.

This PR is not complete but before update docs/tests I wanted to see if it would be accepted as a feature.

## Checklist (especially for first-time contributors)

- [X] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests
- [X] I will try not to use force-push to make the review process easier for reviewers
- [ ] I have updated the documentation for significant changes

<!-- markdownlint-disable-file MD041 -->
