### PR TITLE
ci: fix empty image digest in cosign signing on push

### DIFF
--- a/.github/workflows/docker-tag-push.yml
+++ b/.github/workflows/docker-tag-push.yml
@@ -71,10 +71,9 @@ jobs:
       - name: Push single platform images to Registry 📤
         if: env.PUSH_TO_REGISTRY == 'true'
         run: |
-          docker push --all-tags ${{ env.REGISTRY }}/${{ env.OWNER }}/${{ inputs.image }} | tee /tmp/push.log || \
+          docker push --all-tags ${{ env.REGISTRY }}/${{ env.OWNER }}/${{ inputs.image }} || \
           (sleep 10 && \
-          docker push --all-tags ${{ env.REGISTRY }}/${{ env.OWNER }}/${{ inputs.image }} | tee /tmp/push.log)
-          echo "IMAGE_DIGEST=$(grep -o 'digest: sha256:[a-f0-9]\{64\}' /tmp/push.log | head -1 | cut -d' ' -f2)" >> "$GITHUB_ENV"
+          docker push --all-tags ${{ env.REGISTRY }}/${{ env.OWNER }}/${{ inputs.image }})
         shell: bash
 
       - name: Install Cosign 🔏
@@ -83,6 +82,10 @@ jobs:
       - name: Sign image with Cosign 🔏
         if: env.PUSH_TO_REGISTRY == 'true'
         run: |
+          # The :latest tag was removed earlier, so inspect by image ID to read
+          # the push-populated digest from .RepoDigests.
+          IMAGE_ID=$(docker image ls --quiet --no-trunc ${{ env.REGISTRY }}/${{ env.OWNER }}/${{ inputs.image }} | head -1)
+          IMAGE_DIGEST=$(docker inspect --format='{{index .RepoDigests 0}}' "${IMAGE_ID}" | cut -d'@' -f2)
           cosign sign --yes \
             ${{ env.REGISTRY }}/${{ env.OWNER }}/${{ inputs.image }}@${IMAGE_DIGEST}
         shell: bash

--- a/.github/workflows/docker-tag-push.yml
+++ b/.github/workflows/docker-tag-push.yml
@@ -71,9 +71,10 @@ jobs:
       - name: Push single platform images to Registry 📤
         if: env.PUSH_TO_REGISTRY == 'true'
         run: |
-          docker push --all-tags ${{ env.REGISTRY }}/${{ env.OWNER }}/${{ inputs.image }} || \
+          docker push --all-tags ${{ env.REGISTRY }}/${{ env.OWNER }}/${{ inputs.image }} | tee /tmp/push.log || \
           (sleep 10 && \
-          docker push --all-tags ${{ env.REGISTRY }}/${{ env.OWNER }}/${{ inputs.image }})
+          docker push --all-tags ${{ env.REGISTRY }}/${{ env.OWNER }}/${{ inputs.image }} | tee /tmp/push.log)
+          echo "IMAGE_DIGEST=$(grep -o 'digest: sha256:[a-f0-9]\{64\}' /tmp/push.log | head -1 | cut -d' ' -f2)" >> "$GITHUB_ENV"
         shell: bash
 
       - name: Install Cosign 🔏
@@ -82,7 +83,6 @@ jobs:
       - name: Sign image with Cosign 🔏
         if: env.PUSH_TO_REGISTRY == 'true'
         run: |
-          IMAGE_DIGEST=$(docker inspect --format='{{index .RepoDigests 0}}' ${{ env.REGISTRY }}/${{ env.OWNER }}/${{ inputs.image }} | cut -d'@' -f2)
           cosign sign --yes \
             ${{ env.REGISTRY }}/${{ env.OWNER }}/${{ inputs.image }}@${IMAGE_DIGEST}
         shell: bash

--- a/.github/workflows/docker-tag-push.yml
+++ b/.github/workflows/docker-tag-push.yml
@@ -82,10 +82,7 @@ jobs:
       - name: Sign image with Cosign 🔏
         if: env.PUSH_TO_REGISTRY == 'true'
         run: |
-          # The :latest tag was removed earlier, so inspect by image ID to read
-          # the push-populated digest from .RepoDigests.
-          IMAGE_ID=$(docker image ls --quiet --no-trunc ${{ env.REGISTRY }}/${{ env.OWNER }}/${{ inputs.image }} | head -1)
-          IMAGE_DIGEST=$(docker inspect --format='{{index .RepoDigests 0}}' "${IMAGE_ID}" | cut -d'@' -f2)
+          IMAGE_DIGEST=$(docker images --no-trunc --format '{{.Digest}}' ${{ env.REGISTRY }}/${{ env.OWNER }}/${{ inputs.image }} | head -1)
           cosign sign --yes \
             ${{ env.REGISTRY }}/${{ env.OWNER }}/${{ inputs.image }}@${IMAGE_DIGEST}
         shell: bash


### PR DESCRIPTION
## Problem

The cosign signing step in `docker-tag-push.yml` (added in #2484) resolved the digest with `docker inspect` on the tagless image name, which resolves to `:latest`. But `apply-single-tags` removes the `:latest` tag earlier, so `docker inspect` finds no object, `IMAGE_DIGEST` is empty, and cosign fails on `main` with:

```
error: no such object: quay.io/jupyter/docker-stacks-foundation
```

## Solution

Resolve the digest with `docker images --no-trunc --format '{{.Digest}}'`, which reads the push-populated digest by repository name and doesn't depend on the removed `:latest` tag.