### PR TITLE
Use tty for running docker commands by default

### DIFF
--- a/tests/by_image/docker-stacks-foundation/test_user_options.py
+++ b/tests/by_image/docker-stacks-foundation/test_user_options.py
@@ -175,6 +175,8 @@ def test_set_uid(container: TrackedContainer) -> None:
     Additionally, verify that "--group-add=users" is suggested in a warning to restore
     write access.
     """
+    # This test needs to have tty disabled, the reason is explained here:
+    # https://github.com/jupyter/docker-stacks/pull/2260#discussion_r2008821257
     logs = container.run_and_wait(
         timeout=5, no_warnings=False, user="1010", command=["id"], tty=False
     )

--- a/tests/by_image/docker-stacks-foundation/test_user_options.py
+++ b/tests/by_image/docker-stacks-foundation/test_user_options.py
@@ -176,10 +176,7 @@ def test_set_uid(container: TrackedContainer) -> None:
     write access.
     """
     logs = container.run_and_wait(
-        timeout=5,
-        no_warnings=False,
-        user="1010",
-        command=["id"],
+        timeout=5, no_warnings=False, user="1010", command=["id"], tty=False
     )
     assert "uid=1010(jovyan) gid=0(root)" in logs
     warnings = TrackedContainer.get_warnings(logs)

--- a/tests/utils/tracked_container.py
+++ b/tests/utils/tracked_container.py
@@ -91,8 +91,6 @@ class TrackedContainer:
         assert no_warnings == (not self.get_warnings(logs))
         assert no_errors == (not self.get_errors(logs))
         assert no_failure == (rv["StatusCode"] == 0)
-
-        self.remove()
         return logs
 
     @staticmethod
@@ -115,4 +113,3 @@ class TrackedContainer:
             LOGGER.info(f"Removing container {self.container.name} ...")
             self.container.remove(force=True)
             LOGGER.info(f"Container {self.container.name} removed")
-            self.container = None

--- a/tests/utils/tracked_container.py
+++ b/tests/utils/tracked_container.py
@@ -45,8 +45,10 @@ class TrackedContainer:
             extending and/or overriding key/value pairs passed to the constructor
         """
         LOGGER.info(f"Running {self.image_name} with args {kwargs} ...")
+        default_kwargs = {"detach": True, "tty": True}
+        final_kwargs = default_kwargs | kwargs
         self.container = self.docker_client.containers.run(
-            self.image_name, **kwargs, detach=True
+            self.image_name, **final_kwargs
         )
 
     def get_logs(self) -> str:
@@ -64,7 +66,9 @@ class TrackedContainer:
         assert self.container is not None
         container = self.container
         LOGGER.info(f"Running cmd: `{cmd}` on container: {container.name}")
-        exec_result = container.exec_run(cmd, **kwargs)
+        default_kwargs = {"tty": True}
+        final_kwargs = default_kwargs | kwargs
+        exec_result = container.exec_run(cmd, **final_kwargs)
         output = exec_result.output.decode().rstrip()
         assert isinstance(output, str)
         LOGGER.info(f"Command output: {output}")
@@ -87,6 +91,8 @@ class TrackedContainer:
         assert no_warnings == (not self.get_warnings(logs))
         assert no_errors == (not self.get_errors(logs))
         assert no_failure == (rv["StatusCode"] == 0)
+
+        self.remove()
         return logs
 
     @staticmethod
@@ -109,3 +115,4 @@ class TrackedContainer:
             LOGGER.info(f"Removing container {self.container.name} ...")
             self.container.remove(force=True)
             LOGGER.info(f"Container {self.container.name} removed")
+            self.container = None


### PR DESCRIPTION
## Describe your changes

## Issue ticket if applicable

<!-- Example - Fix: https://github.com/jupyter/docker-stacks/issues/0 -->

## Checklist (especially for first-time contributors)

- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests
- [ ] I will try not to use force-push to make the review process easier for reviewers
- [ ] I have updated the documentation for significant changes

<!-- markdownlint-disable-file MD041 -->
