### PR TITLE
Set only the setgid bit on directories in fix-permissions

### DIFF
--- a/images/docker-stacks-foundation/fix-permissions
+++ b/images/docker-stacks-foundation/fix-permissions
@@ -11,7 +11,7 @@
 # Right permissions are:
 # group=${NB_GID}
 # AND permissions include group rwX (directory-execute)
-# AND directories have setuid,setgid bits set
+# AND directories have the setgid bit set (new files and subdirectories inherit the ${NB_GID} group)
 
 set -e
 
@@ -23,11 +23,9 @@ for d in "$@"; do
         \) \
         -exec chgrp "${NB_GID}" -- {} \+ \
         -exec chmod g+rwX -- {} \+
-    # setuid, setgid *on directories only*
+    # setgid *on directories only*
     find "${d}" \
-        \( \
         -type d \
-        -a ! -perm -6000 \
-        \) \
-        -exec chmod +6000 -- {} \+
+        ! -perm -g+s \
+        -exec chmod g+s -- {} \+
 done

--- a/tests/by_image/docker-stacks-foundation/test_user_options.py
+++ b/tests/by_image/docker-stacks-foundation/test_user_options.py
@@ -186,6 +186,27 @@ def test_group_add(container: TrackedContainer) -> None:
     assert "uid=1010 gid=1010 groups=1010,100(users)" in logs
 
 
+def test_conda_dir_group_inheritance(container: TrackedContainer) -> None:
+    """Files and directories created under /opt/conda at runtime by an arbitrary
+    UID should inherit the users group (via the setgid bit set by fix-permissions),
+    so they stay manageable when the container is later run with a different UID."""
+    logs = container.run_and_wait(
+        timeout=10,
+        no_warnings=False,
+        user="1010:1010",
+        group_add=["users"],
+        command=[
+            "bash",
+            "-c",
+            "mkdir /opt/conda/test-dir && "
+            + "touch /opt/conda/test-dir/test-file && "
+            + "stat -c '%n %G %a' /opt/conda/test-dir /opt/conda/test-dir/test-file",
+        ],
+    )
+    assert "/opt/conda/test-dir users 2755" in logs
+    assert "/opt/conda/test-dir/test-file users 644" in logs
+
+
 def test_set_uid(container: TrackedContainer) -> None:
     """Container should run with the specified uid and NB_USER.
     The /home/jovyan directory will not be writable since it's owned by 1000:users.


### PR DESCRIPTION
## Describe your changes

Linux ignores the setuid bit on directories,
so it never provided the owner inheritance intended in https://github.com/jupyter/docker-stacks/pull/435; only setgid works: new files and subdirectories inherit the directory's group. Directories in existing layers keep their setuid bit — they still satisfy `-perm -g+s`, so the script leaves them untouched. Also add a test pinning the group-inheritance behavior, which previously had no coverage.

Fixes https://github.com/jupyter/docker-stacks/issues/638

## Issue ticket if applicable

<!-- Example - Fix: https://github.com/jupyter/docker-stacks/issues/0 -->

## Checklist (especially for first-time contributors)

- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests
- [ ] I will try not to use force-push to make the review process easier for reviewers
- [ ] I have updated the documentation for significant changes

<!-- markdownlint-disable-file MD041 -->
