### PR TITLE
Sleep between registry login retries

### DIFF
--- a/.github/workflows/docker-tag-merge.yml
+++ b/.github/workflows/docker-tag-merge.yml
@@ -59,9 +59,10 @@ jobs:
           docker login ${{ env.REGISTRY }} \
             --username ${{ secrets.REGISTRY_USERNAME }} \
             --password ${{ secrets.REGISTRY_TOKEN }} || \
+          (sleep 10 && \
           docker login ${{ env.REGISTRY }} \
             --username ${{ secrets.REGISTRY_USERNAME }} \
-            --password ${{ secrets.REGISTRY_TOKEN }}
+            --password ${{ secrets.REGISTRY_TOKEN }})
         shell: bash
         id: login
 

--- a/.github/workflows/docker-tag-push.yml
+++ b/.github/workflows/docker-tag-push.yml
@@ -60,9 +60,10 @@ jobs:
           docker login ${{ env.REGISTRY }} \
             --username ${{ secrets.REGISTRY_USERNAME }} \
             --password ${{ secrets.REGISTRY_TOKEN }} || \
+          (sleep 10 && \
           docker login ${{ env.REGISTRY }} \
             --username ${{ secrets.REGISTRY_USERNAME }} \
-            --password ${{ secrets.REGISTRY_TOKEN }}
+            --password ${{ secrets.REGISTRY_TOKEN }})
         shell: bash
         id: login
 


### PR DESCRIPTION
## Summary

- Wait 10s before the second registry login attempt in `docker-tag-push.yml` and `docker-tag-merge.yml`.

Addresses #2466 
