### PR TITLE
Sleep 10s between registry push retries

### DIFF
--- a/.github/workflows/docker-tag-push.yml
+++ b/.github/workflows/docker-tag-push.yml
@@ -71,7 +71,8 @@ jobs:
         if: env.PUSH_TO_REGISTRY == 'true'
         run: |
           docker push --all-tags ${{ env.REGISTRY }}/${{ env.OWNER }}/${{ inputs.image }} || \
-          docker push --all-tags ${{ env.REGISTRY }}/${{ env.OWNER }}/${{ inputs.image }}
+          (sleep 10 && \
+          docker push --all-tags ${{ env.REGISTRY }}/${{ env.OWNER }}/${{ inputs.image }})
         shell: bash
 
       - name: Logout from Registry 🔐


### PR DESCRIPTION
Addresses #2486



Follows up on #2479, which added a 10s sleep between registry *login* retries. The image *push* step had the same back-to-back retry pattern with no wait.

**Previous behaviour:** on a transient quay.io error, `docker push` retried immediately (~0.25s later, per failed-run logs), so a brief registry blip failed both attempts and the job exited 1.

**New behaviour:** the retry waits 10s before the second `docker push`, giving the registry time to recover, matching the login retry in #2479.