### PR TITLE
Update selecting.md

### DIFF
--- a/docs/using/selecting.md
+++ b/docs/using/selecting.md
@@ -329,7 +329,7 @@ See the [contributing guide](../contributing/stacks.md) for information about ho
 [almond]: https://almond.sh
 [almond_b]: https://mybinder.org/v2/gh/almond-sh/examples/master?urlpath=lab%2Ftree%2Fnotebooks%2Findex.ipynb
 [lisp-stat]: https://lisp-stat.dev
-[lisp-stat_b]: https://github.com/Lisp-Stat/cl-jupyter-image
+[lisp-stat_b]: https://mybinder.org/v2/gh/Lisp-Stat/IPS9/HEAD?urlpath=%2Fdoc%2Ftree%2Findex.ipynb
 
 ### Other GPU-accelerated notebooks
 

--- a/docs/using/selecting.md
+++ b/docs/using/selecting.md
@@ -300,6 +300,7 @@ See the [contributing guide](../contributing/stacks.md) for information about ho
 | [transformers] | [![bb]][transformers_b] | [**Transformers**][transformers_lib] and NLP libraries such as `Tensorflow`, `Keras`, `Jax` and `PyTorch` |
 | [scraper]      | [![bb]][scraper_b]      | **Scraper** tools (`selenium`, `chromedriver`, `beatifulsoup4`, `requests`) on `minimal-notebook` image   |
 | [almond]       | [![bb]][almond_b]       | Scala kernel for Jupyter using **Almond** on top of the `base-notebook` image                             |
+| [lisp-stat]    | [![bb]][lisp-stat_b]    | Common Lisp statistical computing environment on top of the `minimal-notebook` image                      |
 
 [bb]: https://static.mybinder.org/badge_logo.svg
 [csharp]: https://github.com/tlinnet/csharp-notebook
@@ -327,6 +328,8 @@ See the [contributing guide](../contributing/stacks.md) for information about ho
 [scraper_b]: https://mybinder.org/v2/gh/rgriffogoes/scraper-notebook/main
 [almond]: https://almond.sh
 [almond_b]: https://mybinder.org/v2/gh/almond-sh/examples/master?urlpath=lab%2Ftree%2Fnotebooks%2Findex.ipynb
+[lisp-stat]: https://lisp-stat.dev
+[lisp-stat_b]: https://github.com/Lisp-Stat/cl-jupyter-image
 
 ### Other GPU-accelerated notebooks
 


### PR DESCRIPTION
Add lisp-stat community image

## Describe your changes
Add lisp-stat as a community image.  This is a documentation change only.

Question:  How should binder be handled for an image that is based on devcontainer features?  This image is built with the devcontainer CLI and does not have a docker file.  For cloud deployments, I'm recommending github codespaces (see the [README](https://github.com/Lisp-Stat/cl-jupyter-image) for how this is done).

Perhaps a code spaces badge instead of binder?  Or an empty repo with just a docker file pointing to the image?  Or just leave it pointing to github?

