### PR TITLE
ci: sign container images with cosign for supply-chain security

### DIFF
--- a/.github/workflows/docker-tag-merge.yml
+++ b/.github/workflows/docker-tag-merge.yml
@@ -68,7 +68,6 @@ jobs:
         id: login
 
       - name: Merge tags for the images 🔀
-        if: env.PUSH_TO_REGISTRY == 'true'
         run: |
           python3 -m tagging.apps.merge_tags \
             --image ${{ inputs.image }} \
@@ -77,7 +76,7 @@ jobs:
         shell: bash
 
       - name: Install Cosign 🔏
-        uses: sigstore/cosign-installer@v4.1.0
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
 
       - name: Sign image with Cosign 🔏
         if: env.PUSH_TO_REGISTRY == 'true'

--- a/.github/workflows/docker-tag-merge.yml
+++ b/.github/workflows/docker-tag-merge.yml
@@ -32,6 +32,7 @@ jobs:
     runs-on: ubuntu-24.04
     permissions:
       contents: read
+      id-token: write
     timeout-minutes: ${{ inputs.timeout-minutes }}
 
     steps:
@@ -67,11 +68,28 @@ jobs:
         id: login
 
       - name: Merge tags for the images 🔀
+        if: env.PUSH_TO_REGISTRY == 'true'
+        id: merge
         run: |
           python3 -m tagging.apps.merge_tags \
             --image ${{ inputs.image }} \
             --variant ${{ inputs.variant }} \
             --tags-dir /tmp/jupyter/tags/
+          IMAGE_DIGEST=$(docker manifest inspect ${{ env.REGISTRY }}/${{ env.OWNER }}/${{ inputs.image }} --verbose | python3 -c "import sys,json; data=json.load(sys.stdin); print(data[0]['Descriptor']['digest']) if isinstance(data, list) else print(data['Descriptor']['digest'])")
+          echo "digest=${IMAGE_DIGEST}" >> $GITHUB_OUTPUT
+        shell: bash
+
+      - name: Install Cosign 🔏
+        if: env.PUSH_TO_REGISTRY == 'true'
+        uses: sigstore/cosign-installer@3454372f43399081ed03b604cb2d021dabca52bb # v3.8.2
+
+      - name: Sign image with Cosign 🔏
+        if: env.PUSH_TO_REGISTRY == 'true'
+        env:
+          DIGEST: ${{ steps.merge.outputs.digest }}
+        run: |
+          cosign sign --yes \
+            ${{ env.REGISTRY }}/${{ env.OWNER }}/${{ inputs.image }}@${DIGEST}
         shell: bash
 
       - name: Logout from Registry 🔐

--- a/.github/workflows/docker-tag-merge.yml
+++ b/.github/workflows/docker-tag-merge.yml
@@ -69,27 +69,22 @@ jobs:
 
       - name: Merge tags for the images 🔀
         if: env.PUSH_TO_REGISTRY == 'true'
-        id: merge
         run: |
           python3 -m tagging.apps.merge_tags \
             --image ${{ inputs.image }} \
             --variant ${{ inputs.variant }} \
             --tags-dir /tmp/jupyter/tags/
-          IMAGE_DIGEST=$(docker manifest inspect ${{ env.REGISTRY }}/${{ env.OWNER }}/${{ inputs.image }} --verbose | python3 -c "import sys,json; data=json.load(sys.stdin); print(data[0]['Descriptor']['digest']) if isinstance(data, list) else print(data['Descriptor']['digest'])")
-          echo "digest=${IMAGE_DIGEST}" >> $GITHUB_OUTPUT
         shell: bash
 
       - name: Install Cosign 🔏
-        if: env.PUSH_TO_REGISTRY == 'true'
-        uses: sigstore/cosign-installer@3454372f43399081ed03b604cb2d021dabca52bb # v3.8.2
+        uses: sigstore/cosign-installer@v4.1.0
 
       - name: Sign image with Cosign 🔏
         if: env.PUSH_TO_REGISTRY == 'true'
-        env:
-          DIGEST: ${{ steps.merge.outputs.digest }}
         run: |
+          IMAGE_DIGEST=$(docker manifest inspect ${{ env.REGISTRY }}/${{ env.OWNER }}/${{ inputs.image }} --verbose | python3 -c "import sys,json; data=json.load(sys.stdin); print(data[0]['Descriptor']['digest']) if isinstance(data, list) else print(data['Descriptor']['digest'])")
           cosign sign --yes \
-            ${{ env.REGISTRY }}/${{ env.OWNER }}/${{ inputs.image }}@${DIGEST}
+            ${{ env.REGISTRY }}/${{ env.OWNER }}/${{ inputs.image }}@${IMAGE_DIGEST}
         shell: bash
 
       - name: Logout from Registry 🔐

--- a/.github/workflows/docker-tag-push-merge.yml
+++ b/.github/workflows/docker-tag-push-merge.yml
@@ -24,6 +24,7 @@ jobs:
     uses: ./.github/workflows/docker-tag-push.yml
     permissions:
       contents: read
+      id-token: write
     with:
       image: ${{ inputs.image }}
       variant: ${{ inputs.variant }}
@@ -35,6 +36,7 @@ jobs:
     uses: ./.github/workflows/docker-tag-merge.yml
     permissions:
       contents: read
+      id-token: write
     needs: tag-push
     with:
       image: ${{ inputs.image }}

--- a/.github/workflows/docker-tag-push.yml
+++ b/.github/workflows/docker-tag-push.yml
@@ -76,7 +76,7 @@ jobs:
         shell: bash
 
       - name: Install Cosign 🔏
-        uses: sigstore/cosign-installer@v4.1.0
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
 
       - name: Sign image with Cosign 🔏
         if: env.PUSH_TO_REGISTRY == 'true'

--- a/.github/workflows/docker-tag-push.yml
+++ b/.github/workflows/docker-tag-push.yml
@@ -33,6 +33,7 @@ jobs:
     runs-on: ubuntu-24.04
     permissions:
       contents: read
+      id-token: write
     timeout-minutes: ${{ inputs.timeout-minutes }}
     strategy:
       matrix:
@@ -69,9 +70,25 @@ jobs:
 
       - name: Push single platform images to Registry 📤
         if: env.PUSH_TO_REGISTRY == 'true'
+        id: push
         run: |
           docker push --all-tags ${{ env.REGISTRY }}/${{ env.OWNER }}/${{ inputs.image }} || \
           docker push --all-tags ${{ env.REGISTRY }}/${{ env.OWNER }}/${{ inputs.image }}
+          IMAGE_DIGEST=$(docker inspect --format='{{index .RepoDigests 0}}' ${{ env.REGISTRY }}/${{ env.OWNER }}/${{ inputs.image }} | cut -d'@' -f2)
+          echo "digest=${IMAGE_DIGEST}" >> $GITHUB_OUTPUT
+        shell: bash
+
+      - name: Install Cosign 🔏
+        if: env.PUSH_TO_REGISTRY == 'true'
+        uses: sigstore/cosign-installer@3454372f43399081ed03b604cb2d021dabca52bb # v3.8.2
+
+      - name: Sign image with Cosign 🔏
+        if: env.PUSH_TO_REGISTRY == 'true'
+        env:
+          DIGEST: ${{ steps.push.outputs.digest }}
+        run: |
+          cosign sign --yes \
+            ${{ env.REGISTRY }}/${{ env.OWNER }}/${{ inputs.image }}@${DIGEST}
         shell: bash
 
       - name: Logout from Registry 🔐

--- a/.github/workflows/docker-tag-push.yml
+++ b/.github/workflows/docker-tag-push.yml
@@ -70,25 +70,20 @@ jobs:
 
       - name: Push single platform images to Registry 📤
         if: env.PUSH_TO_REGISTRY == 'true'
-        id: push
         run: |
           docker push --all-tags ${{ env.REGISTRY }}/${{ env.OWNER }}/${{ inputs.image }} || \
           docker push --all-tags ${{ env.REGISTRY }}/${{ env.OWNER }}/${{ inputs.image }}
-          IMAGE_DIGEST=$(docker inspect --format='{{index .RepoDigests 0}}' ${{ env.REGISTRY }}/${{ env.OWNER }}/${{ inputs.image }} | cut -d'@' -f2)
-          echo "digest=${IMAGE_DIGEST}" >> $GITHUB_OUTPUT
         shell: bash
 
       - name: Install Cosign 🔏
-        if: env.PUSH_TO_REGISTRY == 'true'
-        uses: sigstore/cosign-installer@3454372f43399081ed03b604cb2d021dabca52bb # v3.8.2
+        uses: sigstore/cosign-installer@v4.1.0
 
       - name: Sign image with Cosign 🔏
         if: env.PUSH_TO_REGISTRY == 'true'
-        env:
-          DIGEST: ${{ steps.push.outputs.digest }}
         run: |
+          IMAGE_DIGEST=$(docker inspect --format='{{index .RepoDigests 0}}' ${{ env.REGISTRY }}/${{ env.OWNER }}/${{ inputs.image }} | cut -d'@' -f2)
           cosign sign --yes \
-            ${{ env.REGISTRY }}/${{ env.OWNER }}/${{ inputs.image }}@${DIGEST}
+            ${{ env.REGISTRY }}/${{ env.OWNER }}/${{ inputs.image }}@${IMAGE_DIGEST}
         shell: bash
 
       - name: Logout from Registry 🔐

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -452,6 +452,7 @@ jobs:
     uses: ./.github/workflows/docker-tag-push-merge.yml
     permissions:
       contents: read
+      id-token: write
     with:
       image: ${{ matrix.image }}
       variant: ${{ matrix.variant }}
@@ -522,6 +523,7 @@ jobs:
     uses: ./.github/workflows/docker-tag-push-merge.yml
     permissions:
       contents: read
+      id-token: write
     with:
       image: ${{ matrix.image }}
       variant: ${{ matrix.variant }}


### PR DESCRIPTION
## What

Signs all published Docker images with cosign (keyless, via GitHub OIDC) 
after they're pushed to Quay.io, addressing the OpenSSF Scorecard 
Signed-Releases check flagged in #2455.

## How it works

- Adds `id-token: write` permission for GitHub OIDC authentication
- Captures the image digest immediately after `docker push`
- Signs by digest (not tag) so the signature is tied to the immutable image content
- Uses `sigstore/cosign-installer` pinned to a specific commit hash

## Layer inheritance is unaffected

The `.sig` signature is attached as a separate OCI artifact on Quay.io —
the image and its layers are completely untouched, so the existing layer
sharing between stacked images (base-notebook → minimal-notebook → scipy-notebook)
works exactly as before.

## Verification

Once merged, users can verify any image with:
cosign verify quay.io/jupyter/base-notebook@sha256:... \
  --certificate-identity-regexp="https://github.com/jupyter/docker-stacks" \
  --certificate-oidc-issuer="https://token.actions.githubusercontent.com"

Note: Cosign is now installed on every run (including PRs) for better CI coverage. The actual signing step is still gated behind PUSH_TO_REGISTRY == 'true' so it only runs on main.

Fixes #2455