### PR TITLE
ci: fix empty cosign digest in docker-tag-push

### DIFF
--- a/.github/workflows/docker-tag-push.yml
+++ b/.github/workflows/docker-tag-push.yml
@@ -82,7 +82,7 @@ jobs:
       - name: Sign image with Cosign 🔏
         if: env.PUSH_TO_REGISTRY == 'true'
         run: |
-          IMAGE_DIGEST=$(docker inspect --format='{{index .RepoDigests 0}}' ${{ env.REGISTRY }}/${{ env.OWNER }}/${{ inputs.image }} | cut -d'@' -f2)
+          IMAGE_DIGEST=$(docker images --no-trunc --format '{{.Digest}}' ${{ env.REGISTRY }}/${{ env.OWNER }}/${{ inputs.image }} | head -1)
           cosign sign --yes \
             ${{ env.REGISTRY }}/${{ env.OWNER }}/${{ inputs.image }}@${IMAGE_DIGEST}
         shell: bash


### PR DESCRIPTION
## Problem

The cosign signing step in `docker-tag-push.yml` (added in #2484) resolved the digest with `docker inspect` on the tagless image name, which resolves to `:latest`. But `apply-single-tags` removes the `:latest` tag earlier, so `docker inspect` finds no object, `IMAGE_DIGEST` is empty, and cosign fails on `main` with:

```
error: no such object: quay.io/jupyter/docker-stacks-foundation
```

## Solution

Resolve the digest with `docker images --no-trunc --format '{{.Digest}}'`, which reads the push-populated digest by repository name and doesn't depend on the removed `:latest` tag.