### PR TITLE
Pin container images to digest hashes

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -43,3 +43,7 @@ updates:
       interval: weekly
     commit-message:
       prefix: "[FAST_BUILD] "
+  - package-ecosystem: docker
+    directory: images/docker-stacks-foundation/
+    schedule:
+      interval: weekly

--- a/binder/Dockerfile
+++ b/binder/Dockerfile
@@ -4,7 +4,7 @@
 # https://quay.io/repository/jupyter/base-notebook?tab=tags
 ARG REGISTRY=quay.io
 ARG OWNER=jupyter
-ARG BASE_IMAGE=$REGISTRY/$OWNER/base-notebook:2025-12-31
+ARG BASE_IMAGE=$REGISTRY/$OWNER/base-notebook:2025-12-31@sha256:4ed6681f1bfe736ac7dff06a9d558acb69b5b1fdbf4fc9904bbf89e4853626cc
 FROM $BASE_IMAGE
 
 LABEL maintainer="Jupyter Project <jupyter@googlegroups.com>"

--- a/examples/docker-compose/notebook/Dockerfile
+++ b/examples/docker-compose/notebook/Dockerfile
@@ -2,7 +2,7 @@
 # Distributed under the terms of the Modified BSD License.
 
 # Pick your favorite docker-stacks image
-FROM quay.io/jupyter/minimal-notebook
+FROM quay.io/jupyter/minimal-notebook:2025-12-31@sha256:5bb65b1758fca6915271353932d8fcd577a17cc73299a557197747555e6f142a
 
 USER root
 

--- a/examples/make-deploy/Dockerfile
+++ b/examples/make-deploy/Dockerfile
@@ -2,7 +2,7 @@
 # Distributed under the terms of the Modified BSD License.
 
 # Pick your favorite docker-stacks image
-FROM quay.io/jupyter/minimal-notebook
+FROM quay.io/jupyter/minimal-notebook:2025-12-31@sha256:5bb65b1758fca6915271353932d8fcd577a17cc73299a557197747555e6f142a
 
 USER root
 

--- a/images/docker-stacks-foundation/Dockerfile
+++ b/images/docker-stacks-foundation/Dockerfile
@@ -3,7 +3,7 @@
 
 # Ubuntu 24.04 (noble)
 # https://hub.docker.com/_/ubuntu/tags?page=1&name=noble
-ARG ROOT_IMAGE=ubuntu:24.04
+ARG ROOT_IMAGE=ubuntu:24.04@sha256:c4a8d5503dfb2a3eb8ab5f807da5bc69a85730fb49b5cfca2330194ebcc41c7b
 
 FROM $ROOT_IMAGE
 


### PR DESCRIPTION
## Summary
- Pins `ubuntu:24.04` in `docker-stacks-foundation` to its sha256 digest
- Pins `quay.io/jupyter/minimal-notebook` in examples to its sha256 digest
- Pins `quay.io/jupyter/base-notebook:2025-12-31` in binder to its sha256 digest
- Improves the Pinned-Dependencies check in the OpenSSF Scorecard

Ref: #2428