### PR TITLE
[FAST_BUILD] Pass params natively to pytest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,10 @@ build-all: $(foreach I, $(ALL_IMAGES), build/$(I)) ## build all stacks
 
 
 check-outdated/%: ## check the outdated mamba/conda packages in a stack and produce a report
-	@TEST_IMAGE="$(REGISTRY)/$(OWNER)/$(notdir $@)" pytest tests/by_image/docker-stacks-foundation/test_outdated.py
+	pytest tests/by_image/docker-stacks-foundation/test_outdated.py \
+	  --registry "$(REGISTRY)" \
+	  --owner "$(OWNER)" \
+	  --image "$(notdir $@)"
 check-outdated-all: $(foreach I, $(ALL_IMAGES), check-outdated/$(I)) ## check all the stacks for outdated packages
 
 

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -17,19 +17,24 @@ def test_image(*, registry: str, owner: str, image: str) -> None:
     LOGGER.info(f"Testing image: {image}")
     test_dirs = get_test_dirs(image)
     LOGGER.info(f"Test dirs to be run: {test_dirs}")
-    with plumbum.local.env(TEST_IMAGE=f"{registry}/{owner}/{image}"):
-        (
-            python3[
-                "-m",
-                "pytest",
-                "--numprocesses",
-                "auto",
-                "-m",
-                "not info",
-                test_dirs,
-            ]
-            & plumbum.FG
-        )
+    (
+        python3[
+            "-m",
+            "pytest",
+            "--numprocesses",
+            "auto",
+            "-m",
+            "not info",
+            test_dirs,
+            "--registry",
+            registry,
+            "--owner",
+            owner,
+            "--image",
+            image,
+        ]
+        & plumbum.FG
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Describe your changes

It's a bit more verbose, but it should be used instead of env variables.
Also, makes `--help` behave nicely and tells early (and in a readable way) that some parameter is missing.

## Issue ticket if applicable

<!-- Example - Fix: https://github.com/jupyter/docker-stacks/issues/0 -->

## Checklist (especially for first-time contributors)

- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests
- [ ] I will try not to use force-push to make the review process easier for reviewers
- [ ] I have updated the documentation for significant changes

<!-- markdownlint-disable-file MD041 -->
