### PR TITLE
Add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @mathbunnyru


### PR DESCRIPTION
## Summary
- Adds `.github/CODEOWNERS` assigning @mathbunnyru as default code owner
- Improves the Code-Review check in the OpenSSF Scorecard report

Ref: #2428