### PR TITLE
Revert "ci: sign container images with cosign for supply-chain security"

### DIFF
--- a/.github/workflows/docker-tag-merge.yml
+++ b/.github/workflows/docker-tag-merge.yml
@@ -32,7 +32,6 @@ jobs:
     runs-on: ubuntu-24.04
     permissions:
       contents: read
-      id-token: write
     timeout-minutes: ${{ inputs.timeout-minutes }}
 
     steps:
@@ -73,17 +72,6 @@ jobs:
             --image ${{ inputs.image }} \
             --variant ${{ inputs.variant }} \
             --tags-dir /tmp/jupyter/tags/
-        shell: bash
-
-      - name: Install Cosign 🔏
-        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
-
-      - name: Sign image with Cosign 🔏
-        if: env.PUSH_TO_REGISTRY == 'true'
-        run: |
-          IMAGE_DIGEST=$(docker manifest inspect ${{ env.REGISTRY }}/${{ env.OWNER }}/${{ inputs.image }} --verbose | python3 -c "import sys,json; data=json.load(sys.stdin); print(data[0]['Descriptor']['digest']) if isinstance(data, list) else print(data['Descriptor']['digest'])")
-          cosign sign --yes \
-            ${{ env.REGISTRY }}/${{ env.OWNER }}/${{ inputs.image }}@${IMAGE_DIGEST}
         shell: bash
 
       - name: Logout from Registry 🔐

--- a/.github/workflows/docker-tag-push-merge.yml
+++ b/.github/workflows/docker-tag-push-merge.yml
@@ -24,7 +24,6 @@ jobs:
     uses: ./.github/workflows/docker-tag-push.yml
     permissions:
       contents: read
-      id-token: write
     with:
       image: ${{ inputs.image }}
       variant: ${{ inputs.variant }}
@@ -36,7 +35,6 @@ jobs:
     uses: ./.github/workflows/docker-tag-merge.yml
     permissions:
       contents: read
-      id-token: write
     needs: tag-push
     with:
       image: ${{ inputs.image }}

--- a/.github/workflows/docker-tag-push.yml
+++ b/.github/workflows/docker-tag-push.yml
@@ -33,7 +33,6 @@ jobs:
     runs-on: ubuntu-24.04
     permissions:
       contents: read
-      id-token: write
     timeout-minutes: ${{ inputs.timeout-minutes }}
     strategy:
       matrix:
@@ -74,17 +73,6 @@ jobs:
           docker push --all-tags ${{ env.REGISTRY }}/${{ env.OWNER }}/${{ inputs.image }} || \
           (sleep 10 && \
           docker push --all-tags ${{ env.REGISTRY }}/${{ env.OWNER }}/${{ inputs.image }})
-        shell: bash
-
-      - name: Install Cosign 🔏
-        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
-
-      - name: Sign image with Cosign 🔏
-        if: env.PUSH_TO_REGISTRY == 'true'
-        run: |
-          IMAGE_DIGEST=$(docker inspect --format='{{index .RepoDigests 0}}' ${{ env.REGISTRY }}/${{ env.OWNER }}/${{ inputs.image }} | cut -d'@' -f2)
-          cosign sign --yes \
-            ${{ env.REGISTRY }}/${{ env.OWNER }}/${{ inputs.image }}@${IMAGE_DIGEST}
         shell: bash
 
       - name: Logout from Registry 🔐

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -452,7 +452,6 @@ jobs:
     uses: ./.github/workflows/docker-tag-push-merge.yml
     permissions:
       contents: read
-      id-token: write
     with:
       image: ${{ matrix.image }}
       variant: ${{ matrix.variant }}
@@ -523,7 +522,6 @@ jobs:
     uses: ./.github/workflows/docker-tag-push-merge.yml
     permissions:
       contents: read
-      id-token: write
     with:
       image: ${{ matrix.image }}
       variant: ${{ matrix.variant }}


### PR DESCRIPTION
Reverts jupyter/docker-stacks#2484

https://github.com/jupyter/docker-stacks/pull/2494 is taking a long time to fix. I would rather revert and implement it correctly at this point.