### PR TITLE
Do not update permissions for user cache

### DIFF
--- a/docs/using/common.md
+++ b/docs/using/common.md
@@ -256,6 +256,7 @@ You can use either `mamba`, `pip`, or `conda` (`mamba` is recommended) to instal
 # the installation
 mamba install --yes some-package && \
     mamba clean --all -f -y && \
+    (rm -r /home/${NB_USER}/.cache/rosetta || true) && \
     fix-permissions "${CONDA_DIR}" && \
     fix-permissions "/home/${NB_USER}"
 
@@ -285,6 +286,7 @@ conda config --system --prepend channels defaults
 # install a package
 mamba install --yes humanize && \
     mamba clean --all -f -y && \
+    (rm -r /home/${NB_USER}/.cache/rosetta || true) && \
     fix-permissions "${CONDA_DIR}" && \
     fix-permissions "/home/${NB_USER}"
 ```

--- a/docs/using/common.md
+++ b/docs/using/common.md
@@ -256,7 +256,7 @@ You can use either `mamba`, `pip`, or `conda` (`mamba` is recommended) to instal
 # the installation
 mamba install --yes some-package && \
     mamba clean --all -f -y && \
-    (rm -r /home/${NB_USER}/.cache/rosetta || true) && \
+    (rm -r /home/"${NB_USER}"/.cache/rosetta || true) && \
     fix-permissions "${CONDA_DIR}" && \
     fix-permissions "/home/${NB_USER}"
 
@@ -286,7 +286,7 @@ conda config --system --prepend channels defaults
 # install a package
 mamba install --yes humanize && \
     mamba clean --all -f -y && \
-    (rm -r /home/${NB_USER}/.cache/rosetta || true) && \
+    (rm -r /home/"${NB_USER}"/.cache/rosetta || true) && \
     fix-permissions "${CONDA_DIR}" && \
     fix-permissions "/home/${NB_USER}"
 ```

--- a/docs/using/recipe_code/dask_jupyterlab.dockerfile
+++ b/docs/using/recipe_code/dask_jupyterlab.dockerfile
@@ -4,7 +4,7 @@ FROM $BASE_IMAGE
 # Install the Dask dashboard
 RUN mamba install --yes 'dask-labextension' && \
     mamba clean --all -f -y && \
-    (rm -r /home/${NB_USER}/.cache/rosetta || true) && \
+    (rm -r /home/"${NB_USER}"/.cache/rosetta || true) && \
     fix-permissions "${CONDA_DIR}" && \
     fix-permissions "/home/${NB_USER}"
 

--- a/docs/using/recipe_code/dask_jupyterlab.dockerfile
+++ b/docs/using/recipe_code/dask_jupyterlab.dockerfile
@@ -4,6 +4,7 @@ FROM $BASE_IMAGE
 # Install the Dask dashboard
 RUN mamba install --yes 'dask-labextension' && \
     mamba clean --all -f -y && \
+    (rm -r /home/${NB_USER}/.cache/rosetta || true) && \
     fix-permissions "${CONDA_DIR}" && \
     fix-permissions "/home/${NB_USER}"
 

--- a/docs/using/recipe_code/ijavascript.dockerfile
+++ b/docs/using/recipe_code/ijavascript.dockerfile
@@ -15,6 +15,7 @@ USER ${NB_UID}
 # https://github.com/n-riesco/ijavascript/issues/184
 RUN mamba install --yes nodejs=20.* && \
     mamba clean --all -f -y && \
+    (rm -r /home/${NB_USER}/.cache/rosetta || true) && \
     fix-permissions "${CONDA_DIR}" && \
     fix-permissions "/home/${NB_USER}"
 

--- a/docs/using/recipe_code/ijavascript.dockerfile
+++ b/docs/using/recipe_code/ijavascript.dockerfile
@@ -15,7 +15,7 @@ USER ${NB_UID}
 # https://github.com/n-riesco/ijavascript/issues/184
 RUN mamba install --yes nodejs=20.* && \
     mamba clean --all -f -y && \
-    (rm -r /home/${NB_USER}/.cache/rosetta || true) && \
+    (rm -r /home/"${NB_USER}"/.cache/rosetta || true) && \
     fix-permissions "${CONDA_DIR}" && \
     fix-permissions "/home/${NB_USER}"
 

--- a/docs/using/recipe_code/jupyterhub_version.dockerfile
+++ b/docs/using/recipe_code/jupyterhub_version.dockerfile
@@ -3,5 +3,6 @@ FROM $BASE_IMAGE
 
 RUN mamba install --yes 'jupyterhub-singleuser==5.2.1' && \
     mamba clean --all -f -y && \
+    (rm -r /home/${NB_USER}/.cache/rosetta || true) && \
     fix-permissions "${CONDA_DIR}" && \
     fix-permissions "/home/${NB_USER}"

--- a/docs/using/recipe_code/jupyterhub_version.dockerfile
+++ b/docs/using/recipe_code/jupyterhub_version.dockerfile
@@ -3,6 +3,6 @@ FROM $BASE_IMAGE
 
 RUN mamba install --yes 'jupyterhub-singleuser==5.2.1' && \
     mamba clean --all -f -y && \
-    (rm -r /home/${NB_USER}/.cache/rosetta || true) && \
+    (rm -r /home/"${NB_USER}"/.cache/rosetta || true) && \
     fix-permissions "${CONDA_DIR}" && \
     fix-permissions "/home/${NB_USER}"

--- a/docs/using/recipe_code/mamba_install.dockerfile
+++ b/docs/using/recipe_code/mamba_install.dockerfile
@@ -3,7 +3,7 @@ FROM $BASE_IMAGE
 
 RUN mamba install --yes 'flake8' && \
     mamba clean --all -f -y && \
-    (rm -r /home/${NB_USER}/.cache/rosetta || true) && \
+    (rm -r /home/"${NB_USER}"/.cache/rosetta || true) && \
     fix-permissions "${CONDA_DIR}" && \
     fix-permissions "/home/${NB_USER}"
 
@@ -11,6 +11,6 @@ RUN mamba install --yes 'flake8' && \
 COPY --chown=${NB_UID}:${NB_GID} requirements.txt /tmp/
 RUN mamba install --yes --file /tmp/requirements.txt && \
     mamba clean --all -f -y && \
-    (rm -r /home/${NB_USER}/.cache/rosetta || true) && \
+    (rm -r /home/"${NB_USER}"/.cache/rosetta || true) && \
     fix-permissions "${CONDA_DIR}" && \
     fix-permissions "/home/${NB_USER}"

--- a/docs/using/recipe_code/mamba_install.dockerfile
+++ b/docs/using/recipe_code/mamba_install.dockerfile
@@ -3,6 +3,7 @@ FROM $BASE_IMAGE
 
 RUN mamba install --yes 'flake8' && \
     mamba clean --all -f -y && \
+    (rm -r /home/${NB_USER}/.cache/rosetta || true) && \
     fix-permissions "${CONDA_DIR}" && \
     fix-permissions "/home/${NB_USER}"
 
@@ -10,5 +11,6 @@ RUN mamba install --yes 'flake8' && \
 COPY --chown=${NB_UID}:${NB_GID} requirements.txt /tmp/
 RUN mamba install --yes --file /tmp/requirements.txt && \
     mamba clean --all -f -y && \
+    (rm -r /home/${NB_USER}/.cache/rosetta || true) && \
     fix-permissions "${CONDA_DIR}" && \
     fix-permissions "/home/${NB_USER}"

--- a/docs/using/recipe_code/microsoft_odbc.dockerfile
+++ b/docs/using/recipe_code/microsoft_odbc.dockerfile
@@ -27,6 +27,6 @@ USER ${NB_UID}
 
 RUN mamba install --yes 'pyodbc' && \
     mamba clean --all -f -y && \
-    (rm -r /home/${NB_USER}/.cache/rosetta || true) && \
+    (rm -r /home/"${NB_USER}"/.cache/rosetta || true) && \
     fix-permissions "${CONDA_DIR}" && \
     fix-permissions "/home/${NB_USER}"

--- a/docs/using/recipe_code/microsoft_odbc.dockerfile
+++ b/docs/using/recipe_code/microsoft_odbc.dockerfile
@@ -27,5 +27,6 @@ USER ${NB_UID}
 
 RUN mamba install --yes 'pyodbc' && \
     mamba clean --all -f -y && \
+    (rm -r /home/${NB_USER}/.cache/rosetta || true) && \
     fix-permissions "${CONDA_DIR}" && \
     fix-permissions "/home/${NB_USER}"

--- a/docs/using/recipe_code/oracledb.dockerfile
+++ b/docs/using/recipe_code/oracledb.dockerfile
@@ -57,5 +57,6 @@ WORKDIR "${HOME}"
 # Install `oracledb` Python library to use Oracle SQL Instant Client
 RUN mamba install --yes 'oracledb' && \
     mamba clean --all -f -y && \
+    (rm -r /home/${NB_USER}/.cache/rosetta || true) && \
     fix-permissions "${CONDA_DIR}" && \
     fix-permissions "/home/${NB_USER}"

--- a/docs/using/recipe_code/oracledb.dockerfile
+++ b/docs/using/recipe_code/oracledb.dockerfile
@@ -57,6 +57,6 @@ WORKDIR "${HOME}"
 # Install `oracledb` Python library to use Oracle SQL Instant Client
 RUN mamba install --yes 'oracledb' && \
     mamba clean --all -f -y && \
-    (rm -r /home/${NB_USER}/.cache/rosetta || true) && \
+    (rm -r /home/"${NB_USER}"/.cache/rosetta || true) && \
     fix-permissions "${CONDA_DIR}" && \
     fix-permissions "/home/${NB_USER}"

--- a/docs/using/recipe_code/rise_jupyterlab.dockerfile
+++ b/docs/using/recipe_code/rise_jupyterlab.dockerfile
@@ -3,6 +3,6 @@ FROM $BASE_IMAGE
 
 RUN mamba install --yes 'jupyterlab_rise' && \
     mamba clean --all -f -y && \
-    (rm -r /home/${NB_USER}/.cache/rosetta || true) && \
+    (rm -r /home/"${NB_USER}"/.cache/rosetta || true) && \
     fix-permissions "${CONDA_DIR}" && \
     fix-permissions "/home/${NB_USER}"

--- a/docs/using/recipe_code/rise_jupyterlab.dockerfile
+++ b/docs/using/recipe_code/rise_jupyterlab.dockerfile
@@ -3,5 +3,6 @@ FROM $BASE_IMAGE
 
 RUN mamba install --yes 'jupyterlab_rise' && \
     mamba clean --all -f -y && \
+    (rm -r /home/${NB_USER}/.cache/rosetta || true) && \
     fix-permissions "${CONDA_DIR}" && \
     fix-permissions "/home/${NB_USER}"

--- a/docs/using/recipe_code/xgboost.dockerfile
+++ b/docs/using/recipe_code/xgboost.dockerfile
@@ -3,5 +3,6 @@ FROM $BASE_IMAGE
 
 RUN mamba install --yes 'py-xgboost' && \
     mamba clean --all -f -y && \
+    (rm -r /home/${NB_USER}/.cache/rosetta || true) && \
     fix-permissions "${CONDA_DIR}" && \
     fix-permissions "/home/${NB_USER}"

--- a/docs/using/recipe_code/xgboost.dockerfile
+++ b/docs/using/recipe_code/xgboost.dockerfile
@@ -3,6 +3,6 @@ FROM $BASE_IMAGE
 
 RUN mamba install --yes 'py-xgboost' && \
     mamba clean --all -f -y && \
-    (rm -r /home/${NB_USER}/.cache/rosetta || true) && \
+    (rm -r /home/"${NB_USER}"/.cache/rosetta || true) && \
     fix-permissions "${CONDA_DIR}" && \
     fix-permissions "/home/${NB_USER}"

--- a/docs/using/recipes.md
+++ b/docs/using/recipes.md
@@ -422,7 +422,7 @@ FROM quay.io/jupyter/pyspark-notebook
 
 RUN mamba install --yes 'delta-spark' && \
     mamba clean --all -f -y && \
-    (rm -r /home/${NB_USER}/.cache/rosetta || true) && \
+    (rm -r /home/"${NB_USER}"/.cache/rosetta || true) && \
     fix-permissions "${CONDA_DIR}" && \
     fix-permissions "/home/${NB_USER}"
 

--- a/docs/using/recipes.md
+++ b/docs/using/recipes.md
@@ -422,6 +422,7 @@ FROM quay.io/jupyter/pyspark-notebook
 
 RUN mamba install --yes 'delta-spark' && \
     mamba clean --all -f -y && \
+    (rm -r /home/${NB_USER}/.cache/rosetta || true) && \
     fix-permissions "${CONDA_DIR}" && \
     fix-permissions "/home/${NB_USER}"
 

--- a/images/all-spark-notebook/Dockerfile
+++ b/images/all-spark-notebook/Dockerfile
@@ -35,5 +35,6 @@ RUN mamba install --yes \
     'r-rcurl' \
     'r-sparklyr' && \
     mamba clean --all -f -y && \
+    (rm -r /home/${NB_USER}/.cache/rosetta || true) && \
     fix-permissions "${CONDA_DIR}" && \
     fix-permissions "/home/${NB_USER}"

--- a/images/all-spark-notebook/Dockerfile
+++ b/images/all-spark-notebook/Dockerfile
@@ -35,6 +35,6 @@ RUN mamba install --yes \
     'r-rcurl' \
     'r-sparklyr' && \
     mamba clean --all -f -y && \
-    (rm -r /home/${NB_USER}/.cache/rosetta || true) && \
+    (rm -r /home/"${NB_USER}"/.cache/rosetta || true) && \
     fix-permissions "${CONDA_DIR}" && \
     fix-permissions "/home/${NB_USER}"

--- a/images/base-notebook/Dockerfile
+++ b/images/base-notebook/Dockerfile
@@ -50,6 +50,7 @@ RUN mamba install --yes \
     jupyter server --generate-config && \
     mamba clean --all -f -y && \
     jupyter lab clean && \
+    (rm -r /home/${NB_USER}/.cache/rosetta || true) && \
     rm -rf "/home/${NB_USER}/.cache/yarn" && \
     fix-permissions "${CONDA_DIR}" && \
     fix-permissions "/home/${NB_USER}"

--- a/images/base-notebook/Dockerfile
+++ b/images/base-notebook/Dockerfile
@@ -50,7 +50,7 @@ RUN mamba install --yes \
     jupyter server --generate-config && \
     mamba clean --all -f -y && \
     jupyter lab clean && \
-    (rm -r /home/${NB_USER}/.cache/rosetta || true) && \
+    (rm -r /home/"${NB_USER}"/.cache/rosetta || true) && \
     rm -rf "/home/${NB_USER}/.cache/yarn" && \
     fix-permissions "${CONDA_DIR}" && \
     fix-permissions "/home/${NB_USER}"

--- a/images/datascience-notebook/Dockerfile
+++ b/images/datascience-notebook/Dockerfile
@@ -59,6 +59,6 @@ RUN mamba install --yes \
     'rpy2' \
     'unixodbc' && \
     mamba clean --all -f -y && \
-    (rm -r /home/${NB_USER}/.cache/rosetta || true) && \
+    (rm -r /home/"${NB_USER}"/.cache/rosetta || true) && \
     fix-permissions "${CONDA_DIR}" && \
     fix-permissions "/home/${NB_USER}"

--- a/images/datascience-notebook/Dockerfile
+++ b/images/datascience-notebook/Dockerfile
@@ -59,5 +59,6 @@ RUN mamba install --yes \
     'rpy2' \
     'unixodbc' && \
     mamba clean --all -f -y && \
+    (rm -r /home/${NB_USER}/.cache/rosetta || true) && \
     fix-permissions "${CONDA_DIR}" && \
     fix-permissions "/home/${NB_USER}"

--- a/images/docker-stacks-foundation/Dockerfile
+++ b/images/docker-stacks-foundation/Dockerfile
@@ -135,6 +135,7 @@ RUN set -x && \
     # https://github.com/conda-forge/libxml2-feedstock/issues/145
     echo 'libxml2<2.14.0' >> /opt/conda/conda-meta/pinned && \
     mamba clean --all -f -y && \
+    (rm -r /home/${NB_USER}/.cache/rosetta || true) && \
     fix-permissions "${CONDA_DIR}" && \
     fix-permissions "/home/${NB_USER}"
 

--- a/images/docker-stacks-foundation/Dockerfile
+++ b/images/docker-stacks-foundation/Dockerfile
@@ -135,7 +135,7 @@ RUN set -x && \
     # https://github.com/conda-forge/libxml2-feedstock/issues/145
     echo 'libxml2<2.14.0' >> /opt/conda/conda-meta/pinned && \
     mamba clean --all -f -y && \
-    (rm -r /home/${NB_USER}/.cache/rosetta || true) && \
+    (rm -r /home/"${NB_USER}"/.cache/rosetta || true) && \
     fix-permissions "${CONDA_DIR}" && \
     fix-permissions "/home/${NB_USER}"
 

--- a/images/docker-stacks-foundation/fix-permissions
+++ b/images/docker-stacks-foundation/fix-permissions
@@ -20,6 +20,7 @@ for d in "$@"; do
         ! \( \
             -group "${NB_GID}" \
             -a -perm -g+rwX \
+            -path "/home/jovyan/.cache" -prune \
         \) \
         -exec chgrp "${NB_GID}" -- {} \+ \
         -exec chmod g+rwX -- {} \+
@@ -28,6 +29,7 @@ for d in "$@"; do
         \( \
             -type d \
             -a ! -perm -6000 \
+            -path "/home/jovyan/.cache" -prune \
         \) \
         -exec chmod +6000 -- {} \+
 done

--- a/images/docker-stacks-foundation/fix-permissions
+++ b/images/docker-stacks-foundation/fix-permissions
@@ -20,7 +20,6 @@ for d in "$@"; do
         ! \( \
             -group "${NB_GID}" \
             -a -perm -g+rwX \
-            -path "/home/jovyan/.cache" -prune \
         \) \
         -exec chgrp "${NB_GID}" -- {} \+ \
         -exec chmod g+rwX -- {} \+
@@ -29,7 +28,6 @@ for d in "$@"; do
         \( \
             -type d \
             -a ! -perm -6000 \
-            -path "/home/jovyan/.cache" -prune \
         \) \
         -exec chmod +6000 -- {} \+
 done

--- a/images/minimal-notebook/setup-scripts/setup-julia-packages.bash
+++ b/images/minimal-notebook/setup-scripts/setup-julia-packages.bash
@@ -51,6 +51,6 @@ fix-permissions "${JULIA_PKGDIR}" "${CONDA_DIR}/share/jupyter"
 mamba install --yes \
     'jupyter-pluto-proxy' && \
     mamba clean --all -f -y && \
-    (rm -r /home/${NB_USER}/.cache/rosetta || true) && \
+    (rm -r /home/"${NB_USER}"/.cache/rosetta || true) && \
     fix-permissions "${CONDA_DIR}" && \
     fix-permissions "/home/${NB_USER}"

--- a/images/minimal-notebook/setup-scripts/setup-julia-packages.bash
+++ b/images/minimal-notebook/setup-scripts/setup-julia-packages.bash
@@ -51,5 +51,6 @@ fix-permissions "${JULIA_PKGDIR}" "${CONDA_DIR}/share/jupyter"
 mamba install --yes \
     'jupyter-pluto-proxy' && \
     mamba clean --all -f -y && \
+    (rm -r /home/${NB_USER}/.cache/rosetta || true) && \
     fix-permissions "${CONDA_DIR}" && \
     fix-permissions "/home/${NB_USER}"

--- a/images/pyspark-notebook/Dockerfile
+++ b/images/pyspark-notebook/Dockerfile
@@ -66,7 +66,7 @@ RUN mamba install --yes \
     'pandas=2.2.2' \
     'pyarrow' && \
     mamba clean --all -f -y && \
-    (rm -r /home/${NB_USER}/.cache/rosetta || true) && \
+    (rm -r /home/"${NB_USER}"/.cache/rosetta || true) && \
     fix-permissions "${CONDA_DIR}" && \
     fix-permissions "/home/${NB_USER}"
 

--- a/images/pyspark-notebook/Dockerfile
+++ b/images/pyspark-notebook/Dockerfile
@@ -66,6 +66,7 @@ RUN mamba install --yes \
     'pandas=2.2.2' \
     'pyarrow' && \
     mamba clean --all -f -y && \
+    (rm -r /home/${NB_USER}/.cache/rosetta || true) && \
     fix-permissions "${CONDA_DIR}" && \
     fix-permissions "/home/${NB_USER}"
 

--- a/images/r-notebook/Dockerfile
+++ b/images/r-notebook/Dockerfile
@@ -50,5 +50,6 @@ RUN mamba install --yes \
     'r-tidyverse' \
     'unixodbc' && \
     mamba clean --all -f -y && \
+    (rm -r /home/${NB_USER}/.cache/rosetta || true) && \
     fix-permissions "${CONDA_DIR}" && \
     fix-permissions "/home/${NB_USER}"

--- a/images/r-notebook/Dockerfile
+++ b/images/r-notebook/Dockerfile
@@ -50,6 +50,6 @@ RUN mamba install --yes \
     'r-tidyverse' \
     'unixodbc' && \
     mamba clean --all -f -y && \
-    (rm -r /home/${NB_USER}/.cache/rosetta || true) && \
+    (rm -r /home/"${NB_USER}"/.cache/rosetta || true) && \
     fix-permissions "${CONDA_DIR}" && \
     fix-permissions "/home/${NB_USER}"

--- a/images/scipy-notebook/Dockerfile
+++ b/images/scipy-notebook/Dockerfile
@@ -59,6 +59,7 @@ RUN mamba install --yes \
     'widgetsnbextension' \
     'xlrd' && \
     mamba clean --all -f -y && \
+    (rm -r /home/${NB_USER}/.cache/rosetta || true) && \
     fix-permissions "${CONDA_DIR}" && \
     fix-permissions "/home/${NB_USER}"
 

--- a/images/scipy-notebook/Dockerfile
+++ b/images/scipy-notebook/Dockerfile
@@ -59,7 +59,7 @@ RUN mamba install --yes \
     'widgetsnbextension' \
     'xlrd' && \
     mamba clean --all -f -y && \
-    (rm -r /home/${NB_USER}/.cache/rosetta || true) && \
+    (rm -r /home/"${NB_USER}"/.cache/rosetta || true) && \
     fix-permissions "${CONDA_DIR}" && \
     fix-permissions "/home/${NB_USER}"
 

--- a/images/tensorflow-notebook/Dockerfile
+++ b/images/tensorflow-notebook/Dockerfile
@@ -14,6 +14,7 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN mamba install --yes \
     'jupyter-server-proxy' && \
     mamba clean --all -f -y && \
+    (rm -r /home/${NB_USER}/.cache/rosetta || true) && \
     fix-permissions "${CONDA_DIR}" && \
     fix-permissions "/home/${NB_USER}"
 

--- a/images/tensorflow-notebook/Dockerfile
+++ b/images/tensorflow-notebook/Dockerfile
@@ -14,7 +14,7 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN mamba install --yes \
     'jupyter-server-proxy' && \
     mamba clean --all -f -y && \
-    (rm -r /home/${NB_USER}/.cache/rosetta || true) && \
+    (rm -r /home/"${NB_USER}"/.cache/rosetta || true) && \
     fix-permissions "${CONDA_DIR}" && \
     fix-permissions "/home/${NB_USER}"
 

--- a/images/tensorflow-notebook/cuda/Dockerfile
+++ b/images/tensorflow-notebook/cuda/Dockerfile
@@ -14,6 +14,7 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN mamba install --yes \
     'jupyter-server-proxy' && \
     mamba clean --all -f -y && \
+    (rm -r /home/${NB_USER}/.cache/rosetta || true) && \
     fix-permissions "${CONDA_DIR}" && \
     fix-permissions "/home/${NB_USER}"
 

--- a/images/tensorflow-notebook/cuda/Dockerfile
+++ b/images/tensorflow-notebook/cuda/Dockerfile
@@ -14,7 +14,7 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN mamba install --yes \
     'jupyter-server-proxy' && \
     mamba clean --all -f -y && \
-    (rm -r /home/${NB_USER}/.cache/rosetta || true) && \
+    (rm -r /home/"${NB_USER}"/.cache/rosetta || true) && \
     fix-permissions "${CONDA_DIR}" && \
     fix-permissions "/home/${NB_USER}"
 


### PR DESCRIPTION
## Describe your changes
When building images on macOS Version 15.4.1
`docker build ./images/pyspark-notebook --platform linux/amd64`
returns 
```
#5 28.91 chgrp: changing group of '/home/jovyan/.cache/rosetta': Operation not permitted
#5 28.93 chmod: changing permissions of '/home/jovyan/.cache/rosetta': Operation not permitted
```

Instead of chaging permissions for cache, we should ignore it.

## Issue ticket if applicable
https://github.com/jupyter/docker-stacks/issues/2296
<!-- Example - Fix: https://github.com/jupyter/docker-stacks/issues/0 -->

## Checklist (especially for first-time contributors)

- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests
- [ ] I will try not to use force-push to make the review process easier for reviewers
- [ ] I have updated the documentation for significant changes

<!-- markdownlint-disable-file MD041 -->
