### PR TITLE
Pin pytest and requests to fix known vulnerabilities

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,12 +1,12 @@
 docker
 plumbum
 pre-commit
-pytest
+pytest>=9.0.3  # GHSA-6w46-j5rx-g56g (tmpdir handling)
 pytest-rerunfailures
 # `pytest-xdist` is a plugin that provides the `--numprocesses` flag,
 # allowing us to run `pytest` tests in parallel
 pytest-xdist
 python-dateutil
-requests
+requests>=2.33.0  # GHSA-gc5v-m9x4-r6x2 (credentials leak)
 tabulate
 tenacity


### PR DESCRIPTION
## Summary
- Pins `pytest>=9.0.3` (GHSA-6w46-j5rx-g56g, tmpdir handling)
- Pins `requests>=2.33.0` (GHSA-gc5v-m9x4-r6x2, credentials leak)
- Fixes all 7 vulnerabilities flagged in the OpenSSF Scorecard report

Ref: #2428