### PR TITLE
Use shfmt instead of bashate

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -67,7 +67,7 @@ repos:
 
   # Autoformat: YAML, JSON, Markdown, etc.
   - repo: https://github.com/rbubley/mirrors-prettier
-    rev: 515f543f5718ebfd6ce22e16708bb32c68ff96e1 # frozen: v3.8.3
+    rev: 06507ab9500d4a9919b5ebd76d9d5b7074f15c1f # frozen: v3.8.4
     hooks:
       - id: prettier
 
@@ -84,7 +84,7 @@ repos:
 
   # Lint: Dockerfile
   - repo: https://github.com/hadolint/hadolint
-    rev: 4e697ba704fd23b2409b947a319c19c3ee54d24f # frozen: v2.14.0
+    rev: 57e1618d78fd469a92c1e584e8c9313024656623 # frozen: v2.14.0
     hooks:
       - id: hadolint-docker
         entry: hadolint/hadolint:v2.14.0 hadolint
@@ -92,7 +92,7 @@ repos:
   # Lint: Dockerfile
   # We're linting .dockerfile files as well
   - repo: https://github.com/hadolint/hadolint
-    rev: 4e697ba704fd23b2409b947a319c19c3ee54d24f # frozen: v2.14.0
+    rev: 57e1618d78fd469a92c1e584e8c9313024656623 # frozen: v2.14.0
     hooks:
       - id: hadolint-docker
         name: Lint *.dockerfile Dockerfiles
@@ -108,11 +108,11 @@ repos:
         args: ["-d {extends: relaxed, rules: {line-length: disable}}", "-s"]
 
   # Lint: Bash scripts
-  - repo: https://github.com/openstack/bashate
-    rev: 5798d24d571676fc407e81df574c1ef57b520f23 # frozen: 2.1.1
+  - repo: https://github.com/scop/pre-commit-shfmt
+    rev: 05c1426671b9237fb5e1444dd63aa5731bec0dfb # frozen: v3.13.1-1
     hooks:
-      - id: bashate
-        args: ["--ignore=E006"]
+      - id: shfmt
+        args: [--write, --indent=4, --case-indent=true]
 
   # Lint: Shell scripts
   - repo: https://github.com/shellcheck-py/shellcheck-py
@@ -123,7 +123,7 @@ repos:
 
   # Lint: Python
   - repo: https://github.com/PyCQA/flake8
-    rev: d93590f5be797aabb60e3b09f2f52dddb02f349f # frozen: 7.3.0
+    rev: c48217e1fc006c2dddd14df54e83b67da15de5cd # frozen: 7.3.0
     hooks:
       - id: flake8
 
@@ -136,14 +136,14 @@ repos:
 
   # Strip output from Jupyter notebooks
   - repo: https://github.com/kynan/nbstripout
-    rev: f5da19ce3b7b40e97c12ee9cd8ce97f48f97ddf7 # frozen: 0.9.1
+    rev: 34071b78c181af3bf5af955c1426466e096fc3db # frozen: 0.9.1
     hooks:
       - id: nbstripout
 
   # nbQA provides tools from the Python ecosystem like
   # pyupgrade, isort, black, and flake8, adjusted for notebooks.
   - repo: https://github.com/nbQA-dev/nbQA
-    rev: f96ec7f3b26a32619435686eb5813235f7e3327e # frozen: 1.9.1
+    rev: d31b7eae1767c43460afb3ba130e0a6602933abe # frozen: 1.9.1
     hooks:
       - id: nbqa-pyupgrade
         args: [--py312-plus]
@@ -154,7 +154,7 @@ repos:
 
   # Run black on python code blocks in documentation files.
   - repo: https://github.com/adamchainz/blacken-docs
-    rev: dda8db18cfc68df532abf33b185ecd12d5b7b326 # frozen: 1.20.0
+    rev: fda77690955e9b63c6687d8806bafd56a526e45f # frozen: 1.20.0
     hooks:
       - id: blacken-docs
         # --skip-errors is added to allow us to have python syntax highlighting even if

--- a/examples/docker-compose/bin/letsencrypt.sh
+++ b/examples/docker-compose/bin/letsencrypt.sh
@@ -8,12 +8,12 @@
 set -e
 
 # Get domain and email from environment
-[ -z "${FQDN}" ] && \
-    echo "ERROR: Must set FQDN environment variable" && \
+[ -z "${FQDN}" ] &&
+    echo "ERROR: Must set FQDN environment variable" &&
     exit 1
 
-[ -z "${EMAIL}" ] && \
-    echo "ERROR: Must set EMAIL environment variable" && \
+[ -z "${EMAIL}" ] &&
+    echo "ERROR: Must set EMAIL environment variable" &&
     exit 1
 
 # letsencrypt certificate server type (default is production).

--- a/examples/docker-compose/bin/sl-dns.sh
+++ b/examples/docker-compose/bin/sl-dns.sh
@@ -5,7 +5,10 @@
 set -e
 
 # User must have slcli installed
-which slcli > /dev/null || (echo "SoftLayer cli not found (pip install softlayer)"; exit 1)
+which slcli >/dev/null || (
+    echo "SoftLayer cli not found (pip install softlayer)"
+    exit 1
+)
 
 USAGE="Usage: $(basename "${0}") machine_name [domain]"
 E_BADARGS=85
@@ -14,8 +17,8 @@ E_BADARGS=85
 MACHINE_NAME="${1}" && [ -z "${MACHINE_NAME}" ] && echo "${USAGE}" && exit ${E_BADARGS}
 
 # Use SOFTLAYER_DOMAIN env var if domain name not set as second arg
-DOMAIN="${2:-$SOFTLAYER_DOMAIN}" && [ -z "${DOMAIN}" ] && \
-    echo "Must specify domain or set SOFTLAYER_DOMAIN environment variable" && \
+DOMAIN="${2:-$SOFTLAYER_DOMAIN}" && [ -z "${DOMAIN}" ] &&
+    echo "Must specify domain or set SOFTLAYER_DOMAIN environment variable" &&
     echo "${USAGE}" && exit ${E_BADARGS}
 
 IP=$(docker-machine ip "${MACHINE_NAME}")

--- a/examples/docker-compose/notebook/build.sh
+++ b/examples/docker-compose/notebook/build.sh
@@ -2,7 +2,7 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 # Setup environment
 # shellcheck source=examples/docker-compose/notebook/env.sh

--- a/examples/docker-compose/notebook/down.sh
+++ b/examples/docker-compose/notebook/down.sh
@@ -2,7 +2,7 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 # Setup environment
 # shellcheck source=examples/docker-compose/notebook/env.sh

--- a/examples/docker-compose/notebook/up.sh
+++ b/examples/docker-compose/notebook/up.sh
@@ -4,7 +4,7 @@
 
 set -e
 
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 USAGE="Usage: $(basename "${0}") [--secure | --letsencrypt] [--password PASSWORD] [--secrets SECRETS_VOLUME]"
 
@@ -12,27 +12,27 @@ USAGE="Usage: $(basename "${0}") [--secure | --letsencrypt] [--password PASSWORD
 SECURE=${SECURE:=no}
 LETSENCRYPT=${LETSENCRYPT:=no}
 while [[ $# -gt 0 ]]; do
-key="${1}"
-case "${key}" in
-    --secure)
-    SECURE=yes
-    ;;
-    --letsencrypt)
-    LETSENCRYPT=yes
-    ;;
-    --secrets)
-    SECRETS_VOLUME="${2}"
-    shift # past argument
-    ;;
-    --password)
-    PASSWORD="${2}"
-    export PASSWORD
-    shift # past argument
-    ;;
-    *) # unknown option
-    ;;
-esac
-shift # past argument or value
+    key="${1}"
+    case "${key}" in
+        --secure)
+            SECURE=yes
+            ;;
+        --letsencrypt)
+            LETSENCRYPT=yes
+            ;;
+        --secrets)
+            SECRETS_VOLUME="${2}"
+            shift # past argument
+            ;;
+        --password)
+            PASSWORD="${2}"
+            export PASSWORD
+            shift # past argument
+            ;;
+        *) # unknown option
+            ;;
+    esac
+    shift # past argument or value
 done
 
 if [[ "${LETSENCRYPT}" == yes || "${SECURE}" == yes ]]; then

--- a/images/docker-stacks-foundation/_docker_stacks_log.sh
+++ b/images/docker-stacks-foundation/_docker_stacks_log.sh
@@ -6,10 +6,10 @@
 # It will always log fatals, errors and warnings but can be silenced for other
 # messages by setting the JUPYTER_DOCKER_STACKS_QUIET environment variable.
 # Colorizes FATAL, ERROR, WARNING, and DEBUG output when stderr is a terminal.
-_log () {
+_log() {
     local level="${1}"
     case "${level}" in
-        INFO|WARNING|ERROR|FATAL|DEBUG)
+        INFO | WARNING | ERROR | FATAL | DEBUG)
             shift
             ;;
         *)
@@ -22,10 +22,10 @@ _log () {
         if [[ -t 2 ]] && [[ "${NO_COLOR:-}" == "" ]]; then
             local color=""
             case "${level}" in
-                FATAL)   color='1;31' ;; # bold red
-                ERROR)   color='31' ;;   # red
-                WARNING) color='33' ;;   # yellow
-                DEBUG)   color='36' ;;   # cyan
+                FATAL) color='1;31' ;; # bold red
+                ERROR) color='31' ;;   # red
+                WARNING) color='33' ;; # yellow
+                DEBUG) color='36' ;;   # cyan
             esac
             if [[ -n "${color}" ]]; then
                 msg=$'\033[0;'"${color}m${msg}"$'\033[0m'
@@ -34,7 +34,10 @@ _log () {
         echo "${msg}" >&2
     fi
 }
-_log_info () { _log "INFO" "$@"; }
-_log_warn () { _log "WARNING" "$@"; }
-_log_error () { _log "ERROR" "$@"; }
-_log_fatal () { _log "FATAL" "$@"; exit 1; }
+_log_info() { _log "INFO" "$@"; }
+_log_warn() { _log "WARNING" "$@"; }
+_log_error() { _log "ERROR" "$@"; }
+_log_fatal() {
+    _log "FATAL" "$@"
+    exit 1
+}

--- a/images/docker-stacks-foundation/fix-permissions
+++ b/images/docker-stacks-foundation/fix-permissions
@@ -18,16 +18,16 @@ set -e
 for d in "$@"; do
     find "${d}" \
         ! \( \
-            -group "${NB_GID}" \
-            -a -perm -g+rwX \
+        -group "${NB_GID}" \
+        -a -perm -g+rwX \
         \) \
         -exec chgrp "${NB_GID}" -- {} \+ \
         -exec chmod g+rwX -- {} \+
     # setuid, setgid *on directories only*
     find "${d}" \
         \( \
-            -type d \
-            -a ! -perm -6000 \
+        -type d \
+        -a ! -perm -6000 \
         \) \
         -exec chmod +6000 -- {} \+
 done

--- a/images/docker-stacks-foundation/run-hooks.sh
+++ b/images/docker-stacks-foundation/run-hooks.sh
@@ -3,7 +3,7 @@
 # Distributed under the terms of the Modified BSD License.
 
 # Source logging functions if not already available
-if ! declare -F _log > /dev/null; then
+if ! declare -F _log >/dev/null; then
     # shellcheck source=images/docker-stacks-foundation/_docker_stacks_log.sh
     source /usr/local/bin/_docker_stacks_log.sh
 fi

--- a/images/docker-stacks-foundation/start.sh
+++ b/images/docker-stacks-foundation/start.sh
@@ -10,7 +10,7 @@ _log_info "Entered start.sh with args:" "$@"
 
 # A helper function to unset env vars listed in the value of the env var
 # JUPYTER_ENV_VARS_TO_UNSET.
-unset_explicit_env_vars () {
+unset_explicit_env_vars() {
     if [ -n "${JUPYTER_ENV_VARS_TO_UNSET}" ]; then
         for env_var_to_unset in $(echo "${JUPYTER_ENV_VARS_TO_UNSET}" | tr ',' ' '); do
             _log_info "Unset ${env_var_to_unset} due to JUPYTER_ENV_VARS_TO_UNSET"
@@ -20,12 +20,11 @@ unset_explicit_env_vars () {
     fi
 }
 
-
 # Default to starting bash if no command was specified
 if [ $# -eq 0 ]; then
-    cmd=( "bash" )
+    cmd=("bash")
 else
-    cmd=( "$@" )
+    cmd=("$@")
 fi
 
 # Backwards compatibility: `start.sh` is executed by default in ENTRYPOINT
@@ -37,7 +36,6 @@ if [ "${_START_SH_EXECUTED}" = "1" ]; then
 else
     export _START_SH_EXECUTED=1
 fi
-
 
 # NOTE: This hook will run as the user the container was started with!
 # shellcheck source=images/docker-stacks-foundation/run-hooks.sh
@@ -60,13 +58,13 @@ if [ "$(id -u)" == 0 ]; then
     # - CHOWN_HOME_OPTS / CHOWN_EXTRA_OPTS: arguments to the chown commands
 
     # Refit the jovyan user to the desired user (NB_USER)
-    if id jovyan &> /dev/null; then
-        if ! usermod --home "/home/${NB_USER}" --login "${NB_USER}" jovyan 2>&1 | grep "no changes" > /dev/null; then
+    if id jovyan &>/dev/null; then
+        if ! usermod --home "/home/${NB_USER}" --login "${NB_USER}" jovyan 2>&1 | grep "no changes" >/dev/null; then
             _log_info "Updated the jovyan user:"
             _log_info "- username: jovyan       -> ${NB_USER}"
             _log_info "- home dir: /home/jovyan -> /home/${NB_USER}"
         fi
-    elif ! id -u "${NB_USER}" &> /dev/null; then
+    elif ! id -u "${NB_USER}" &>/dev/null; then
         _log_fatal "Neither the jovyan user nor '${NB_USER}' exists. This could be the result of stopping and starting, the container with a different NB_USER environment variable."
     fi
     # Ensure the desired user (NB_USER) gets its desired user id (NB_UID) and is
@@ -133,12 +131,12 @@ if [ "$(id -u)" == 0 ]; then
     fi
 
     # Prepend ${CONDA_DIR}/bin to sudo secure_path
-    sed -r "s#Defaults\s+secure_path\s*=\s*\"?([^\"]+)\"?#Defaults secure_path=\"${CONDA_DIR}/bin:\1\"#" /etc/sudoers | grep secure_path > /etc/sudoers.d/path
+    sed -r "s#Defaults\s+secure_path\s*=\s*\"?([^\"]+)\"?#Defaults secure_path=\"${CONDA_DIR}/bin:\1\"#" /etc/sudoers | grep secure_path >/etc/sudoers.d/path
 
     # Optionally grant passwordless sudo rights for the desired user
     if [[ "${GRANT_SUDO}" == "1" || "${GRANT_SUDO}" == "yes" ]]; then
         _log_info "Granting ${NB_USER} passwordless sudo rights!"
-        echo "${NB_USER} ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers.d/added-by-start-script
+        echo "${NB_USER} ALL=(ALL) NOPASSWD:ALL" >>/etc/sudoers.d/added-by-start-script
     fi
 
     # NOTE: This hook is run as the root user!
@@ -192,8 +190,8 @@ else
         _log_warn "container must be started as root to grant sudo permissions!"
     fi
 
-    JOVYAN_UID="$(id -u jovyan 2>/dev/null)"  # The default UID for the jovyan user
-    JOVYAN_GID="$(id -g jovyan 2>/dev/null)"  # The default GID for the jovyan user
+    JOVYAN_UID="$(id -u jovyan 2>/dev/null)" # The default UID for the jovyan user
+    JOVYAN_GID="$(id -g jovyan 2>/dev/null)" # The default GID for the jovyan user
 
     # Attempt to ensure the user uid we currently run as has a named entry in
     # the /etc/passwd file, as it avoids software crashing on hard assumptions
@@ -201,16 +199,16 @@ else
     # from the Dockerfile during the build.
     #
     # ref: https://github.com/jupyter/docker-stacks/issues/552
-    if ! whoami &> /dev/null; then
+    if ! whoami &>/dev/null; then
         _log_info "There is no entry in /etc/passwd for our UID=$(id -u). Attempting to fix..."
         if [[ -w /etc/passwd ]]; then
             _log_info "Renaming old jovyan user to nayvoj ($(id -u jovyan):$(id -g jovyan))"
 
             # We cannot use "sed --in-place" since sed tries to create a temp file in
             # /etc/ and we may not have write access. Apply sed on our own temp file:
-            sed --expression="s/^jovyan:/nayvoj:/" /etc/passwd > /tmp/passwd
-            echo "${NB_USER}:x:$(id -u):$(id -g):,,,:/home/jovyan:/bin/bash" >> /tmp/passwd
-            cat /tmp/passwd > /etc/passwd
+            sed --expression="s/^jovyan:/nayvoj:/" /etc/passwd >/tmp/passwd
+            echo "${NB_USER}:x:$(id -u):$(id -g):,,,:/home/jovyan:/bin/bash" >>/tmp/passwd
+            cat /tmp/passwd >/etc/passwd
             rm /tmp/passwd
 
             _log_info "Added new ${NB_USER} user ($(id -u):$(id -g)). Fixed UID!"

--- a/images/minimal-notebook/setup-scripts/setup-julia-packages.bash
+++ b/images/minimal-notebook/setup-scripts/setup-julia-packages.bash
@@ -5,7 +5,6 @@ set -exuo pipefail
 # - The JULIA_PKGDIR environment variable is set
 # - Julia is already set up, with the setup_julia.py command
 
-
 # If we don't specify what CPUs the precompilation should be done for, it's
 # *only* done for the target of the host doing the compilation.  When the
 # container runs on a host that's the same architecture, but a *different*
@@ -49,7 +48,7 @@ fix-permissions "${JULIA_PKGDIR}" "${CONDA_DIR}/share/jupyter"
 
 # Install jupyter-pluto-proxy to get Pluto to work on JupyterHub
 mamba install --yes \
-    'jupyter-pluto-proxy' && \
-    mamba clean --all -f -y && \
-    fix-permissions "${CONDA_DIR}" && \
+    'jupyter-pluto-proxy' &&
+    mamba clean --all -f -y &&
+    fix-permissions "${CONDA_DIR}" &&
     fix-permissions "/home/${NB_USER}"


### PR DESCRIPTION
## Describe your changes

`bashate` seems to be abandoned, and it also doesn't auto-format files, so they end up being slightly different.

`sh` with very little setup formats existing files nicely

## Issue ticket if applicable

<!-- Example - Fix: https://github.com/jupyter/docker-stacks/issues/0 -->

## Checklist (especially for first-time contributors)

- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests
- [ ] I will try not to use force-push to make the review process easier for reviewers
- [ ] I have updated the documentation for significant changes

<!-- markdownlint-disable-file MD041 -->
