### PR TITLE
Remove facets package installation from Dockerfile

### DIFF
--- a/images/scipy-notebook/Dockerfile
+++ b/images/scipy-notebook/Dockerfile
@@ -69,8 +69,6 @@ RUN mamba install --yes \
     fix-permissions "/home/${NB_USER}"
 
 # Import matplotlib the first time to build the font cache
-WORKDIR /tmp
-
 RUN MPLBACKEND=Agg python -c "import matplotlib.pyplot" && \
     fix-permissions "/home/${NB_USER}"
 


### PR DESCRIPTION
Fix: https://github.com/jupyter/docker-stacks/issues/2346
Removed installation of the facets package from Dockerfile. It's abandoned.

## Describe your changes

## Issue ticket if applicable

<!-- Example - Fix: https://github.com/jupyter/docker-stacks/issues/0 -->

## Checklist (especially for first-time contributors)

- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests
- [ ] I will try not to use force-push to make the review process easier for reviewers
- [ ] I have updated the documentation for significant changes

<!-- markdownlint-disable-file MD041 -->
