### PR TITLE
Add top-level permissions: {} to all workflows

### DIFF
--- a/.github/workflows/contributed-recipes.yml
+++ b/.github/workflows/contributed-recipes.yml
@@ -30,6 +30,8 @@ on:
         required: true
         type: boolean
 
+permissions: {}
+
 jobs:
   generate-matrix:
     runs-on: ubuntu-24.04

--- a/.github/workflows/docker-build-test-upload.yml
+++ b/.github/workflows/docker-build-test-upload.yml
@@ -38,6 +38,8 @@ on:
         required: true
         type: number
 
+permissions: {}
+
 jobs:
   build-test-upload:
     runs-on: ${{ inputs.runs-on }}

--- a/.github/workflows/docker-tag-merge.yml
+++ b/.github/workflows/docker-tag-merge.yml
@@ -25,6 +25,8 @@ on:
       REGISTRY_TOKEN:
         required: true
 
+permissions: {}
+
 jobs:
   tag-merge:
     runs-on: ubuntu-24.04

--- a/.github/workflows/docker-tag-push-merge.yml
+++ b/.github/workflows/docker-tag-push-merge.yml
@@ -17,6 +17,8 @@ on:
       REGISTRY_TOKEN:
         required: true
 
+permissions: {}
+
 jobs:
   tag-push:
     uses: ./.github/workflows/docker-tag-push.yml

--- a/.github/workflows/docker-tag-push.yml
+++ b/.github/workflows/docker-tag-push.yml
@@ -26,6 +26,8 @@ on:
       REGISTRY_TOKEN:
         required: true
 
+permissions: {}
+
 jobs:
   tag-push:
     runs-on: ubuntu-24.04

--- a/.github/workflows/docker-wiki-update.yml
+++ b/.github/workflows/docker-wiki-update.yml
@@ -8,6 +8,8 @@ env:
 on:
   workflow_call:
 
+permissions: {}
+
 jobs:
   wiki-update:
     runs-on: ubuntu-24.04

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -67,6 +67,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions: {}
+
 jobs:
   aarch64-foundation:
     uses: ./.github/workflows/docker-build-test-upload.yml

--- a/.github/workflows/image-delete.yml
+++ b/.github/workflows/image-delete.yml
@@ -36,6 +36,8 @@ on:
           - quay
           - both
 
+permissions: {}
+
 jobs:
   image-delete:
     runs-on: ubuntu-24.04

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -7,6 +7,8 @@ on:
       - main
   workflow_dispatch:
 
+permissions: {}
+
 jobs:
   run-hooks:
     runs-on: ubuntu-24.04

--- a/.github/workflows/registry-move.yml
+++ b/.github/workflows/registry-move.yml
@@ -15,6 +15,8 @@ on:
       - ".github/workflows/registry-move.yml"
   workflow_dispatch:
 
+permissions: {}
+
 jobs:
   registry-move:
     # To be able to use the latest skopeo

--- a/.github/workflows/registry-overviews.yml
+++ b/.github/workflows/registry-overviews.yml
@@ -13,6 +13,8 @@ on:
       - "images/*/README.md"
   workflow_dispatch:
 
+permissions: {}
+
 jobs:
   update-overview:
     runs-on: ubuntu-24.04

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -14,6 +14,8 @@ on:
   push:
     branches: ["main"]
 
+permissions: {}
+
 jobs:
   analysis:
     name: Scorecard analysis

--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -38,6 +38,8 @@ on:
       - "tagging/taggers/tagger_interface.py"
   workflow_dispatch:
 
+permissions: {}
+
 jobs:
   build-docs:
     runs-on: ubuntu-24.04


### PR DESCRIPTION
## Summary
- Adds `permissions: {}` at the workflow level to all 13 workflow files; jobs already declare their own so behavior is unchanged
- Addresses the Token-Permissions check in the OpenSSF Scorecard

#2428