### PR TITLE
Force using keyword-only arguments where types are the same

### DIFF
--- a/images/pyspark-notebook/setup_spark.py
+++ b/images/pyspark-notebook/setup_spark.py
@@ -55,6 +55,7 @@ def get_latest_spark_version() -> str:
 
 
 def download_spark(
+    *,
     spark_version: str,
     hadoop_version: str,
     scala_version: str,

--- a/tagging/apps/apply_tags.py
+++ b/tagging/apps/apply_tags.py
@@ -17,7 +17,9 @@ LOGGER = logging.getLogger(__name__)
 def apply_tags(config: Config) -> None:
     LOGGER.info(f"Tagging image: {config.image}")
 
-    file_prefix = get_file_prefix_for_platform(config.platform, config.variant)
+    file_prefix = get_file_prefix_for_platform(
+        platform=config.platform, variant=config.variant
+    )
     filename = f"{file_prefix}-{config.image}.txt"
     tags = (config.tags_dir / filename).read_text().splitlines()
 

--- a/tagging/apps/merge_tags.py
+++ b/tagging/apps/merge_tags.py
@@ -26,7 +26,9 @@ def read_local_tags_from_files(config: Config) -> tuple[list[str], set[str]]:
     for platform in ALL_PLATFORMS:
         LOGGER.info(f"Reading tags for platform: {platform}")
 
-        file_prefix = get_file_prefix_for_platform(platform, config.variant)
+        file_prefix = get_file_prefix_for_platform(
+            platform=platform, variant=config.variant
+        )
         filename = f"{file_prefix}-{config.image}.txt"
         path = config.tags_dir / filename
         if not path.exists():

--- a/tagging/apps/write_manifest.py
+++ b/tagging/apps/write_manifest.py
@@ -22,7 +22,7 @@ BUILD_TIMESTAMP = datetime.datetime.now(datetime.UTC).isoformat()[:-13] + "Z"
 MARKDOWN_LINE_BREAK = "<br />"
 
 
-def get_build_history_line(config: Config, filename: str, container: Container) -> str:
+def get_build_history_line(config: Config, container: Container, filename: str) -> str:
     LOGGER.info(f"Calculating build history line for image: {config.image}")
 
     taggers = get_taggers(config.image)
@@ -48,19 +48,19 @@ def get_build_history_line(config: Config, filename: str, container: Container) 
 
 
 def write_build_history_line(
-    config: Config, filename: str, container: Container
+    config: Config, container: Container, filename: str
 ) -> None:
     LOGGER.info(f"Writing tags for image: {config.image}")
 
     path = config.hist_lines_dir / f"{filename}.txt"
     path.parent.mkdir(parents=True, exist_ok=True)
-    build_history_line = get_build_history_line(config, filename, container)
+    build_history_line = get_build_history_line(config, container, filename)
     path.write_text(build_history_line)
 
     LOGGER.info(f"Build history line written to: {path}")
 
 
-def get_manifest(config: Config, commit_hash_tag: str, container: Container) -> str:
+def get_manifest(config: Config, container: Container, commit_hash_tag: str) -> str:
     LOGGER.info(f"Calculating manifest file for image: {config.image}")
 
     manifests = get_manifests(config.image)
@@ -87,7 +87,7 @@ def get_manifest(config: Config, commit_hash_tag: str, container: Container) -> 
 
 
 def write_manifest(
-    config: Config, filename: str, commit_hash_tag: str, container: Container
+    config: Config, container: Container, *, filename: str, commit_hash_tag: str
 ) -> None:
     LOGGER.info(f"Writing manifest file for image: {config.image}")
 
@@ -107,8 +107,10 @@ def write_all(config: Config) -> None:
     filename = f"{file_prefix}-{config.image}-{commit_hash_tag}"
 
     with DockerRunner(config.full_image()) as container:
-        write_build_history_line(config, filename, container)
-        write_manifest(config, filename, commit_hash_tag, container)
+        write_build_history_line(config, container, filename)
+        write_manifest(
+            config, container, filename=filename, commit_hash_tag=commit_hash_tag
+        )
 
     LOGGER.info(f"All files written for image: {config.image}")
 

--- a/tagging/apps/write_manifest.py
+++ b/tagging/apps/write_manifest.py
@@ -93,7 +93,7 @@ def write_manifest(
 
     path = config.manifests_dir / f"{filename}.md"
     path.parent.mkdir(parents=True, exist_ok=True)
-    manifest = get_manifest(config, commit_hash_tag, container)
+    manifest = get_manifest(config, container, commit_hash_tag)
     path.write_text(manifest)
 
     LOGGER.info(f"Manifest file wrtitten to: {path}")

--- a/tagging/utils/get_prefix.py
+++ b/tagging/utils/get_prefix.py
@@ -5,11 +5,11 @@ from tagging.utils.get_platform import get_platform
 DEFAULT_VARIANT = "default"
 
 
-def get_file_prefix_for_platform(platform: str, variant: str) -> str:
+def get_file_prefix_for_platform(*, platform: str, variant: str) -> str:
     return f"{platform}-{variant}"
 
 
-def get_tag_prefix_for_platform(platform: str, variant: str) -> str:
+def _get_tag_prefix_for_platform(*, platform: str, variant: str) -> str:
     if variant == DEFAULT_VARIANT:
         return platform
     return f"{platform}-{variant}"
@@ -17,9 +17,9 @@ def get_tag_prefix_for_platform(platform: str, variant: str) -> str:
 
 def get_file_prefix(variant: str) -> str:
     platform = get_platform()
-    return get_file_prefix_for_platform(platform, variant)
+    return get_file_prefix_for_platform(platform=platform, variant=variant)
 
 
 def get_tag_prefix(variant: str) -> str:
     platform = get_platform()
-    return get_tag_prefix_for_platform(platform, variant)
+    return _get_tag_prefix_for_platform(platform=platform, variant=variant)

--- a/tests/by_image/base-notebook/test_healthcheck.py
+++ b/tests/by_image/base-notebook/test_healthcheck.py
@@ -12,6 +12,7 @@ LOGGER = logging.getLogger(__name__)
 
 def get_healthy_status(
     container: TrackedContainer,
+    *,
     env: list[str] | None,
     cmd: list[str] | None,
     user: str | None,
@@ -84,7 +85,7 @@ def test_healthy(
     cmd: list[str] | None,
     user: str | None,
 ) -> None:
-    assert get_healthy_status(container, env, cmd, user) == "healthy"
+    assert get_healthy_status(container, env=env, cmd=cmd, user=user) == "healthy"
 
 
 @pytest.mark.parametrize(
@@ -117,7 +118,7 @@ def test_healthy_with_proxy(
     cmd: list[str] | None,
     user: str | None,
 ) -> None:
-    assert get_healthy_status(container, env, cmd, user) == "healthy"
+    assert get_healthy_status(container, env=env, cmd=cmd, user=user) == "healthy"
 
 
 @pytest.mark.parametrize(
@@ -140,5 +141,5 @@ def test_not_healthy(
     cmd: list[str] | None,
 ) -> None:
     assert (
-        get_healthy_status(container, env, cmd, user=None) != "healthy"
+        get_healthy_status(container, env=env, cmd=cmd, user=None) != "healthy"
     ), "Container should not be healthy for this testcase"

--- a/tests/by_image/docker-stacks-foundation/test_run_hooks.py
+++ b/tests/by_image/docker-stacks-foundation/test_run_hooks.py
@@ -70,6 +70,7 @@ def test_run_hooks_empty_dir(container: TrackedContainer) -> None:
 
 def run_source_in_dir(
     container: TrackedContainer,
+    *,
     subdir: str,
     command_suffix: str = "",
     no_failure: bool = True,

--- a/tests/utils/tracked_container.py
+++ b/tests/utils/tracked_container.py
@@ -1,7 +1,7 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 import logging
-from typing import Any
+from typing import Any, LiteralString
 
 import docker
 from docker.models.containers import Container
@@ -85,6 +85,7 @@ class TrackedContainer:
     def run_and_wait(
         self,
         timeout: int,
+        *,
         no_warnings: bool = True,
         no_errors: bool = True,
         no_failure: bool = True,
@@ -123,7 +124,7 @@ class TrackedContainer:
         return TrackedContainer._lines_starting_with(logs, "WARNING")
 
     @staticmethod
-    def _lines_starting_with(logs: str, pattern: str) -> list[str]:
+    def _lines_starting_with(logs: str, pattern: LiteralString) -> list[str]:
         return [line for line in logs.splitlines() if line.startswith(pattern)]
 
     def remove(self) -> None:


### PR DESCRIPTION
## Describe your changes

## Issue ticket if applicable

<!-- Example - Fix: https://github.com/jupyter/docker-stacks/issues/0 -->

## Checklist (especially for first-time contributors)

- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests
- [ ] I will try not to use force-push to make the review process easier for reviewers
- [ ] I have updated the documentation for significant changes

<!-- markdownlint-disable-file MD041 -->
