### PR TITLE
chore: improve docker-stacks maintenance path

### DIFF
--- a/tests/by_image/base-notebook/test_notebook.py
+++ b/tests/by_image/base-notebook/test_notebook.py
@@ -9,6 +9,7 @@ def test_secured_server(
     container: TrackedContainer, http_client: requests.Session, free_host_port: int
 ) -> None:
     """Jupyter Server should eventually request user login."""
+    assert isinstance(free_host_port, int) and 0 < free_host_port <= 65535
     container.run_detached(ports={"8888/tcp": free_host_port})
     resp = http_client.get(f"http://localhost:{free_host_port}")
     resp.raise_for_status()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -69,7 +69,7 @@ def image_name(request: pytest.FixtureRequest) -> str:
 @pytest.fixture(scope="function")
 def container(
     docker_client: docker.DockerClient, image_name: str
-) -> Generator[TrackedContainer]:
+) -> Generator[TrackedContainer, None, None]:
     """Notebook container with initial configuration appropriate for testing
     (e.g., HTTP port exposed to the host for HTTP calls).
 
@@ -84,9 +84,11 @@ def container(
 
 
 @pytest.fixture(scope="function")
-def free_host_port() -> Generator[int]:
+def free_host_port() -> Generator[int, None, None]:
     """Finds a free port on the host machine"""
     with closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as s:
         s.bind(("", 0))
         s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-        yield s.getsockname()[1]
+        port = s.getsockname()[1]
+        assert isinstance(port, int) and 0 < port <= 65535
+        yield port


### PR DESCRIPTION
Summary:
- Add or tighten focused edge-case tests or type assertions in tests/conftest.py, tests/run_tests.py related to Python typing, tests, CLI ergonomics, observability; avoid docs-only changes and broad refactors.
- Keep the change narrow so it is straightforward to review.

Notes:
- I kept this scoped to the relevant implementation and tests.