### PR TITLE
Do not reset docker state

### DIFF
--- a/.github/workflows/docker-merge-tags.yml
+++ b/.github/workflows/docker-merge-tags.yml
@@ -48,15 +48,6 @@ jobs:
           path: /tmp/jupyter/tags/
         if: ${{ !contains(inputs.variant, 'cuda') }}
 
-      # Docker might be stuck when pulling images
-      # https://github.com/docker/for-mac/issues/2083
-      # https://stackoverflow.com/questions/38087027/docker-compose-stuck-downloading-or-pulling-fs-layer
-      - name: Reset docker state 🗑️
-        run: |
-          docker system prune --all --force
-          sudo systemctl restart docker
-        shell: bash
-
       - name: Login to Registry 🔐
         if: env.PUSH_TO_REGISTRY == 'true'
         uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0


### PR DESCRIPTION
## Describe your changes

Now we install latest docker engine, so the problem might be gone.
We will stop installing latest docker, when runners update built-in version to a recent one (should happen in May).

I will revert this change, if docker will be stuck during `docker pull`

## Issue ticket if applicable

<!-- Example - Fix: https://github.com/jupyter/docker-stacks/issues/0 -->

## Checklist (especially for first-time contributors)

- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests
- [ ] I will try not to use force-push to make the review process easier for reviewers
- [ ] I have updated the documentation for significant changes

<!-- markdownlint-disable-file MD041 -->
