### PR TITLE
Upgrade CUDA version used in PyTorch cuda12-variant to 12.8

### DIFF
--- a/images/pytorch-notebook/cuda12/Dockerfile
+++ b/images/pytorch-notebook/cuda12/Dockerfile
@@ -13,7 +13,7 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # Install PyTorch with pip (https://pytorch.org/get-started/locally/)
 # hadolint ignore=DL3013
-RUN pip install --no-cache-dir --extra-index-url=https://pypi.nvidia.com --index-url 'https://download.pytorch.org/whl/cu124' \
+RUN pip install --no-cache-dir --extra-index-url=https://pypi.nvidia.com --index-url 'https://download.pytorch.org/whl/cu128' \
     'torch' \
     'torchaudio' \
     'torchvision' && \


### PR DESCRIPTION
## Describe your changes

Upgrade the CUDA-version used in the PyTorch image from 12.4 to 12.8 . This is needed to get PyTorch working on recent GPUs like the RTX5090 with nvidia drivers R570 which has CUDA version 12.8 .

I tested the resulting image on an older machine which is running R535 with CUDA version 12.2, and my local tests ran fine. I don't think that there are any adverse effects to upgrading the CUDA version used.

Also, note that the PyTorch-release with CUDA 12.4 is not even mentioned anymore on https://pytorch.org/get-started/locally/, so it makes sense to update our version used to something that is officially supported.

![image](https://github.com/user-attachments/assets/1c6d0050-326f-4b0c-b9a4-d59d66b812db)

For further reference, the following script was used to diagnose the original issue I had:

```python
import torch

# Check if GPU is available
device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
print(f"Using device: {device}")
# Create large tensors
size = 10000

a = torch.randn(size, size, device=device)
```

Using the current image results in this error:

```bash
(base) jovyan@99ca327e81ed:/work$ python3 test.py
Using device: cuda
/opt/conda/lib/python3.12/site-packages/torch/cuda/__init__.py:235: UserWarning:
NVIDIA GeForce RTX 5090 with CUDA capability sm_120 is not compatible with the current PyTorch installation.
The current PyTorch install supports CUDA capabilities sm_50 sm_60 sm_70 sm_75 sm_80 sm_86 sm_90.
If you want to use the NVIDIA GeForce RTX 5090 GPU with PyTorch, please check the instructions at https://pytorch.org/get-started/locally/

  warnings.warn(
Traceback (most recent call last):
  File "/work/torch-stress.py", line 10, in <module>
    a = torch.randn(size, size, device=device)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
RuntimeError: CUDA error: no kernel image is available for execution on the device
CUDA kernel errors might be asynchronously reported at some other API call, so the stacktrace below might be incorrect.
For debugging consider passing CUDA_LAUNCH_BLOCKING=1
Compile with `TORCH_USE_CUDA_DSA` to enable device-side assertions.
```

After applying the fix in this PR, this code runs without issues.

## Issue ticket if applicable

<!-- Example - Fix: https://github.com/jupyter/docker-stacks/issues/0 -->

## Checklist (especially for first-time contributors)

- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests
- [x] I will try not to use force-push to make the review process easier for reviewers
- [ ] I have updated the documentation for significant changes

<!-- markdownlint-disable-file MD041 -->
