### PR TITLE
Bump build-docs timeout to 15 minutes

### DIFF
--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -45,7 +45,7 @@ jobs:
     runs-on: ubuntu-24.04
     permissions:
       contents: read
-    timeout-minutes: 10
+    timeout-minutes: 15
     if: github.repository_owner == 'jupyter' || github.repository_owner == 'mathbunnyru' || github.event_name != 'schedule'
 
     steps:


### PR DESCRIPTION
linkcheck retries on rate-limited or slow external URLs occasionally push the job past 10 minutes (e.g. https://github.com/jupyter/docker-stacks/actions/runs/27047077398/job/79835076575).

Refs #2466.