### PR TITLE
Ignore huggingface.co in sphinx linkcheck

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -69,6 +69,7 @@ linkcheck_ignore = [
     r"https://anaconda\.org\/conda-forge",  # frequent read timeouts
     r"https://www\.unixodbc\.org/?",  # frequently down
     r"https://www\.python-excel\.org/?",  # may fail intermittently
+    r"https://huggingface\.co/.*",  # frequently rate-limited
 ]
 
 linkcheck_allowed_redirects = {


### PR DESCRIPTION
huggingface.co rate-limits sphinx-linkcheck, causing the build-docs job to retry-and-sleep until the 10-minute timeout. Same pattern as the existing entries for unixodbc.org and python-excel.org.

Example failure: https://github.com/jupyter/docker-stacks/actions/runs/27047077398/job/79835076575

Refs #2466.