### PR TITLE
Remove Facets from scipy-notebook description

### DIFF
--- a/docs/using/selecting.md
+++ b/docs/using/selecting.md
@@ -172,8 +172,6 @@ It contains:
 - [ipympl](https://github.com/matplotlib/ipympl) and
   [ipywidgets](https://ipywidgets.readthedocs.io/en/stable/)
   for interactive visualizations and plots in Python notebooks
-- [Facets](https://github.com/PAIR-code/facets)
-  for visualizing machine learning datasets
 
 ### jupyter/tensorflow-notebook
 


### PR DESCRIPTION
Removed reference to Facets for visualizing machine learning datasets.

## Describe your changes

## Issue ticket if applicable

<!-- Example - Fix: https://github.com/jupyter/docker-stacks/issues/0 -->

## Checklist (especially for first-time contributors)

- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests
- [ ] I will try not to use force-push to make the review process easier for reviewers
- [ ] I have updated the documentation for significant changes

<!-- markdownlint-disable-file MD041 -->
