### PR TITLE
Add _log_fatal helper and use it for fatal errors in start.sh

### DIFF
--- a/images/docker-stacks-foundation/_docker_stacks_log.sh
+++ b/images/docker-stacks-foundation/_docker_stacks_log.sh
@@ -36,3 +36,4 @@ _log () {
 _log_info () { _log "INFO" "$@"; }
 _log_warn () { _log "WARNING" "$@"; }
 _log_error () { _log "ERROR" "$@"; }
+_log_fatal () { _log "ERROR" "$@"; exit 1; }

--- a/images/docker-stacks-foundation/_docker_stacks_log.sh
+++ b/images/docker-stacks-foundation/_docker_stacks_log.sh
@@ -3,28 +3,29 @@
 # Distributed under the terms of the Modified BSD License.
 
 # The _log function is used for everything these scripts want to log.
-# It will always log errors and warnings but can be silenced for other messages
-# by setting the JUPYTER_DOCKER_STACKS_QUIET environment variable.
-# Colorizes ERROR, WARNING, and DEBUG output when stderr is a terminal.
+# It will always log fatals, errors and warnings but can be silenced for other
+# messages by setting the JUPYTER_DOCKER_STACKS_QUIET environment variable.
+# Colorizes FATAL, ERROR, WARNING, and DEBUG output when stderr is a terminal.
 _log () {
     local level="${1}"
     case "${level}" in
-        INFO|WARNING|ERROR|DEBUG)
+        INFO|WARNING|ERROR|FATAL|DEBUG)
             shift
             ;;
         *)
             level="INFO"
             ;;
     esac
-    if [[ "${level}" == "ERROR" ]] || [[ "${level}" == "WARNING" ]] || [[ "${JUPYTER_DOCKER_STACKS_QUIET}" == "" ]]; then
+    if [[ "${level}" == "FATAL" ]] || [[ "${level}" == "ERROR" ]] || [[ "${level}" == "WARNING" ]] || [[ "${JUPYTER_DOCKER_STACKS_QUIET}" == "" ]]; then
         local msg
         msg="${level}[$(date '+%Y-%m-%d %H:%M:%S')] $*"
         if [[ -t 2 ]] && [[ "${NO_COLOR:-}" == "" ]]; then
             local color=""
             case "${level}" in
-                ERROR)   color='31' ;; # red
-                WARNING) color='33' ;; # yellow
-                DEBUG)   color='36' ;; # cyan
+                FATAL)   color='1;31' ;; # bold red
+                ERROR)   color='31' ;;   # red
+                WARNING) color='33' ;;   # yellow
+                DEBUG)   color='36' ;;   # cyan
             esac
             if [[ -n "${color}" ]]; then
                 msg=$'\033[0;'"${color}m${msg}"$'\033[0m'
@@ -36,4 +37,4 @@ _log () {
 _log_info () { _log "INFO" "$@"; }
 _log_warn () { _log "WARNING" "$@"; }
 _log_error () { _log "ERROR" "$@"; }
-_log_fatal () { _log "ERROR" "$@"; exit 1; }
+_log_fatal () { _log "FATAL" "$@"; exit 1; }

--- a/images/docker-stacks-foundation/start.sh
+++ b/images/docker-stacks-foundation/start.sh
@@ -67,8 +67,7 @@ if [ "$(id -u)" == 0 ]; then
             _log_info "- home dir: /home/jovyan -> /home/${NB_USER}"
         fi
     elif ! id -u "${NB_USER}" &> /dev/null; then
-        _log_error "Neither the jovyan user nor '${NB_USER}' exists. This could be the result of stopping and starting, the container with a different NB_USER environment variable."
-        exit 1
+        _log_fatal "Neither the jovyan user nor '${NB_USER}' exists. This could be the result of stopping and starting, the container with a different NB_USER environment variable."
     fi
     # Ensure the desired user (NB_USER) gets its desired user id (NB_UID) and is
     # a member of the desired group (NB_GROUP, NB_GID)
@@ -106,8 +105,7 @@ if [ "$(id -u)" == 0 ]; then
                 if ln -s /home/jovyan "/home/${NB_USER}"; then
                     _log_info "Success creating symlink!"
                 else
-                    _log_error "Failed copy data from /home/jovyan to /home/${NB_USER} or to create symlink!"
-                    exit 1
+                    _log_fatal "Failed copy data from /home/jovyan to /home/${NB_USER} or to create symlink!"
                 fi
             fi
         fi

--- a/tests/by_image/docker-stacks-foundation/test_logging.py
+++ b/tests/by_image/docker-stacks-foundation/test_logging.py
@@ -17,9 +17,11 @@ SOURCE_LOG = "source /usr/local/bin/_docker_stacks_log.sh"
 INFO_PREFIX = "INFO["
 WARNING_PREFIX = "WARNING["
 ERROR_PREFIX = "ERROR["
+FATAL_PREFIX = "FATAL["
 
 # ANSI color sequences
 ANSI_RED = "\x1b[0;31m"
+ANSI_BOLD_RED = "\x1b[0;1;31m"
 ANSI_RESET = "\x1b[0m"
 ANSI_PREFIX = "\x1b["
 
@@ -113,18 +115,33 @@ def test_log_no_color_without_tty(container: TrackedContainer) -> None:
 
 
 def test_log_fatal_exits_nonzero(container: TrackedContainer) -> None:
-    """_log_fatal should emit an ERROR message and exit with a non-zero status."""
+    """_log_fatal should emit a FATAL message and exit with a non-zero status."""
     _, stderr = container.run_and_wait(
         timeout=10,
         no_failure=False,
-        no_errors=False,
         user="root",
         environment=ROOT_ENV,
         command=["bash", "-c", f'{SOURCE_LOG} && _log_fatal "{TEST_ERROR_MSG}"'],
         split_stderr=True,
     )
-    assert ERROR_PREFIX in stderr
+    assert FATAL_PREFIX in stderr
+    assert ERROR_PREFIX not in stderr
     assert TEST_ERROR_MSG in stderr
+
+
+def test_log_fatal_color_on_tty(container: TrackedContainer) -> None:
+    """When stderr is a tty, FATAL messages should be colorized in bold red."""
+    logs = container.run_and_wait(
+        timeout=10,
+        no_failure=False,
+        user="root",
+        environment=ROOT_ENV,
+        command=["bash", "-c", f'{SOURCE_LOG} && _log_fatal "{TEST_ERROR_MSG}"'],
+    )
+    assert ANSI_BOLD_RED in logs
+    assert FATAL_PREFIX in logs
+    assert TEST_ERROR_MSG in logs
+    assert ANSI_RESET in logs
 
 
 def test_log_no_color_env_override(container: TrackedContainer) -> None:

--- a/tests/by_image/docker-stacks-foundation/test_logging.py
+++ b/tests/by_image/docker-stacks-foundation/test_logging.py
@@ -112,6 +112,21 @@ def test_log_no_color_without_tty(container: TrackedContainer) -> None:
     assert TEST_ERROR_MSG in stderr
 
 
+def test_log_fatal_exits_nonzero(container: TrackedContainer) -> None:
+    """_log_fatal should emit an ERROR message and exit with a non-zero status."""
+    _, stderr = container.run_and_wait(
+        timeout=10,
+        no_failure=False,
+        no_errors=False,
+        user="root",
+        environment=ROOT_ENV,
+        command=["bash", "-c", f'{SOURCE_LOG} && _log_fatal "{TEST_ERROR_MSG}"'],
+        split_stderr=True,
+    )
+    assert ERROR_PREFIX in stderr
+    assert TEST_ERROR_MSG in stderr
+
+
 def test_log_no_color_env_override(container: TrackedContainer) -> None:
     """NO_COLOR should suppress ANSI colors even when stderr is a tty."""
     logs = container.run_and_wait(


### PR DESCRIPTION
Adds a `_log_fatal` helper (logs ERROR + `exit 1`) and uses it for the two fatal paths in `start.sh`

Closes #1532