### PR TITLE
Enable CUDA build for ARM64

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -267,7 +267,7 @@ jobs:
       image: pytorch-notebook
       variant: cuda12
       platform: aarch64
-      runs-on: ubuntu-24.04
+      runs-on: ubuntu-24.04-arm
       timeout-minutes: 25
     needs: aarch64-scipy
     if: ${{ !contains(github.event.pull_request.title, '[FAST_BUILD]') }}


### PR DESCRIPTION
## Enable CUDA build for ARM64

Since there are ARM64 platform like DGX spark, we need CUDA build for ARM64.
(give DGX spark case, given it requires CUDA capacity of 12.1, so latest CUDA is fine)

## Checklist (especially for first-time contributors)

- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests
- [x] I will try not to use force-push to make the review process easier for reviewers
- [x] I have updated the documentation for significant changes

<!-- markdownlint-disable-file MD041 -->
