### PR TITLE
Pin devcontainer base image to digest

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/devcontainers/python:3.13
+FROM mcr.microsoft.com/devcontainers/python:3.13@sha256:e797f7e02a8adf1c6d375a4873591205cc867a2d68083506e7f3aa89822f2026
 
 COPY requirements-dev.txt /tmp/requirements-dev.txt
 COPY docs/requirements.txt /tmp/requirements-docs.txt

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -37,3 +37,9 @@ updates:
       interval: weekly
     commit-message:
       prefix: "[FAST_BUILD] "
+  - package-ecosystem: docker
+    directory: .devcontainer/
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: "[FAST_BUILD] "


### PR DESCRIPTION
## Summary
- Pins the `.devcontainer/Dockerfile` base image to its sha256 digest
- Improves the Pinned-Dependencies check in the OpenSSF Scorecard

Ref: #2428