### PR TITLE
Increase x86_64-tensorflow build timeout to 25 minutes

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -243,7 +243,7 @@ jobs:
       image: tensorflow-notebook
       platform: x86_64
       runs-on: ubuntu-24.04
-      timeout-minutes: 15
+      timeout-minutes: 25
     needs: x86_64-scipy
     if: ${{ !contains(github.event.pull_request.title, '[FAST_BUILD]') }}
 


### PR DESCRIPTION
The `x86_64-tensorflow` job has a 15-minute timeout, while all other tensorflow variants (aarch64, x86_64-cuda, aarch64-cuda) have 25 minutes. This causes unpredictable  CI failures on unrelated PRs.

Bumps to 25 minutes to match the other tensorflow jobs.