### PR TITLE
[FAST_BUILD] Do not create manifest list on `docker build`

### DIFF
--- a/.github/actions/create-dev-env/action.yml
+++ b/.github/actions/create-dev-env/action.yml
@@ -23,3 +23,4 @@ runs:
       uses: docker/setup-docker-action@efe9e3891a4f7307e689f2100b33a155b900a608 # v4.5.0
       with:
         set-host: true
+        version: 28.5.2

--- a/.github/workflows/docker-build-test-upload.yml
+++ b/.github/workflows/docker-build-test-upload.yml
@@ -71,7 +71,6 @@ jobs:
         run: |
           docker build \
             --rm --force-rm \
-            --provenance=false \
             --tag ${{ env.REGISTRY }}/${{ env.OWNER }}/${{ inputs.image }} \
             images/${{ inputs.image }}/${{ inputs.variant != 'default' && inputs.variant || '.' }}/ \
             --build-arg REGISTRY=${{ env.REGISTRY }} \


### PR DESCRIPTION
## Describe your changes

Let's explicitly set Docker v28 because of https://github.com/jupyter/docker-stacks/issues/2354

## Issue ticket if applicable

<!-- Example - Fix: https://github.com/jupyter/docker-stacks/issues/0 -->

## Checklist (especially for first-time contributors)

- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests
- [ ] I will try not to use force-push to make the review process easier for reviewers
- [ ] I have updated the documentation for significant changes

<!-- markdownlint-disable-file MD041 -->
