### PR TITLE
Add development setup guide for local pre-PR checks

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,6 +9,9 @@ and [community-maintained stacks](https://jupyter-docker-stacks.readthedocs.io/e
 
 ## Before Submitting
 
+For a complete guide to running all checks locally (linters, build, tests), see the
+[Development Setup](https://jupyter-docker-stacks.readthedocs.io/en/latest/contributing/dev-setup.html) page.
+
 Please run the [linters](https://jupyter-docker-stacks.readthedocs.io/en/latest/contributing/lint.html)
 locally before opening a pull request.
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -67,6 +67,7 @@ linkcheck_ignore = [
     r"https://mybinder\.org/v2/gh/.*",  # lots of 500 errors
     r"https://packages\.ubuntu\.com/search\?keywords=openjdk",  # frequent read timeouts
     r"https://anaconda\.org\/conda-forge",  # frequent read timeouts
+    r"https://www\.unixodbc\.org/?",  # frequently down
 ]
 
 linkcheck_allowed_redirects = {

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -68,6 +68,7 @@ linkcheck_ignore = [
     r"https://packages\.ubuntu\.com/search\?keywords=openjdk",  # frequent read timeouts
     r"https://anaconda\.org\/conda-forge",  # frequent read timeouts
     r"https://www\.unixodbc\.org/?",  # frequently down
+    r"https://www\.python-excel\.org/?",  # may fail intermittently
 ]
 
 linkcheck_allowed_redirects = {

--- a/docs/contributing/dev-setup.md
+++ b/docs/contributing/dev-setup.md
@@ -4,9 +4,9 @@ This page covers everything you need to run the full CI-equivalent checks locall
 
 ## Prerequisites
 
-- [Docker](https://docs.docker.com/get-docker/)
+- [Docker](https://docs.docker.com/get-started/get-docker/)
 - Python 3.12+
-- [GNU Make](https://www.gnu.org/software/make/)
+- GNU Make
 - Git
 
 ## One-time setup

--- a/docs/contributing/dev-setup.md
+++ b/docs/contributing/dev-setup.md
@@ -49,10 +49,12 @@ This means changes to a parent image won't be reflected unless you also rebuild 
 Replace `<image-name>` with the image you modified (e.g., `docker-stacks-foundation`, `base-notebook`, `scipy-notebook`).
 
 ```{note}
-`make test/<image-name>` runs the tests defined under `tests/by_image/<image-name>/`
-against the named image only. CI additionally re-runs that same test set against every
-downstream image, so a change in `docker-stacks-foundation` is verified across all images
-in CI even though locally you'd only run `make test/docker-stacks-foundation`.
+`make test/<image-name>` runs the tests for that image plus every parent image's
+tests against it (e.g., testing `scipy-notebook` also runs `base-notebook` and
+`docker-stacks-foundation` test files against the `scipy-notebook` image). CI
+additionally runs the same test set against every downstream image, so a change
+in `docker-stacks-foundation` is verified across all images in CI even though
+locally you'd only run `make test/docker-stacks-foundation`.
 ```
 
 ## Common examples

--- a/docs/contributing/dev-setup.md
+++ b/docs/contributing/dev-setup.md
@@ -12,10 +12,10 @@ This page covers everything you need to run the full CI-equivalent checks locall
 ## One-time setup
 
 ```bash
-# Clone the repository (HTTPS)
-git clone https://github.com/jupyter/docker-stacks.git
-# or via SSH
+# Clone the repository (SSH, recommended)
 git clone git@github.com:jupyter/docker-stacks.git
+# or via HTTPS
+git clone https://github.com/jupyter/docker-stacks.git
 
 cd docker-stacks
 
@@ -28,7 +28,7 @@ pre-commit install --install-hooks
 
 ## Pre-PR checklist
 
-Run these steps locally before pushing. They mirror what CI does.
+Run these steps locally before pushing.
 
 ```bash
 # 1. Run all linters including mypy
@@ -41,12 +41,18 @@ make build/<image-name>
 make test/<image-name>
 ```
 
+```{note}
+If the parent image isn't built locally, Docker pulls it from the registry.
+This means changes to a parent image won't be reflected unless you also rebuild it locally.
+```
+
 Replace `<image-name>` with the image you modified (e.g., `docker-stacks-foundation`, `base-notebook`, `scipy-notebook`).
 
 ```{note}
-Tests run against all images that inherit from the one you specify.
-If you modified `docker-stacks-foundation`, you only need to build and test that image,
-but your changes will also be tested against downstream images in CI.
+`make test/<image-name>` runs the tests defined under `tests/by_image/<image-name>/`
+against the named image only. CI additionally re-runs that same test set against every
+downstream image, so a change in `docker-stacks-foundation` is verified across all images
+in CI even though locally you'd only run `make test/docker-stacks-foundation`.
 ```
 
 ## Common examples
@@ -62,4 +68,9 @@ pre-commit run --all-files --hook-stage manual
 make build/docker-stacks-foundation
 make build/base-notebook
 make test/base-notebook
+
+# Build and test every image (slow; mainly useful before opening a PR
+# that changes the foundation or base image)
+make build-all
+make test-all
 ```

--- a/docs/contributing/dev-setup.md
+++ b/docs/contributing/dev-setup.md
@@ -1,0 +1,68 @@
+# Development Setup
+
+This page covers everything you need to run the full CI-equivalent checks locally before opening a pull request.
+
+## Prerequisites
+
+- [Docker](https://docs.docker.com/get-docker/) (with BuildKit enabled, which is the default in modern Docker)
+- Python 3.12+
+- [GNU Make](https://www.gnu.org/software/make/)
+- Git
+
+## One-time setup
+
+```bash
+# Clone the repository
+git clone https://github.com/jupyter/docker-stacks.git
+cd docker-stacks
+
+# Install Python development dependencies
+pip install --upgrade -r requirements-dev.txt
+
+# Install pre-commit hooks (runs linters automatically on git commit)
+pre-commit install --install-hooks
+```
+
+## Pre-PR checklist
+
+Run these steps locally before pushing. They mirror what CI does and take under a minute (after the initial image build).
+
+```bash
+# 1. Run all linters including mypy
+pre-commit run --all-files --hook-stage manual
+
+# 2. Build the image you changed
+make build/<image-name>
+
+# 3. Run tests for that image
+make test/<image-name>
+```
+
+Replace `<image-name>` with the image you modified (e.g., `docker-stacks-foundation`, `base-notebook`, `scipy-notebook`).
+
+```{note}
+Tests run against all images that inherit from the one you specify.
+If you modified `docker-stacks-foundation`, you only need to build and test that image,
+but your changes will also be tested against downstream images in CI.
+```
+
+## Common examples
+
+```bash
+# Working on the foundation image (start scripts, logging, etc.)
+pre-commit run --all-files --hook-stage manual
+make build/docker-stacks-foundation
+make test/docker-stacks-foundation
+
+# Working on the base notebook image
+pre-commit run --all-files --hook-stage manual
+make build/docker-stacks-foundation
+make build/base-notebook
+make test/base-notebook
+```
+
+## Troubleshooting
+
+- **Hadolint fails in pre-commit**: Hadolint runs via Docker, so make sure Docker is running.
+- **Tests are slow the first time**: The initial `make build` pulls base images and installs packages. Subsequent builds use Docker layer caching and are much faster.
+- **shellcheck not found**: The pre-commit hook installs shellcheck automatically; no system install needed.

--- a/docs/contributing/dev-setup.md
+++ b/docs/contributing/dev-setup.md
@@ -4,7 +4,7 @@ This page covers everything you need to run the full CI-equivalent checks locall
 
 ## Prerequisites
 
-- [Docker](https://docs.docker.com/get-docker/) (with BuildKit enabled, which is the default in modern Docker)
+- [Docker](https://docs.docker.com/get-docker/)
 - Python 3.12+
 - [GNU Make](https://www.gnu.org/software/make/)
 - Git
@@ -12,8 +12,11 @@ This page covers everything you need to run the full CI-equivalent checks locall
 ## One-time setup
 
 ```bash
-# Clone the repository
+# Clone the repository (HTTPS)
 git clone https://github.com/jupyter/docker-stacks.git
+# or via SSH
+git clone git@github.com:jupyter/docker-stacks.git
+
 cd docker-stacks
 
 # Install Python development dependencies
@@ -25,7 +28,7 @@ pre-commit install --install-hooks
 
 ## Pre-PR checklist
 
-Run these steps locally before pushing. They mirror what CI does and take under a minute (after the initial image build).
+Run these steps locally before pushing. They mirror what CI does.
 
 ```bash
 # 1. Run all linters including mypy
@@ -60,9 +63,3 @@ make build/docker-stacks-foundation
 make build/base-notebook
 make test/base-notebook
 ```
-
-## Troubleshooting
-
-- **Hadolint fails in pre-commit**: Hadolint runs via Docker, so make sure Docker is running.
-- **Tests are slow the first time**: The initial `make build` pulls base images and installs packages. Subsequent builds use Docker layer caching and are much faster.
-- **shellcheck not found**: The pre-commit hook installs shellcheck automatically; no system install needed.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -22,6 +22,7 @@ Table of Contents
    :maxdepth: 2
    :caption: Contributor Guide
 
+   contributing/dev-setup
    contributing/issues
    contributing/features
    contributing/tests

--- a/docs/using/selecting.md
+++ b/docs/using/selecting.md
@@ -127,7 +127,7 @@ It contains:
   [rsqlite](https://cran.r-project.org/web/packages/RSQLite/index.html),
   [shiny](https://shiny.posit.co),
   [tidymodels](https://www.tidymodels.org/),
-  unixODBC
+  [unixODBC](https://www.unixodbc.org/)
   packages from [conda-forge](https://conda-forge.org/feedstock-outputs/index.html)
 
 ### jupyter/julia-notebook

--- a/docs/using/selecting.md
+++ b/docs/using/selecting.md
@@ -127,7 +127,7 @@ It contains:
   [rsqlite](https://cran.r-project.org/web/packages/RSQLite/index.html),
   [shiny](https://shiny.posit.co),
   [tidymodels](https://www.tidymodels.org/),
-  [unixodbc](https://www.unixodbc.org)
+  unixODBC
   packages from [conda-forge](https://conda-forge.org/feedstock-outputs/index.html)
 
 ### jupyter/julia-notebook


### PR DESCRIPTION
## Summary
- Adds a new `docs/contributing/dev-setup.md` page that consolidates all prerequisites and the full local check sequence into one place
- Covers: Docker, Python, Make prerequisites; one-time setup (pip install, pre-commit install); pre-PR checklist (lint, build, test); common examples; troubleshooting
- Adds the page to the Contributor Guide in `docs/index.rst` (listed first)
- Updates `CONTRIBUTING.md` to link to the new page

Fix #2460