### PR TITLE
Enable double-quoted identifiers in sparklyr test notebook

### DIFF
--- a/tests/by_image/all-spark-notebook/data/local_sparklyr.ipynb
+++ b/tests/by_image/all-spark-notebook/data/local_sparklyr.ipynb
@@ -12,6 +12,8 @@
     "conf <- spark_config()\n",
     "# Set the catalog implementation in-memory\n",
     "conf$spark.sql.catalogImplementation <- \"in-memory\"\n",
+    "# Spark 4 reads double-quoted names as string literals by default, breaking sparklyr-generated SQL\n",
+    "conf$spark.sql.ansi.doubleQuotedIdentifiers <- \"true\"\n",
     "\n",
     "# Spark session & context\n",
     "sc <- spark_connect(master = \"local\", config = conf)\n",


### PR DESCRIPTION
Part of #2486

The `local_sparklyr` test notebook runs `sdf_len(sc, 100) %>% spark_apply(...)`. To execute that pipeline, sparklyr/dbplyr generate Spark SQL that refers to the `id` column `sdf_len` creates, quoting it as a double-quoted identifier (`"id"`).

This worked under Spark 3, but the all-spark image installs the latest Spark when the version is unpinned, which is now Spark 4. Spark 4 enables ANSI mode by default, and `spark.sql.ansi.doubleQuotedIdentifiers` defaults to `false`, so Spark 4 reads `"id"` as a string literal rather than a column name and rejects the query:

```
[PARSE_SYNTAX_ERROR] Syntax error at or near '"id"'. SQLSTATE: 42601
```

The test fails on a few runs (it exhausts its flaky reruns, then fails), so it is a real Spark-4 incompatibility, not flakiness.

Fix: set `spark.sql.ansi.doubleQuotedIdentifiers = true` in the notebook's `spark_config()` so Spark again reads the double-quoted names sparklyr emits as identifiers.

References:
- All-spark installs the latest Spark when unpinned: https://github.com/jupyter/docker-stacks/blob/91aceb0b50cd35c8c914ce6cb56ed33eb10abf9a/images/pyspark-notebook/Dockerfile#L27
- Spark 4 enables ANSI mode by default (Spark SQL migration guide, "Upgrading from Spark SQL 3.5 to 4.0"): https://spark.apache.org/docs/latest/sql-migration-guide.html#upgrading-from-spark-sql-35-to-40
- `spark.sql.ansi.doubleQuotedIdentifiers` (default `false`; true reads `"..."` as identifiers, false as string literals): https://github.com/apache/spark/blob/master/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala#L5301
- Failing run: https://github.com/jupyter/docker-stacks/actions/runs/27866515947

Reproduced locally on pyspark 4.1.2 (exact error) and confirmed the config fixes it.