### PR TITLE
docs: clarify when to pull Quay.io image vs build locally

### DIFF
--- a/docs/using/selecting.md
+++ b/docs/using/selecting.md
@@ -4,9 +4,10 @@
 - [Image Relationships](#image-relationships)
 - [Community Stacks](#community-stacks)
 
-> **Pull vs build: quick guidance**
+> **Pull vs Build: Quick Guidance**
 >
-> Images are published on **Quay.io** and most users should start by pulling an existing image that closely matches their needs. Pulling a pre-built image is fast and suitable for common use cases such as running notebooks, teaching, or standard data science workflows.
+> Images are published on **Quay.io** registry and most users should start by pulling an existing image that closely matches their needs.
+> Pulling a pre-built image is fast and suitable for common use cases such as running notebooks, teaching, or standard data science workflows.
 >
 > Building images locally is recommended only when additional customization is required, for example:
 >


### PR DESCRIPTION
This PR adds a short clarification to help new users decide when to pull an existing image from Quay.io versus when to build a custom image locally.

It is based on the discussion in issue #2395 and aims to make the image selection workflow clearer for first-time users.

Changes:
- Added a brief "Pull vs build" guidance block to docs/using/selecting.md
