### PR TITLE
Sign pushed images with cosign

### DIFF
--- a/.github/workflows/docker-tag-merge.yml
+++ b/.github/workflows/docker-tag-merge.yml
@@ -90,9 +90,10 @@ jobs:
           echo "IMAGE_REF=${IMAGE_REF}" >> "${GITHUB_ENV}"
         shell: bash
 
+      # The bundle format stores the signature using OCI 1.1 referrers and requires cosign v3+ to verify
       - name: Sign multi-platform image with Cosign 🔏
         if: env.PUSH_TO_REGISTRY == 'true'
-        run: cosign sign --yes "${IMAGE_REF}"
+        run: cosign sign --yes --new-bundle-format=true "${IMAGE_REF}"
         shell: bash
 
       - name: Logout from Registry 🔐

--- a/.github/workflows/docker-tag-merge.yml
+++ b/.github/workflows/docker-tag-merge.yml
@@ -32,6 +32,7 @@ jobs:
     runs-on: ubuntu-24.04
     permissions:
       contents: read
+      id-token: write
     timeout-minutes: ${{ inputs.timeout-minutes }}
 
     steps:
@@ -75,6 +76,23 @@ jobs:
             --image ${{ inputs.image }} \
             --variant ${{ inputs.variant }} \
             --tags-dir /tmp/jupyter/tags/
+        shell: bash
+
+      - name: Install Cosign 🔏
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+
+      - name: Calculate image ref 🔑
+        run: |
+          IMAGE_REF=$(python3 -m tagging.apps.calculate_image_ref \
+            --image ${{ inputs.image }} \
+            --variant ${{ inputs.variant }} \
+            --tags-dir /tmp/jupyter/tags/)
+          echo "IMAGE_REF=${IMAGE_REF}" >> "${GITHUB_ENV}"
+        shell: bash
+
+      - name: Sign multi-platform image with Cosign 🔏
+        if: env.PUSH_TO_REGISTRY == 'true'
+        run: cosign sign --yes "${IMAGE_REF}"
         shell: bash
 
       - name: Logout from Registry 🔐

--- a/.github/workflows/docker-tag-push-merge.yml
+++ b/.github/workflows/docker-tag-push-merge.yml
@@ -24,6 +24,7 @@ jobs:
     uses: ./.github/workflows/docker-tag-push.yml
     permissions:
       contents: read
+      id-token: write
     with:
       image: ${{ inputs.image }}
       variant: ${{ inputs.variant }}
@@ -35,6 +36,7 @@ jobs:
     uses: ./.github/workflows/docker-tag-merge.yml
     permissions:
       contents: read
+      id-token: write
     needs: tag-push
     with:
       image: ${{ inputs.image }}

--- a/.github/workflows/docker-tag-push.yml
+++ b/.github/workflows/docker-tag-push.yml
@@ -33,6 +33,7 @@ jobs:
     runs-on: ubuntu-24.04
     permissions:
       contents: read
+      id-token: write
     timeout-minutes: ${{ inputs.timeout-minutes }}
     strategy:
       matrix:
@@ -76,6 +77,24 @@ jobs:
           docker push --all-tags ${{ env.REGISTRY }}/${{ env.OWNER }}/${{ inputs.image }} || \
           (sleep 10 && \
           docker push --all-tags ${{ env.REGISTRY }}/${{ env.OWNER }}/${{ inputs.image }})
+        shell: bash
+
+      - name: Install Cosign 🔏
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+
+      - name: Calculate image ref 🔑
+        run: |
+          IMAGE_REF=$(python3 -m tagging.apps.calculate_image_ref \
+            --image ${{ inputs.image }} \
+            --variant ${{ inputs.variant }} \
+            --platform ${{ matrix.platform }} \
+            --tags-dir /tmp/jupyter/tags/)
+          echo "IMAGE_REF=${IMAGE_REF}" >> "${GITHUB_ENV}"
+        shell: bash
+
+      - name: Sign single platform image with Cosign 🔏
+        if: env.PUSH_TO_REGISTRY == 'true'
+        run: cosign sign --yes "${IMAGE_REF}"
         shell: bash
 
       - name: Logout from Registry 🔐

--- a/.github/workflows/docker-tag-push.yml
+++ b/.github/workflows/docker-tag-push.yml
@@ -92,9 +92,10 @@ jobs:
           echo "IMAGE_REF=${IMAGE_REF}" >> "${GITHUB_ENV}"
         shell: bash
 
+      # The bundle format stores the signature using OCI 1.1 referrers and requires cosign v3+ to verify
       - name: Sign single platform image with Cosign 🔏
         if: env.PUSH_TO_REGISTRY == 'true'
-        run: cosign sign --yes "${IMAGE_REF}"
+        run: cosign sign --yes --new-bundle-format=true "${IMAGE_REF}"
         shell: bash
 
       - name: Logout from Registry 🔐

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -456,6 +456,7 @@ jobs:
     uses: ./.github/workflows/docker-tag-push-merge.yml
     permissions:
       contents: read
+      id-token: write
     with:
       image: ${{ matrix.image }}
       variant: ${{ matrix.variant }}
@@ -524,6 +525,7 @@ jobs:
     uses: ./.github/workflows/docker-tag-push-merge.yml
     permissions:
       contents: read
+      id-token: write
     with:
       image: ${{ matrix.image }}
       variant: ${{ matrix.variant }}

--- a/docs/using/selecting.md
+++ b/docs/using/selecting.md
@@ -310,6 +310,7 @@ than the latest git commit SHA in the default branch of the
 
 Pushed images (both multi-platform and single-platform ones) are signed with [cosign](https://docs.sigstore.dev/cosign/signing/overview/)
 using keyless signing with the GitHub Actions OIDC identity.
+Signatures are stored in the Sigstore bundle format, which requires cosign v3+ to verify.
 To verify that an image was built and pushed by this repository's CI:
 
 ```bash

--- a/docs/using/selecting.md
+++ b/docs/using/selecting.md
@@ -306,6 +306,18 @@ tag from a date before the current date (in UTC) or a git commit SHA older
 than the latest git commit SHA in the default branch of the
 [jupyter/docker-stacks GitHub repository](https://github.com/jupyter/docker-stacks/).
 
+### Verifying image signatures
+
+Pushed images (both multi-platform and single-platform ones) are signed with [cosign](https://docs.sigstore.dev/cosign/signing/overview/)
+using keyless signing with the GitHub Actions OIDC identity.
+To verify that an image was built and pushed by this repository's CI:
+
+```bash
+cosign verify quay.io/jupyter/base-notebook:latest \
+    --certificate-identity-regexp='^https://github\.com/jupyter/docker-stacks/' \
+    --certificate-oidc-issuer=https://token.actions.githubusercontent.com
+```
+
 ## Community Stacks
 
 The core stacks are but a tiny sample of what's possible when combining Jupyter with other technologies.

--- a/tagging/apps/calculate_image_ref.py
+++ b/tagging/apps/calculate_image_ref.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+import logging
+import os
+
+from tenacity import RetryError
+
+from tagging.apps.common_cli_arguments import common_arguments_parser
+from tagging.apps.config import Config
+from tagging.apps.merge_tags import read_local_tags_from_files
+from tagging.utils.get_manifest_digest import ManifestNotFoundError, get_manifest_digest
+from tagging.utils.get_prefix import get_file_prefix_for_platform
+
+LOGGER = logging.getLogger(__name__)
+
+
+def get_tag_to_sign(config: Config) -> str:
+    """All tags of an image point to the same digest, so any tag can be signed.
+    If the platform is not specified, choose one of the merged tags."""
+    if config.platform:
+        file_prefix = get_file_prefix_for_platform(
+            platform=config.platform, variant=config.variant
+        )
+        filename = f"{file_prefix}-{config.image}.txt"
+        return (config.tags_dir / filename).read_text().splitlines()[0]
+    return next(iter(read_local_tags_from_files(config)))
+
+
+def calculate_image_ref(config: Config, push_to_registry: bool) -> str | None:
+    tag = get_tag_to_sign(config)
+    try:
+        digest = get_manifest_digest(tag)
+    except (ManifestNotFoundError, RetryError):
+        # The tag might not exist in the registry yet if the image is new
+        if push_to_registry:
+            raise
+        LOGGER.warning(f"Failed to calculate digest for tag: {tag}")
+        return None
+    image = tag.rpartition(":")[0]
+    return f"{image}@{digest}"
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+
+    config = common_arguments_parser(
+        image=True, variant=True, platform_optional=True, tags_dir=True
+    )
+    push_to_registry = os.environ.get("PUSH_TO_REGISTRY", "false").lower() == "true"
+
+    image_ref = calculate_image_ref(config, push_to_registry)
+    if image_ref is not None:
+        print(image_ref)

--- a/tagging/apps/common_cli_arguments.py
+++ b/tagging/apps/common_cli_arguments.py
@@ -14,6 +14,7 @@ def common_arguments_parser(
     image: bool = False,
     variant: bool = False,
     platform: bool = False,
+    platform_optional: bool = False,
     tags_dir: bool = False,
     hist_lines_dir: bool = False,
     manifests_dir: bool = False,
@@ -47,10 +48,11 @@ def common_arguments_parser(
             required=True,
             help="Variant tag prefix",
         )
-    if platform:
+    if platform or platform_optional:
         parser.add_argument(
             "--platform",
-            required=True,
+            required=platform,
+            default="",
             type=str,
             choices=["x86_64", "aarch64", "arm64"],
             help="Image platform",
@@ -83,7 +85,7 @@ def common_arguments_parser(
             help="Repository name on GitHub",
         )
     args = parser.parse_args()
-    if platform:
+    if platform or platform_optional:
         args.platform = unify_aarch64(args.platform)
 
     return Config(**vars(args))

--- a/tagging/apps/merge_tags.py
+++ b/tagging/apps/merge_tags.py
@@ -5,16 +5,11 @@ import logging
 import os
 
 import plumbum
-from tenacity import (
-    RetryError,
-    retry,
-    retry_if_not_exception_type,
-    stop_after_attempt,
-    wait_exponential,
-)
+from tenacity import RetryError
 
 from tagging.apps.common_cli_arguments import common_arguments_parser
 from tagging.apps.config import Config
+from tagging.utils.get_manifest_digest import ManifestNotFoundError, get_manifest_digest
 from tagging.utils.get_platform import ALL_PLATFORMS
 from tagging.utils.get_prefix import get_file_prefix_for_platform
 from tagging.utils.git_helper import GitHelper
@@ -22,12 +17,6 @@ from tagging.utils.git_helper import GitHelper
 docker = plumbum.local["docker"]
 
 LOGGER = logging.getLogger(__name__)
-
-MANIFEST_NOT_FOUND_ERRORS = ("manifest unknown", "name unknown", "not found")
-
-
-class ManifestNotFoundError(RuntimeError):
-    """Raised when the registry definitively reports that a manifest doesn't exist"""
 
 
 def read_local_tags_from_files(config: Config) -> dict[str, set[str]]:
@@ -55,29 +44,6 @@ def read_local_tags_from_files(config: Config) -> dict[str, set[str]]:
     return local_platforms_per_tag
 
 
-@retry(
-    stop=stop_after_attempt(3),
-    wait=wait_exponential(multiplier=1, min=4),
-    # A definitive answer from the registry that the manifest doesn't exist
-    # is not a transient error, so there is no reason to retry
-    retry=retry_if_not_exception_type(ManifestNotFoundError),
-)
-def inspect_manifest(tag: str) -> None:
-    LOGGER.info(f"Inspecting manifest for tag: {tag}")
-    retcode, stdout, stderr = docker["buildx", "imagetools", "inspect", tag].run(
-        retcode=None
-    )
-    if retcode == 0:
-        LOGGER.info(f"Manifest {tag} exists")
-        return
-    output = f"{stdout}\n{stderr}"
-    if any(error in output.lower() for error in MANIFEST_NOT_FOUND_ERRORS):
-        raise ManifestNotFoundError(
-            f"Manifest for tag: {tag} doesn't exist in the registry:\n{output}"
-        )
-    raise RuntimeError(f"Failed to inspect manifest for tag: {tag}\n{output}")
-
-
 def find_platform_tags(
     merged_tag: str, local_platforms: set[str], push_to_registry: bool
 ) -> list[str]:
@@ -88,7 +54,7 @@ def find_platform_tags(
         platform_tag = f"{image}:{platform}-{tag}"
         LOGGER.info(f"Trying to inspect: {platform_tag} in the registry")
         try:
-            inspect_manifest(platform_tag)
+            get_manifest_digest(platform_tag)
             platform_tags.append(platform_tag)
             LOGGER.info(f"Tag {platform_tag} found successfully")
         except ManifestNotFoundError as e:

--- a/tagging/utils/get_manifest_digest.py
+++ b/tagging/utils/get_manifest_digest.py
@@ -1,0 +1,45 @@
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+import logging
+
+import plumbum
+from tenacity import (
+    retry,
+    retry_if_not_exception_type,
+    stop_after_attempt,
+    wait_exponential,
+)
+
+docker = plumbum.local["docker"]
+
+LOGGER = logging.getLogger(__name__)
+
+MANIFEST_NOT_FOUND_ERRORS = ("manifest unknown", "name unknown", "not found")
+
+
+class ManifestNotFoundError(RuntimeError):
+    """Raised when the registry definitively reports that a manifest doesn't exist"""
+
+
+@retry(
+    stop=stop_after_attempt(3),
+    wait=wait_exponential(multiplier=1, min=4),
+    # A definitive answer from the registry that the manifest doesn't exist
+    # is not a transient error, so there is no reason to retry
+    retry=retry_if_not_exception_type(ManifestNotFoundError),
+)
+def get_manifest_digest(tag: str) -> str:
+    LOGGER.info(f"Inspecting manifest for tag: {tag}")
+    retcode, stdout, stderr = docker[
+        "buildx", "imagetools", "inspect", tag, "--format", "{{.Manifest.Digest}}"
+    ].run(retcode=None)
+    if retcode == 0:
+        digest: str = stdout.strip()
+        LOGGER.info(f"Manifest for tag: {tag} has digest: {digest}")
+        return digest
+    output = f"{stdout}\n{stderr}"
+    if any(error in output.lower() for error in MANIFEST_NOT_FOUND_ERRORS):
+        raise ManifestNotFoundError(
+            f"Manifest for tag: {tag} doesn't exist in the registry:\n{output}"
+        )
+    raise RuntimeError(f"Failed to inspect manifest for tag: {tag}\n{output}")


### PR DESCRIPTION
The digest to sign is calculated by a new tagging app, which resolves it from the first tag in the tags file, because the image can't be referenced by bare name: the "latest" tag is deliberately removed before pushing single-platform images.

All tags of an image point to the same digest, so a single signature covers all of them.
The digest calculation runs in PRs as well, tolerating images missing from the registry,
and only the signing itself is gated behind PUSH_TO_REGISTRY.

I also merged these commits to my fork and verified my fork images:
```
cosign verify quay.io/mathbunnyru/base-notebook:latest \
    --certificate-identity-regexp='^https://github\.com/mathbunnyru/docker-stacks/' \
    --certificate-oidc-issuer=https://token.actions.githubusercontent.com

Verification for quay.io/mathbunnyru/base-notebook:latest --
The following checks were performed on each of these signatures:
  - The cosign claims were validated
  - Existence of the claims in the transparency log was verified offline
  - The code-signing certificate was verified using trusted certificate authority certificates

[{"critical":{"identity":{"docker-reference":"quay.io/mathbunnyru/base-notebook:latest"},"image":{"docker-manifest-digest":"sha256:750fd765951630e08ed8206116f94917cdb461b60da070d12a8f8b2091b0c183"},"type":"https://sigstore.dev/cosign/sign/v1"},"optional":{}}]
```

Fixes #2455

## Describe your changes

## Issue ticket if applicable

<!-- Example - Fix: https://github.com/jupyter/docker-stacks/issues/0 -->

## Checklist (especially for first-time contributors)

- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests
- [ ] I will try not to use force-push to make the review process easier for reviewers
- [ ] I have updated the documentation for significant changes

<!-- markdownlint-disable-file MD041 -->
