### PR TITLE
Build pytorch cuda13 image instead of cuda11

### DIFF
--- a/.github/workflows/docker-tag-merge.yml
+++ b/.github/workflows/docker-tag-merge.yml
@@ -45,7 +45,6 @@ jobs:
         with:
           name: ${{ inputs.image }}-aarch64-${{ inputs.variant }}-tags
           path: /tmp/jupyter/tags/
-        if: ${{ !contains(inputs.variant, 'cuda11') }}
 
       - name: Download x86_64 tags file 🏷
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0

--- a/.github/workflows/docker-tag-push.yml
+++ b/.github/workflows/docker-tag-push.yml
@@ -48,7 +48,6 @@ jobs:
 
       - name: Download image tar and apply tags 🏷
         uses: ./.github/actions/apply-single-tags
-        if: ${{ !(contains(inputs.variant, 'cuda11') && matrix.platform == 'aarch64') }}
         with:
           image: ${{ inputs.image }}
           variant: ${{ inputs.variant }}
@@ -67,7 +66,7 @@ jobs:
         id: login
 
       - name: Push single platform images to Registry 📤
-        if: env.PUSH_TO_REGISTRY == 'true' && !(contains(inputs.variant, 'cuda11') && matrix.platform == 'aarch64')
+        if: env.PUSH_TO_REGISTRY == 'true'
         run: |
           docker push --all-tags ${{ env.REGISTRY }}/${{ env.OWNER }}/${{ inputs.image }} || \
           docker push --all-tags ${{ env.REGISTRY }}/${{ env.OWNER }}/${{ inputs.image }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -266,18 +266,6 @@ jobs:
     needs: x86_64-scipy
     if: ${{ !contains(github.event.pull_request.title, '[FAST_BUILD]') }}
 
-  x86_64-pytorch-cuda11:
-    uses: ./.github/workflows/docker-build-test-upload.yml
-    with:
-      parent-image: scipy-notebook
-      image: pytorch-notebook
-      variant: cuda11
-      platform: x86_64
-      runs-on: ubuntu-24.04
-      timeout-minutes: 25
-    needs: x86_64-scipy
-    if: ${{ !contains(github.event.pull_request.title, '[FAST_BUILD]') }}
-
   aarch64-pytorch-cuda12:
     uses: ./.github/workflows/docker-build-test-upload.yml
     with:
@@ -296,6 +284,30 @@ jobs:
       parent-image: scipy-notebook
       image: pytorch-notebook
       variant: cuda12
+      platform: x86_64
+      runs-on: ubuntu-24.04
+      timeout-minutes: 25
+    needs: x86_64-scipy
+    if: ${{ !contains(github.event.pull_request.title, '[FAST_BUILD]') }}
+
+  aarch64-pytorch-cuda13:
+    uses: ./.github/workflows/docker-build-test-upload.yml
+    with:
+      parent-image: scipy-notebook
+      image: pytorch-notebook
+      variant: cuda13
+      platform: aarch64
+      runs-on: ubuntu-24.04-arm
+      timeout-minutes: 25
+    needs: aarch64-scipy
+    if: ${{ !contains(github.event.pull_request.title, '[FAST_BUILD]') }}
+
+  x86_64-pytorch-cuda13:
+    uses: ./.github/workflows/docker-build-test-upload.yml
+    with:
+      parent-image: scipy-notebook
+      image: pytorch-notebook
+      variant: cuda13
       platform: x86_64
       runs-on: ubuntu-24.04
       timeout-minutes: 25
@@ -408,9 +420,9 @@ jobs:
           - image: tensorflow-notebook
             variant: cuda
           - image: pytorch-notebook
-            variant: cuda11
-          - image: pytorch-notebook
             variant: cuda12
+          - image: pytorch-notebook
+            variant: cuda13
     needs:
       [
         contributed-recipes,
@@ -425,6 +437,7 @@ jobs:
         aarch64-tensorflow-cuda,
         aarch64-pytorch,
         aarch64-pytorch-cuda12,
+        aarch64-pytorch-cuda13,
         aarch64-datascience,
         aarch64-pyspark,
         aarch64-all-spark,
@@ -438,8 +451,8 @@ jobs:
         x86_64-tensorflow,
         x86_64-tensorflow-cuda,
         x86_64-pytorch,
-        x86_64-pytorch-cuda11,
         x86_64-pytorch-cuda12,
+        x86_64-pytorch-cuda13,
         x86_64-datascience,
         x86_64-pyspark,
         x86_64-all-spark,

--- a/docs/images/inherit.svg
+++ b/docs/images/inherit.svg
@@ -40,7 +40,7 @@
   <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="9" font-style="normal" font-weight="normal" text-anchor="middle" textLength="65" x="128" y="470">+cuda variant</text>
   <rect fill="rgb(255,255,255)" height="40" stroke="rgb(0,0,0)" width="128" x="256" y="440" />
   <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="9" font-style="normal" font-weight="normal" text-anchor="middle" textLength="80" x="320" y="459">pytorch-notebook</text>
-  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="9" font-style="normal" font-weight="normal" text-anchor="middle" textLength="114" x="320" y="470">+cuda11/cuda12 variants</text>
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="9" font-style="normal" font-weight="normal" text-anchor="middle" textLength="114" x="320" y="470">+cuda12/cuda13 variants</text>
   <rect fill="rgb(255,255,255)" height="40" stroke="rgb(0,0,0)" width="128" x="448" y="440" />
   <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="9" font-style="normal" font-weight="normal" text-anchor="middle" textLength="100" x="512" y="465">datascience-notebook</text>
   <rect fill="rgb(255,255,255)" height="40" stroke="rgb(0,0,0)" width="128" x="640" y="440" />

--- a/docs/using/selecting.md
+++ b/docs/using/selecting.md
@@ -253,7 +253,7 @@ The following diagram depicts the build dependency tree of the core images. (i.e
 Any given image inherits the complete content of all ancestor images pointing to it.
 
 [![Image inheritance
-diagram](../images/inherit.svg)](http://interactive.blockdiag.com/?compression=deflate&src=eJyFj0FqwzAQRfc5hfAqpYiS7kpoT9BdugyEsTxuplZmjDRqcEvvXinQggzGK8Gb97_4rRc3dATv5ntjTIc9JK-nXlgjfaF5Nk_7zCUQsoKScEajBA1Aut_kU5PaxJqOvH19O5gr6TnfidUE9AgR7xpjX0yXf8Fgo4Ibou0lcXdrK-VLt5Jrc4NlUWxFhiJXoBgXYrqAr6Q5K150NE6VVZPiNIocJfRerv_8yPcudWA-IRCwNgvJcVIJ7jyP7XYPt-fxLx8XCvJkyBTZ4eqUsGp8JE-wMnac4ghhqKw5Kx54b-fmzy_M3cYh)
+diagram](../images/inherit.svg)](http://interactive.blockdiag.com/?compression=deflate&src=eJyFj8FKxDAQhu_7FKEnRYKsnmTRJ9ibe1yQaTp1x2ZnSjJxqeK7mywopFB6Cnzz_X_4Wy9u6AjezffGmA57SF7femGN9IXm2TztMpdAyApKwhmNEjQA6W6TT01qE2s68s3-8GoupKd8J1YT0CNEvG2MfTFd_gWDjQpuiLaXxN21rZQv3UquzQ2WRbEVGYpcgWKciekMvpLmrHjR0ThVVk2K0yhylNB7ufzzI9-51IH5hEDA2iwkx0kluNM8tn24vz6Pf_m4UJAnQ6bIDlenhFXjI3mClbHjFEcIQ2XNWfHAezs3f34BzoTGIw)
 
 ### Builds
 

--- a/images/pytorch-notebook/cuda13/Dockerfile
+++ b/images/pytorch-notebook/cuda13/Dockerfile
@@ -13,7 +13,7 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # Install PyTorch with pip (https://pytorch.org/get-started/locally/)
 # hadolint ignore=DL3013
-RUN pip install --no-cache-dir --extra-index-url=https://pypi.nvidia.com --index-url 'https://download.pytorch.org/whl/cu118' \
+RUN pip install --no-cache-dir --extra-index-url=https://pypi.nvidia.com --index-url 'https://download.pytorch.org/whl/cu130' \
     'torch' \
     'torchaudio' \
     'torchvision' && \


### PR DESCRIPTION
## Describe your changes

https://pytorch.org/get-started/locally/ doesn't suggest cuda11 anymore, so let's build cuda13 and remove cuda11
Also, we probably can build cuda13 images on aarch64 (cuda12 works fine).

## Issue ticket if applicable

<!-- Example - Fix: https://github.com/jupyter/docker-stacks/issues/0 -->

## Checklist (especially for first-time contributors)

- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests
- [ ] I will try not to use force-push to make the review process easier for reviewers
- [ ] I have updated the documentation for significant changes

<!-- markdownlint-disable-file MD041 -->
