### PR TITLE
Add pre-submit linting reminder to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,6 +7,11 @@ for information about how to contribute
 [tests](https://jupyter-docker-stacks.readthedocs.io/en/latest/contributing/tests.html),
 and [community-maintained stacks](https://jupyter-docker-stacks.readthedocs.io/en/latest/contributing/stacks.html).
 
+## Before Submitting
+
+Please run the [linters](https://jupyter-docker-stacks.readthedocs.io/en/latest/contributing/lint.html)
+locally before opening a pull request.
+
 ## Our Copyright Policy
 
 Jupyter uses a shared copyright model. Each contributor maintains copyright


### PR DESCRIPTION
## Summary
- Adds a "Before Submitting" section linking to the lint documentation
- Helps contributors discover the pre-commit step before opening PRs