### PR TITLE
[FAST_BUILD] Make dependabot updates trigger only fast build

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,20 +3,30 @@
 # Please see the documentation for all configuration options:
 # https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference
 
+# We're adding `[FAST_BUILD]` prefix to commit messages (this adds it to PR title)
+# This triggers a faster build, see more info in `.github/workflows/docker.yml`
+
 version: 2
 updates:
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: weekly
+    commit-message:
+      prefix: "[FAST_BUILD] "
   - package-ecosystem: github-actions
     directory: .github/actions/apply-single-tags/
     schedule:
       interval: weekly
+    commit-message:
+      prefix: "[FAST_BUILD] "
   - package-ecosystem: github-actions
     directory: .github/actions/create-dev-env/
     schedule:
       interval: weekly
+    commit-message:
+      prefix: "[FAST_BUILD] "
+  # This action is only used for some images, so full build is required
   - package-ecosystem: github-actions
     directory: .github/actions/free-disk-space/
     schedule:
@@ -25,3 +35,5 @@ updates:
     directory: .github/actions/load-image/
     schedule:
       interval: weekly
+    commit-message:
+      prefix: "[FAST_BUILD] "


### PR DESCRIPTION
## Describe your changes

## Issue ticket if applicable

<!-- Example - Fix: https://github.com/jupyter/docker-stacks/issues/0 -->

## Checklist (especially for first-time contributors)

- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests
- [ ] I will try not to use force-push to make the review process easier for reviewers
- [ ] I have updated the documentation for significant changes

<!-- markdownlint-disable-file MD041 -->
