### PR TITLE
Add pip -v to framework image builds for visibility

### DIFF
--- a/images/pytorch-notebook/Dockerfile
+++ b/images/pytorch-notebook/Dockerfile
@@ -13,7 +13,7 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # Install PyTorch with pip (https://pytorch.org/get-started/locally/)
 # hadolint ignore=DL3013
-RUN pip install --no-cache-dir --index-url 'https://download.pytorch.org/whl/cpu' \
+RUN pip install -v --no-cache-dir --index-url 'https://download.pytorch.org/whl/cpu' \
     'torch' \
     'torchaudio' \
     'torchvision' && \

--- a/images/pytorch-notebook/cuda12/Dockerfile
+++ b/images/pytorch-notebook/cuda12/Dockerfile
@@ -13,7 +13,7 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # Install PyTorch with pip (https://pytorch.org/get-started/locally/)
 # hadolint ignore=DL3013
-RUN pip install --no-cache-dir --extra-index-url=https://pypi.nvidia.com --index-url 'https://download.pytorch.org/whl/cu128' \
+RUN pip install -v --no-cache-dir --extra-index-url=https://pypi.nvidia.com --index-url 'https://download.pytorch.org/whl/cu128' \
     'torch' \
     'torchaudio' \
     'torchvision' && \

--- a/images/pytorch-notebook/cuda13/Dockerfile
+++ b/images/pytorch-notebook/cuda13/Dockerfile
@@ -13,7 +13,7 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # Install PyTorch with pip (https://pytorch.org/get-started/locally/)
 # hadolint ignore=DL3013
-RUN pip install --no-cache-dir --extra-index-url=https://pypi.nvidia.com --index-url 'https://download.pytorch.org/whl/cu130' \
+RUN pip install -v --no-cache-dir --extra-index-url=https://pypi.nvidia.com --index-url 'https://download.pytorch.org/whl/cu130' \
     'torch' \
     'torchaudio' \
     'torchvision' && \

--- a/images/tensorflow-notebook/Dockerfile
+++ b/images/tensorflow-notebook/Dockerfile
@@ -23,7 +23,7 @@ RUN mamba install --yes \
 
 # Install tensorflow with pip, on x86_64 tensorflow-cpu
 RUN [[ $(uname -m) = x86_64 ]] && TF_POSTFIX="-cpu" || TF_POSTFIX="" && \
-    pip install --no-cache-dir \
+    pip install -v --no-cache-dir \
     "tensorflow${TF_POSTFIX}" && \
     fix-permissions "${CONDA_DIR}" && \
     fix-permissions "/home/${NB_USER}"

--- a/images/tensorflow-notebook/cuda/Dockerfile
+++ b/images/tensorflow-notebook/cuda/Dockerfile
@@ -22,7 +22,7 @@ RUN mamba install --yes \
     fix-permissions "/home/${NB_USER}"
 
 # Install TensorFlow, CUDA and cuDNN with pip
-RUN pip install -vv --no-cache-dir \
+RUN pip install -v --no-cache-dir \
     'tensorflow[and-cuda]' && \
     fix-permissions "${CONDA_DIR}" && \
     fix-permissions "/home/${NB_USER}"

--- a/images/tensorflow-notebook/cuda/Dockerfile
+++ b/images/tensorflow-notebook/cuda/Dockerfile
@@ -22,7 +22,7 @@ RUN mamba install --yes \
     fix-permissions "/home/${NB_USER}"
 
 # Install TensorFlow, CUDA and cuDNN with pip
-RUN pip install --no-cache-dir \
+RUN pip install -vv --no-cache-dir \
     'tensorflow[and-cuda]' && \
     fix-permissions "${CONDA_DIR}" && \
     fix-permissions "/home/${NB_USER}"


### PR DESCRIPTION
## Summary

Adds `-v` to the `pip install` step in every deep-learning image:

- `images/tensorflow-notebook/Dockerfile` (CPU tensorflow)
- `images/tensorflow-notebook/cuda/Dockerfile` (`tensorflow[and-cuda]`)
- `images/pytorch-notebook/Dockerfile` (CPU torch)
- `images/pytorch-notebook/cuda12/Dockerfile`
- `images/pytorch-notebook/cuda13/Dockerfile`

These builds regularly approach the 25-minute job timeout in CI (e.g. https://github.com/jupyter/docker-stacks/actions/runs/26813492547/job/79051883222) but offer no insight into where they stall. With `-v`, pip prints resolver decisions, download URLs, and install events, making it possible to see whether a stuck build is in the resolver, download, or unzip phase.

Ref: #2466