### PR TITLE
[FAST_BUILD] Add color to log output based on level

### DIFF
--- a/images/docker-stacks-foundation/_docker_stacks_log.sh
+++ b/images/docker-stacks-foundation/_docker_stacks_log.sh
@@ -5,8 +5,7 @@
 # The _log function is used for everything these scripts want to log.
 # It will always log errors and warnings but can be silenced for other messages
 # by setting the JUPYTER_DOCKER_STACKS_QUIET environment variable.
-# Colorizes WARNING and ERROR output when stderr is a terminal.
-# Respects NO_COLOR (https://no-color.org/).
+# Colorizes ERROR, WARNING, and DEBUG output when stderr is a terminal.
 _log () {
     local level="${1}"
     case "${level}" in

--- a/images/docker-stacks-foundation/_docker_stacks_log.sh
+++ b/images/docker-stacks-foundation/_docker_stacks_log.sh
@@ -5,6 +5,8 @@
 # The _log function is used for everything these scripts want to log.
 # It will always log errors and warnings but can be silenced for other messages
 # by setting the JUPYTER_DOCKER_STACKS_QUIET environment variable.
+# Colorizes WARNING and ERROR output when stderr is a terminal.
+# Respects NO_COLOR (https://no-color.org/).
 _log () {
     local level="${1}"
     case "${level}" in
@@ -16,7 +18,20 @@ _log () {
             ;;
     esac
     if [[ "${level}" == "ERROR" ]] || [[ "${level}" == "WARNING" ]] || [[ "${JUPYTER_DOCKER_STACKS_QUIET}" == "" ]]; then
-        echo "${level}[$(date '+%Y-%m-%d %H:%M:%S')] $*" >&2
+        local msg
+        msg="${level}[$(date '+%Y-%m-%d %H:%M:%S')] $*"
+        if [[ -t 2 ]] && [[ "${NO_COLOR:-}" == "" ]]; then
+            local color=""
+            case "${level}" in
+                ERROR)   color='31' ;; # red
+                WARNING) color='33' ;; # yellow
+                DEBUG)   color='36' ;; # cyan
+            esac
+            if [[ -n "${color}" ]]; then
+                msg=$'\033[0;'"${color}m${msg}"$'\033[0m'
+            fi
+        fi
+        echo "${msg}" >&2
     fi
 }
 _log_info () { _log "INFO" "$@"; }

--- a/tests/by_image/docker-stacks-foundation/test_logging.py
+++ b/tests/by_image/docker-stacks-foundation/test_logging.py
@@ -4,19 +4,45 @@ import re
 
 from tests.utils.tracked_container import TrackedContainer
 
+# Standard env vars used across these tests to run as the root user
+ROOT_ENV = ["NB_USER=root", "NB_UID=0", "NB_GID=0"]
+
+# Trivial commands used to trigger start.sh hooks
+DONE_CMD = ["echo", "done"]
+
+# Source the logging script and run an ad-hoc _log invocation
+SOURCE_LOG = "source /usr/local/bin/_docker_stacks_log.sh"
+
+# Log level prefixes (timestamp follows in square brackets)
+INFO_PREFIX = "INFO["
+WARNING_PREFIX = "WARNING["
+ERROR_PREFIX = "ERROR["
+
+# ANSI color sequences
+ANSI_RED = "\x1b[0;31m"
+ANSI_RESET = "\x1b[0m"
+ANSI_PREFIX = "\x1b["
+
+# Sample messages
+TEST_ERROR_MSG = "test error"
+NO_LEVEL_MSG = "no level here"
+
+# Regex matching the exact log line emitted at the top of start.sh
+START_SH_LOG_RE = re.compile(
+    rf"{re.escape(INFO_PREFIX)}\d{{4}}-\d{{2}}-\d{{2}} \d{{2}}:\d{{2}}:\d{{2}}\] Entered start\.sh"
+)
+
 
 def test_log_format_includes_timestamp(container: TrackedContainer) -> None:
     """Log messages should include a timestamp and level."""
     _, stderr = container.run_and_wait(
         timeout=10,
         user="root",
-        environment=["NB_USER=root", "NB_UID=0", "NB_GID=0"],
-        command=["echo", "done"],
+        environment=ROOT_ENV,
+        command=DONE_CMD,
         split_stderr=True,
     )
-    assert re.search(
-        r"INFO\[\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\] Entered start\.sh", stderr
-    )
+    assert START_SH_LOG_RE.search(stderr)
 
 
 def test_quiet_mode_suppresses_info(container: TrackedContainer) -> None:
@@ -24,31 +50,23 @@ def test_quiet_mode_suppresses_info(container: TrackedContainer) -> None:
     _, stderr = container.run_and_wait(
         timeout=10,
         user="root",
-        environment=[
-            "NB_USER=root",
-            "NB_UID=0",
-            "NB_GID=0",
-            "JUPYTER_DOCKER_STACKS_QUIET=1",
-        ],
-        command=["echo", "done"],
+        environment=[*ROOT_ENV, "JUPYTER_DOCKER_STACKS_QUIET=1"],
+        command=DONE_CMD,
         split_stderr=True,
     )
-    assert "INFO[" not in stderr
+    assert INFO_PREFIX not in stderr
 
 
 def test_quiet_mode_shows_warnings(container: TrackedContainer) -> None:
     """JUPYTER_DOCKER_STACKS_QUIET should still show WARNING messages."""
     _, stderr = container.run_and_wait(
         timeout=10,
-        environment=[
-            "JUPYTER_DOCKER_STACKS_QUIET=1",
-            "GRANT_SUDO=1",
-        ],
-        command=["echo", "done"],
+        environment=["JUPYTER_DOCKER_STACKS_QUIET=1", "GRANT_SUDO=1"],
+        command=DONE_CMD,
         split_stderr=True,
         no_warnings=False,
     )
-    assert "WARNING[" in stderr
+    assert WARNING_PREFIX in stderr
 
 
 def test_log_without_level_defaults_to_info(container: TrackedContainer) -> None:
@@ -56,16 +74,12 @@ def test_log_without_level_defaults_to_info(container: TrackedContainer) -> None
     _, stderr = container.run_and_wait(
         timeout=10,
         user="root",
-        environment=["NB_USER=root", "NB_UID=0", "NB_GID=0"],
-        command=[
-            "bash",
-            "-c",
-            'source /usr/local/bin/_docker_stacks_log.sh && _log "no level here"',
-        ],
+        environment=ROOT_ENV,
+        command=["bash", "-c", f'{SOURCE_LOG} && _log "{NO_LEVEL_MSG}"'],
         split_stderr=True,
     )
-    assert "INFO[" in stderr
-    assert "no level here" in stderr
+    assert INFO_PREFIX in stderr
+    assert NO_LEVEL_MSG in stderr
 
 
 def test_log_color_on_tty(container: TrackedContainer) -> None:
@@ -74,17 +88,13 @@ def test_log_color_on_tty(container: TrackedContainer) -> None:
         timeout=10,
         no_errors=False,
         user="root",
-        environment=["NB_USER=root", "NB_UID=0", "NB_GID=0"],
-        command=[
-            "bash",
-            "-c",
-            'source /usr/local/bin/_docker_stacks_log.sh && _log_error "test error"',
-        ],
+        environment=ROOT_ENV,
+        command=["bash", "-c", f'{SOURCE_LOG} && _log_error "{TEST_ERROR_MSG}"'],
     )
-    assert "\x1b[0;31m" in logs
-    assert "ERROR[" in logs
-    assert "test error" in logs
-    assert "\x1b[0m" in logs
+    assert ANSI_RED in logs
+    assert ERROR_PREFIX in logs
+    assert TEST_ERROR_MSG in logs
+    assert ANSI_RESET in logs
 
 
 def test_log_no_color_without_tty(container: TrackedContainer) -> None:
@@ -93,17 +103,13 @@ def test_log_no_color_without_tty(container: TrackedContainer) -> None:
         timeout=10,
         no_errors=False,
         user="root",
-        environment=["NB_USER=root", "NB_UID=0", "NB_GID=0"],
-        command=[
-            "bash",
-            "-c",
-            'source /usr/local/bin/_docker_stacks_log.sh && _log_error "test error"',
-        ],
+        environment=ROOT_ENV,
+        command=["bash", "-c", f'{SOURCE_LOG} && _log_error "{TEST_ERROR_MSG}"'],
         split_stderr=True,
     )
-    assert "\x1b[" not in stderr
-    assert "ERROR[" in stderr
-    assert "test error" in stderr
+    assert ANSI_PREFIX not in stderr
+    assert ERROR_PREFIX in stderr
+    assert TEST_ERROR_MSG in stderr
 
 
 def test_log_no_color_env_override(container: TrackedContainer) -> None:
@@ -112,12 +118,8 @@ def test_log_no_color_env_override(container: TrackedContainer) -> None:
         timeout=10,
         no_errors=False,
         user="root",
-        environment=["NB_USER=root", "NB_UID=0", "NB_GID=0", "NO_COLOR=1"],
-        command=[
-            "bash",
-            "-c",
-            'source /usr/local/bin/_docker_stacks_log.sh && _log_error "test error"',
-        ],
+        environment=[*ROOT_ENV, "NO_COLOR=1"],
+        command=["bash", "-c", f'{SOURCE_LOG} && _log_error "{TEST_ERROR_MSG}"'],
     )
-    assert "\x1b[" not in logs
-    assert "ERROR[" in logs
+    assert ANSI_PREFIX not in logs
+    assert ERROR_PREFIX in logs

--- a/tests/by_image/docker-stacks-foundation/test_logging.py
+++ b/tests/by_image/docker-stacks-foundation/test_logging.py
@@ -66,3 +66,58 @@ def test_log_without_level_defaults_to_info(container: TrackedContainer) -> None
     )
     assert "INFO[" in stderr
     assert "no level here" in stderr
+
+
+def test_log_color_on_tty(container: TrackedContainer) -> None:
+    """When stderr is a tty, ERROR messages should be colorized."""
+    logs = container.run_and_wait(
+        timeout=10,
+        no_errors=False,
+        user="root",
+        environment=["NB_USER=root", "NB_UID=0", "NB_GID=0"],
+        command=[
+            "bash",
+            "-c",
+            'source /usr/local/bin/_docker_stacks_log.sh && _log_error "test error"',
+        ],
+    )
+    assert "\x1b[0;31m" in logs
+    assert "ERROR[" in logs
+    assert "test error" in logs
+    assert "\x1b[0m" in logs
+
+
+def test_log_no_color_without_tty(container: TrackedContainer) -> None:
+    """When stderr is not a tty (split_stderr uses pipes), no ANSI codes should appear."""
+    _, stderr = container.run_and_wait(
+        timeout=10,
+        no_errors=False,
+        user="root",
+        environment=["NB_USER=root", "NB_UID=0", "NB_GID=0"],
+        command=[
+            "bash",
+            "-c",
+            'source /usr/local/bin/_docker_stacks_log.sh && _log_error "test error"',
+        ],
+        split_stderr=True,
+    )
+    assert "\x1b[" not in stderr
+    assert "ERROR[" in stderr
+    assert "test error" in stderr
+
+
+def test_log_no_color_env_override(container: TrackedContainer) -> None:
+    """NO_COLOR should suppress ANSI colors even when stderr is a tty."""
+    logs = container.run_and_wait(
+        timeout=10,
+        no_errors=False,
+        user="root",
+        environment=["NB_USER=root", "NB_UID=0", "NB_GID=0", "NO_COLOR=1"],
+        command=[
+            "bash",
+            "-c",
+            'source /usr/local/bin/_docker_stacks_log.sh && _log_error "test error"',
+        ],
+    )
+    assert "\x1b[" not in logs
+    assert "ERROR[" in logs

--- a/tests/utils/tracked_container.py
+++ b/tests/utils/tracked_container.py
@@ -1,6 +1,7 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 import logging
+import re
 from typing import Any, Literal, LiteralString, overload
 
 import docker
@@ -172,8 +173,16 @@ class TrackedContainer:
         return warnings
 
     @staticmethod
+    def _strip_ansi(text: str) -> str:
+        return re.sub(r"\x1b\[[0-9;]*m", "", text)
+
+    @staticmethod
     def _lines_starting_with(logs: str, pattern: LiteralString) -> list[str]:
-        return [line for line in logs.splitlines() if line.startswith(pattern)]
+        return [
+            line
+            for line in logs.splitlines()
+            if TrackedContainer._strip_ansi(line).startswith(pattern)
+        ]
 
     def remove(self) -> None:
         """Kills and removes the tracked docker container."""


### PR DESCRIPTION
## Summary
- Colorizes ERROR (red), WARNING (yellow), and DEBUG (cyan) log messages automatically when stderr is a terminal
- No color when output is piped or redirected (standard tty detection via `-t 2`)
- Respects the `NO_COLOR` environment variable
- INFO messages remain uncolored to keep default output clean
- Updates the test utility to strip ANSI codes before matching level prefixes, so existing assertions work with or without color

Addresses #1532 (checkbox: "Based on the log level color can be added").