### PR TITLE
Add JAX with CUDA recipe

### DIFF
--- a/docs/using/recipe_code/jax_cuda.dockerfile
+++ b/docs/using/recipe_code/jax_cuda.dockerfile
@@ -1,0 +1,6 @@
+ARG BASE_IMAGE=quay.io/jupyter/base-notebook
+FROM $BASE_IMAGE
+
+RUN pip install -v --no-cache-dir 'jax[cuda13]' && \
+    fix-permissions "${CONDA_DIR}" && \
+    fix-permissions "/home/${NB_USER}"

--- a/docs/using/recipes.md
+++ b/docs/using/recipes.md
@@ -121,6 +121,16 @@ You can find the original Jupyter Notebook extension [here](https://github.com/d
 :language: docker
 ```
 
+## JAX with CUDA
+
+[JAX](https://jax.readthedocs.io/) GPU support via the bundled NVIDIA CUDA wheels.
+Run with `--gpus all` and a host NVIDIA driver new enough for CUDA 13.
+For CUDA 12 instead, swap `jax[cuda13]` for `jax[cuda12]`.
+
+```{literalinclude} recipe_code/jax_cuda.dockerfile
+:language: docker
+```
+
 ## Running behind an nginx proxy
 
 ```{warning}


### PR DESCRIPTION
Issue: #2471.

Adds a small recipe to `docs/using/recipes.md` that installs JAX with CUDA 13 wheels into the base notebook image. Same shape as the `xgboost` recipe.