### PR TITLE
Fix flaky test_start_notebook log race with a wait_until helper

### DIFF
--- a/tests/by_image/base-notebook/test_healthcheck.py
+++ b/tests/by_image/base-notebook/test_healthcheck.py
@@ -1,11 +1,11 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 import logging
-import time
 
 import pytest  # type: ignore
 
 from tests.utils.tracked_container import TrackedContainer
+from tests.utils.wait import wait_until
 
 LOGGER = logging.getLogger(__name__)
 
@@ -24,16 +24,8 @@ def get_healthy_status(
     )
 
     # giving some time to let the server start
-    finish_time = time.time() + 10
-    sleep_time = 1
-    while time.time() < finish_time:
-        time.sleep(sleep_time)
-
-        status = container.get_health()
-        if status == "healthy":
-            return status
-
-    return status
+    wait_until(lambda: container.get_health() == "healthy")
+    return container.get_health()
 
 
 @pytest.mark.parametrize(

--- a/tests/by_image/base-notebook/test_start_container.py
+++ b/tests/by_image/base-notebook/test_start_container.py
@@ -7,6 +7,7 @@ import pytest  # type: ignore
 import requests
 
 from tests.utils.tracked_container import TrackedContainer
+from tests.utils.wait import wait_until
 
 LOGGER = logging.getLogger(__name__)
 
@@ -49,10 +50,13 @@ def test_start_notebook(
     else:
         # For non-listening cases (e.g. jupyterhub-singleuser), give the script time to print
         time.sleep(5)
+    # Buffered container stdout can lag the server being reachable, so poll the logs.
+    expected_log = f"Executing: {expected_command}"
+    wait_until(lambda: expected_log in container.get_logs())
     logs = container.get_logs()
     LOGGER.debug(logs)
     assert (
-        f"Executing: {expected_command}" in logs
+        expected_log in logs
     ), f"Not the expected command ({expected_command}) was launched"
     assert "ERROR" not in logs, "ERROR(s) found in logs"
     for exp_warning in expected_warnings:

--- a/tests/utils/wait.py
+++ b/tests/utils/wait.py
@@ -1,0 +1,23 @@
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+import time
+from collections.abc import Callable
+
+
+def wait_until(
+    predicate: Callable[[], bool],
+    *,
+    timeout: float = 10.0,
+    interval: float = 1.0,
+) -> bool:
+    """Call ``predicate`` until it returns True or ``timeout`` elapses.
+
+    Useful when something becomes ready asynchronously (a container's buffered
+    logs, a health status, a booting server). Returns whether it succeeded.
+    """
+    finish_time = time.monotonic() + timeout
+    while time.monotonic() < finish_time:
+        if predicate():
+            return True
+        time.sleep(interval)
+    return False


### PR DESCRIPTION
Part of #2486

Fixes the flaky `test_start_notebook` failure on `all-spark`, where the log check failed even though the server had started (the HTTP 200 assert before it passed). `get_logs()` reads stdout once, and the container's buffered output can flush just after the server is reachable, so the read misses `Executing: jupyter lab`.

Now it waits for the line instead of reading once, via a new `wait_until` helper in `tests/utils/wait.py` (also reused in `test_healthcheck`).

Failing runs: [1](https://github.com/jupyter/docker-stacks/actions/runs/26383287219), [2](https://github.com/jupyter/docker-stacks/actions/runs/26013548599)