### PR TITLE
Improve logging in start.sh and run-hooks.sh

### DIFF
--- a/images/docker-stacks-foundation/Dockerfile
+++ b/images/docker-stacks-foundation/Dockerfile
@@ -142,7 +142,7 @@ RUN set -x && \
     fix-permissions "/home/${NB_USER}"
 
 # Copy local files as late as possible to avoid cache busting
-COPY run-hooks.sh start.sh /usr/local/bin/
+COPY _docker_stacks_log.sh run-hooks.sh start.sh /usr/local/bin/
 
 # Configure container entrypoint
 ENTRYPOINT ["tini", "-g", "--", "start.sh"]

--- a/images/docker-stacks-foundation/_docker_stacks_log.sh
+++ b/images/docker-stacks-foundation/_docker_stacks_log.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+
+# The _log function is used for everything these scripts want to log.
+# It will always log errors and warnings but can be silenced for other messages
+# by setting the JUPYTER_DOCKER_STACKS_QUIET environment variable.
+_log () {
+    local level="${1}"
+    case "${level}" in
+        INFO|WARNING|ERROR|DEBUG)
+            shift
+            ;;
+        *)
+            level="INFO"
+            ;;
+    esac
+    if [[ "${level}" == "ERROR" ]] || [[ "${level}" == "WARNING" ]] || [[ "${JUPYTER_DOCKER_STACKS_QUIET}" == "" ]]; then
+        echo "${level}[$(date '+%Y-%m-%d %H:%M:%S')] $*" >&2
+    fi
+}
+_log_info () { _log "INFO" "$@"; }
+_log_warn () { _log "WARNING" "$@"; }
+_log_error () { _log "ERROR" "$@"; }

--- a/images/docker-stacks-foundation/run-hooks.sh
+++ b/images/docker-stacks-foundation/run-hooks.sh
@@ -2,55 +2,51 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 
-# identical _log to start.sh
-# only used when _not_ sourced from start.sh (i.e. unittests)
+# Source logging functions if not already available
 if ! declare -F _log > /dev/null; then
-    _log () {
-        if [[ "$*" == "ERROR:"* ]] || [[ "$*" == "WARNING:"* ]] || [[ "${JUPYTER_DOCKER_STACKS_QUIET}" == "" ]]; then
-            echo "$@" >&2
-        fi
-    }
+    # shellcheck source=images/docker-stacks-foundation/_docker_stacks_log.sh
+    source /usr/local/bin/_docker_stacks_log.sh
 fi
 
 # The run-hooks.sh script looks for *.sh scripts to source
 # and executable files to run within a passed directory
 
 if [ "$#" -ne 1 ]; then
-    _log "ERROR: Should pass exactly one directory"
+    _log_error "Should pass exactly one directory"
     return 1
 fi
 
 if [[ ! -d "${1}" ]]; then
-    _log "ERROR: Directory ${1} doesn't exist or is not a directory"
+    _log_error "Directory ${1} doesn't exist or is not a directory"
     return 1
 fi
 
-_log "Running hooks in: ${1} as uid: $(id -u) gid: $(id -g)"
+_log_info "Running hooks in: ${1} as uid: $(id -u) gid: $(id -g)"
 for f in "${1}/"*; do
     # Handling a case when the directory is empty
     [ -e "${f}" ] || continue
     case "${f}" in
         *.sh)
-            _log "Sourcing shell script: ${f}"
+            _log_info "Sourcing shell script: ${f}"
             # shellcheck disable=SC1090
             source "${f}"
             # shellcheck disable=SC2181
             if [ $? -ne 0 ]; then
-                _log "ERROR: ${f} has failed, continuing execution"
+                _log_error "${f} has failed, continuing execution"
             fi
             ;;
         *)
             if [ -x "${f}" ]; then
-                _log "Running executable: ${f}"
+                _log_info "Running executable: ${f}"
                 "${f}"
                 # shellcheck disable=SC2181
                 if [ $? -ne 0 ]; then
-                    _log "ERROR: ${f} has failed, continuing execution"
+                    _log_error "${f} has failed, continuing execution"
                 fi
             else
-                _log "Ignoring non-executable: ${f}"
+                _log_info "Ignoring non-executable: ${f}"
             fi
             ;;
     esac
 done
-_log "Done running hooks in: ${1}"
+_log_info "Done running hooks in: ${1}"

--- a/images/docker-stacks-foundation/start.sh
+++ b/images/docker-stacks-foundation/start.sh
@@ -4,22 +4,16 @@
 
 set -e
 
-# The _log function is used for everything this script wants to log.
-# It will always log errors and warnings but can be silenced for other messages
-# by setting the JUPYTER_DOCKER_STACKS_QUIET environment variable.
-_log () {
-    if [[ "$*" == "ERROR:"* ]] || [[ "$*" == "WARNING:"* ]] || [[ "${JUPYTER_DOCKER_STACKS_QUIET}" == "" ]]; then
-        echo "$@" >&2
-    fi
-}
-_log "Entered start.sh with args:" "$@"
+# shellcheck source=images/docker-stacks-foundation/_docker_stacks_log.sh
+source /usr/local/bin/_docker_stacks_log.sh
+_log_info "Entered start.sh with args:" "$@"
 
 # A helper function to unset env vars listed in the value of the env var
 # JUPYTER_ENV_VARS_TO_UNSET.
 unset_explicit_env_vars () {
     if [ -n "${JUPYTER_ENV_VARS_TO_UNSET}" ]; then
         for env_var_to_unset in $(echo "${JUPYTER_ENV_VARS_TO_UNSET}" | tr ',' ' '); do
-            _log "Unset ${env_var_to_unset} due to JUPYTER_ENV_VARS_TO_UNSET"
+            _log_info "Unset ${env_var_to_unset} due to JUPYTER_ENV_VARS_TO_UNSET"
             unset "${env_var_to_unset}"
         done
         unset JUPYTER_ENV_VARS_TO_UNSET
@@ -37,8 +31,8 @@ fi
 # Backwards compatibility: `start.sh` is executed by default in ENTRYPOINT
 # so it should no longer be specified in CMD
 if [ "${_START_SH_EXECUTED}" = "1" ]; then
-    _log "WARNING: start.sh is the default ENTRYPOINT, do not include it in CMD"
-    _log "Executing the command:" "${cmd[@]}"
+    _log_warn "start.sh is the default ENTRYPOINT, do not include it in CMD"
+    _log_info "Executing the command:" "${cmd[@]}"
     exec "${cmd[@]}"
 else
     export _START_SH_EXECUTED=1
@@ -68,18 +62,18 @@ if [ "$(id -u)" == 0 ]; then
     # Refit the jovyan user to the desired user (NB_USER)
     if id jovyan &> /dev/null; then
         if ! usermod --home "/home/${NB_USER}" --login "${NB_USER}" jovyan 2>&1 | grep "no changes" > /dev/null; then
-            _log "Updated the jovyan user:"
-            _log "- username: jovyan       -> ${NB_USER}"
-            _log "- home dir: /home/jovyan -> /home/${NB_USER}"
+            _log_info "Updated the jovyan user:"
+            _log_info "- username: jovyan       -> ${NB_USER}"
+            _log_info "- home dir: /home/jovyan -> /home/${NB_USER}"
         fi
     elif ! id -u "${NB_USER}" &> /dev/null; then
-        _log "ERROR: Neither the jovyan user nor '${NB_USER}' exists. This could be the result of stopping and starting, the container with a different NB_USER environment variable."
+        _log_error "Neither the jovyan user nor '${NB_USER}' exists. This could be the result of stopping and starting, the container with a different NB_USER environment variable."
         exit 1
     fi
     # Ensure the desired user (NB_USER) gets its desired user id (NB_UID) and is
     # a member of the desired group (NB_GROUP, NB_GID)
     if [ "${NB_UID}" != "$(id -u "${NB_USER}")" ] || [ "${NB_GID}" != "$(id -g "${NB_USER}")" ]; then
-        _log "Update ${NB_USER}'s UID:GID to ${NB_UID}:${NB_GID}"
+        _log_info "Update ${NB_USER}'s UID:GID to ${NB_UID}:${NB_GID}"
         # Ensure the desired group's existence
         if [ "${NB_GID}" != "$(id -g "${NB_USER}")" ]; then
             groupadd --force --gid "${NB_GID}" --non-unique "${NB_GROUP:-${NB_USER}}"
@@ -101,18 +95,18 @@ if [ "$(id -u)" == 0 ]; then
     # directory to the new location if needed.
     if [[ "${NB_USER}" != "jovyan" ]]; then
         if [[ ! -e "/home/${NB_USER}" ]]; then
-            _log "Attempting to copy /home/jovyan to /home/${NB_USER}..."
+            _log_info "Attempting to copy /home/jovyan to /home/${NB_USER}..."
             mkdir "/home/${NB_USER}"
             # shellcheck disable=SC2086
             if cp ${CP_OPTS:--a} /home/jovyan/. "/home/${NB_USER}/"; then
-                _log "Success!"
+                _log_info "Success!"
             else
-                _log "Failed to copy data from /home/jovyan to /home/${NB_USER}!"
-                _log "Attempting to symlink /home/jovyan to /home/${NB_USER}..."
+                _log_info "Failed to copy data from /home/jovyan to /home/${NB_USER}!"
+                _log_info "Attempting to symlink /home/jovyan to /home/${NB_USER}..."
                 if ln -s /home/jovyan "/home/${NB_USER}"; then
-                    _log "Success creating symlink!"
+                    _log_info "Success creating symlink!"
                 else
-                    _log "ERROR: Failed copy data from /home/jovyan to /home/${NB_USER} or to create symlink!"
+                    _log_error "Failed copy data from /home/jovyan to /home/${NB_USER} or to create symlink!"
                     exit 1
                 fi
             fi
@@ -120,7 +114,7 @@ if [ "$(id -u)" == 0 ]; then
         # Ensure the current working directory is updated to the new path
         if [[ "${PWD}/" == "/home/jovyan/"* ]]; then
             new_wd="/home/${NB_USER}/${PWD:13}"
-            _log "Changing working directory to ${new_wd}"
+            _log_info "Changing working directory to ${new_wd}"
             cd "${new_wd}"
         fi
     fi
@@ -128,13 +122,13 @@ if [ "$(id -u)" == 0 ]; then
     # Optionally ensure the desired user gets filesystem ownership of its home
     # folder and/or additional folders
     if [[ "${CHOWN_HOME}" == "1" || "${CHOWN_HOME}" == "yes" ]]; then
-        _log "Ensuring /home/${NB_USER} is owned by ${NB_UID}:${NB_GID} ${CHOWN_HOME_OPTS:+(chown options: ${CHOWN_HOME_OPTS})}"
+        _log_info "Ensuring /home/${NB_USER} is owned by ${NB_UID}:${NB_GID} ${CHOWN_HOME_OPTS:+(chown options: ${CHOWN_HOME_OPTS})}"
         # shellcheck disable=SC2086
         chown ${CHOWN_HOME_OPTS} "${NB_UID}:${NB_GID}" "/home/${NB_USER}"
     fi
     if [ -n "${CHOWN_EXTRA}" ]; then
         for extra_dir in $(echo "${CHOWN_EXTRA}" | tr ',' ' '); do
-            _log "Ensuring ${extra_dir} is owned by ${NB_UID}:${NB_GID} ${CHOWN_EXTRA_OPTS:+(chown options: ${CHOWN_EXTRA_OPTS})}"
+            _log_info "Ensuring ${extra_dir} is owned by ${NB_UID}:${NB_GID} ${CHOWN_EXTRA_OPTS:+(chown options: ${CHOWN_EXTRA_OPTS})}"
             # shellcheck disable=SC2086
             chown ${CHOWN_EXTRA_OPTS} "${NB_UID}:${NB_GID}" "${extra_dir}"
         done
@@ -145,7 +139,7 @@ if [ "$(id -u)" == 0 ]; then
 
     # Optionally grant passwordless sudo rights for the desired user
     if [[ "${GRANT_SUDO}" == "1" || "${GRANT_SUDO}" == "yes" ]]; then
-        _log "Granting ${NB_USER} passwordless sudo rights!"
+        _log_info "Granting ${NB_USER} passwordless sudo rights!"
         echo "${NB_USER} ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers.d/added-by-start-script
     fi
 
@@ -154,7 +148,7 @@ if [ "$(id -u)" == 0 ]; then
     source /usr/local/bin/run-hooks.sh /usr/local/bin/before-notebook.d
     unset_explicit_env_vars
 
-    _log "Running as ${NB_USER}:" "${cmd[@]}"
+    _log_info "Running as ${NB_USER}:" "${cmd[@]}"
     if [ "${NB_USER}" = "root" ] && [ "${NB_UID}" = "$(id -u "${NB_USER}")" ] && [ "${NB_GID}" = "$(id -g "${NB_USER}")" ]; then
         HOME="/home/root" exec "${cmd[@]}"
     else
@@ -197,7 +191,7 @@ if [ "$(id -u)" == 0 ]; then
 else
     # Warn about misconfiguration of: granting sudo rights
     if [[ "${GRANT_SUDO}" == "1" || "${GRANT_SUDO}" == "yes" ]]; then
-        _log "WARNING: container must be started as root to grant sudo permissions!"
+        _log_warn "container must be started as root to grant sudo permissions!"
     fi
 
     JOVYAN_UID="$(id -u jovyan 2>/dev/null)"  # The default UID for the jovyan user
@@ -210,9 +204,9 @@ else
     #
     # ref: https://github.com/jupyter/docker-stacks/issues/552
     if ! whoami &> /dev/null; then
-        _log "There is no entry in /etc/passwd for our UID=$(id -u). Attempting to fix..."
+        _log_info "There is no entry in /etc/passwd for our UID=$(id -u). Attempting to fix..."
         if [[ -w /etc/passwd ]]; then
-            _log "Renaming old jovyan user to nayvoj ($(id -u jovyan):$(id -g jovyan))"
+            _log_info "Renaming old jovyan user to nayvoj ($(id -u jovyan):$(id -g jovyan))"
 
             # We cannot use "sed --in-place" since sed tries to create a temp file in
             # /etc/ and we may not have write access. Apply sed on our own temp file:
@@ -221,13 +215,13 @@ else
             cat /tmp/passwd > /etc/passwd
             rm /tmp/passwd
 
-            _log "Added new ${NB_USER} user ($(id -u):$(id -g)). Fixed UID!"
+            _log_info "Added new ${NB_USER} user ($(id -u):$(id -g)). Fixed UID!"
 
             if [[ "${NB_USER}" != "jovyan" ]]; then
-                _log "WARNING: user is ${NB_USER} but home is /home/jovyan. You must run as root to rename the home directory!"
+                _log_warn "user is ${NB_USER} but home is /home/jovyan. You must run as root to rename the home directory!"
             fi
         else
-            _log "WARNING: unable to fix missing /etc/passwd entry because we don't have write permission. Try setting gid=0 with \"--user=$(id -u):0\"."
+            _log_warn "unable to fix missing /etc/passwd entry because we don't have write permission. Try setting gid=0 with \"--user=$(id -u):0\"."
         fi
     fi
 
@@ -236,18 +230,18 @@ else
     # NB_USER, NB_UID, or NB_GID, but we cannot update those values because we
     # are not root.
     if [[ "${NB_USER}" != "jovyan" && "${NB_USER}" != "$(id -un)" ]]; then
-        _log "WARNING: container must be started as root to change the desired user's name with NB_USER=\"${NB_USER}\"!"
+        _log_warn "container must be started as root to change the desired user's name with NB_USER=\"${NB_USER}\"!"
     fi
     if [[ "${NB_UID}" != "${JOVYAN_UID}" && "${NB_UID}" != "$(id -u)" ]]; then
-        _log "WARNING: container must be started as root to change the desired user's id with NB_UID=\"${NB_UID}\"!"
+        _log_warn "container must be started as root to change the desired user's id with NB_UID=\"${NB_UID}\"!"
     fi
     if [[ "${NB_GID}" != "${JOVYAN_GID}" && "${NB_GID}" != "$(id -g)" ]]; then
-        _log "WARNING: container must be started as root to change the desired user's group id with NB_GID=\"${NB_GID}\"!"
+        _log_warn "container must be started as root to change the desired user's group id with NB_GID=\"${NB_GID}\"!"
     fi
 
     # Warn if the user isn't able to write files to ${HOME}
     if [[ ! -w /home/jovyan ]]; then
-        _log "WARNING: no write access to /home/jovyan. Try starting the container with group 'users' (100), e.g. using \"--group-add=users\"."
+        _log_warn "no write access to /home/jovyan. Try starting the container with group 'users' (100), e.g. using \"--group-add=users\"."
     fi
 
     # NOTE: This hook is run as the user we started the container as!
@@ -255,6 +249,6 @@ else
     source /usr/local/bin/run-hooks.sh /usr/local/bin/before-notebook.d
     unset_explicit_env_vars
 
-    _log "Executing the command:" "${cmd[@]}"
+    _log_info "Executing the command:" "${cmd[@]}"
     exec "${cmd[@]}"
 fi

--- a/tests/by_image/base-notebook/test_start_container.py
+++ b/tests/by_image/base-notebook/test_start_container.py
@@ -42,24 +42,23 @@ def test_start_notebook(
         f"Test that the start-notebook.py launches the {expected_command} server from the env {env} ..."
     )
     container.run_detached(environment=env, ports={"8888/tcp": free_host_port})
-    # sleeping some time to let the server start
-    time.sleep(2)
+    # Wait for the server to be reachable (proves start-notebook.py finished launching)
+    if expected_start:
+        resp = http_client.get(f"http://localhost:{free_host_port}")
+        assert resp.status_code == 200, "Server is not listening"
+    else:
+        # For non-listening cases (e.g. jupyterhub-singleuser), give the script time to print
+        time.sleep(5)
     logs = container.get_logs()
     LOGGER.debug(logs)
-    # checking that the expected command is launched
     assert (
         f"Executing: {expected_command}" in logs
     ), f"Not the expected command ({expected_command}) was launched"
-    # checking errors and warnings in logs
     assert "ERROR" not in logs, "ERROR(s) found in logs"
     for exp_warning in expected_warnings:
         assert exp_warning in logs, f"Expected warning {exp_warning} not found in logs"
     warnings = TrackedContainer.get_warnings(logs)
     assert len(expected_warnings) == len(warnings)
-    # checking if the server is listening
-    if expected_start:
-        resp = http_client.get(f"http://localhost:{free_host_port}")
-        assert resp.status_code == 200, "Server is not listening"
 
 
 def test_tini_entrypoint(

--- a/tests/by_image/docker-stacks-foundation/test_logging.py
+++ b/tests/by_image/docker-stacks-foundation/test_logging.py
@@ -14,7 +14,9 @@ def test_log_format_includes_timestamp(container: TrackedContainer) -> None:
         command=["echo", "done"],
         split_stderr=True,
     )
-    assert re.search(r"INFO\[\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\]", stderr)
+    assert re.search(
+        r"INFO\[\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\] Entered start\.sh", stderr
+    )
 
 
 def test_quiet_mode_suppresses_info(container: TrackedContainer) -> None:

--- a/tests/by_image/docker-stacks-foundation/test_logging.py
+++ b/tests/by_image/docker-stacks-foundation/test_logging.py
@@ -1,0 +1,66 @@
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+import re
+
+from tests.utils.tracked_container import TrackedContainer
+
+
+def test_log_format_includes_timestamp(container: TrackedContainer) -> None:
+    """Log messages should include a timestamp and level."""
+    _, stderr = container.run_and_wait(
+        timeout=10,
+        user="root",
+        environment=["NB_USER=root", "NB_UID=0", "NB_GID=0"],
+        command=["echo", "done"],
+        split_stderr=True,
+    )
+    assert re.search(r"INFO\[\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\]", stderr)
+
+
+def test_quiet_mode_suppresses_info(container: TrackedContainer) -> None:
+    """JUPYTER_DOCKER_STACKS_QUIET should suppress INFO messages."""
+    _, stderr = container.run_and_wait(
+        timeout=10,
+        user="root",
+        environment=[
+            "NB_USER=root",
+            "NB_UID=0",
+            "NB_GID=0",
+            "JUPYTER_DOCKER_STACKS_QUIET=1",
+        ],
+        command=["echo", "done"],
+        split_stderr=True,
+    )
+    assert "INFO[" not in stderr
+
+
+def test_quiet_mode_shows_warnings(container: TrackedContainer) -> None:
+    """JUPYTER_DOCKER_STACKS_QUIET should still show WARNING messages."""
+    _, stderr = container.run_and_wait(
+        timeout=10,
+        environment=[
+            "JUPYTER_DOCKER_STACKS_QUIET=1",
+            "GRANT_SUDO=1",
+        ],
+        command=["echo", "done"],
+        split_stderr=True,
+        no_warnings=False,
+    )
+    assert "WARNING[" in stderr
+
+
+def test_log_without_level_defaults_to_info(container: TrackedContainer) -> None:
+    """Calling _log without a recognized level should default to INFO."""
+    _, stderr = container.run_and_wait(
+        timeout=10,
+        user="root",
+        environment=["NB_USER=root", "NB_UID=0", "NB_GID=0"],
+        command=[
+            "bash",
+            "-c",
+            'source /usr/local/bin/_docker_stacks_log.sh && _log "no level here"',
+        ],
+        split_stderr=True,
+    )
+    assert "INFO[" in stderr
+    assert "no level here" in stderr

--- a/tests/by_image/docker-stacks-foundation/test_user_options.py
+++ b/tests/by_image/docker-stacks-foundation/test_user_options.py
@@ -287,10 +287,7 @@ def test_startsh_multiple_exec(container: TrackedContainer) -> None:
     assert "uid=0(root)" in logs
     warnings = TrackedContainer.get_warnings(logs)
     assert len(warnings) == 1
-    assert (
-        "WARNING: start.sh is the default ENTRYPOINT, do not include it in CMD"
-        in warnings[0]
-    )
+    assert "start.sh is the default ENTRYPOINT, do not include it in CMD" in warnings[0]
 
 
 def test_rootless_triplet_change(container: TrackedContainer) -> None:

--- a/tests/shared_checks/R_mimetype_check.py
+++ b/tests/shared_checks/R_mimetype_check.py
@@ -15,6 +15,5 @@ def check_r_mimetypes(container: TrackedContainer) -> None:
     logs = container.run_and_wait(timeout=10, command=command)
     LOGGER.debug(f"{logs=}")
     # If there is any output after this it means there was an error
-    assert logs.splitlines()[-1] == "Executing the command: " + " ".join(
-        command
-    ), f"Command {R_MIMETYPES_CHECK_CMD=} failed"
+    expected = "Executing the command: " + " ".join(command)
+    assert expected in logs.splitlines()[-1], f"Command {R_MIMETYPES_CHECK_CMD=} failed"


### PR DESCRIPTION
## Summary
- Refactors `_log` to accept level as first argument with timestamp output
- Adds convenience wrappers: `_log_info`, `_log_warn`, `_log_error`
- Output format: `LEVEL[YYYY-MM-DD HH:MM:SS] message`
- `_log` remains available for custom levels if needed
- Adds tests for timestamp format and `JUPYTER_DOCKER_STACKS_QUIET` behavior

Ref: #1532