### PR TITLE
Install mamba the same version as pinned micromamba

### DIFF
--- a/images/docker-stacks-foundation/Dockerfile
+++ b/images/docker-stacks-foundation/Dockerfile
@@ -127,7 +127,9 @@ RUN --mount=type=bind,from=micromamba,source=/bin/micromamba,target=/usr/local/b
         --yes \
         'jupyter_core' \
         'conda' \
-        'mamba' \
+        # mamba 2.9.0 fails to parse the history file entries with comma-range specs
+        # (like protobuf in tensorflow-notebook), breaking `mamba env export --from-history`
+        'mamba==2.8.1' \
         "${PYTHON_SPECIFIER}" && \
     # Pin major.minor version of python
     # https://conda.io/projects/conda/en/latest/user-guide/tasks/manage-pkgs.html#preventing-packages-from-updating-pinning

--- a/images/docker-stacks-foundation/Dockerfile
+++ b/images/docker-stacks-foundation/Dockerfile
@@ -127,9 +127,9 @@ RUN --mount=type=bind,from=micromamba,source=/bin/micromamba,target=/usr/local/b
         --yes \
         'jupyter_core' \
         'conda' \
-        # mamba 2.9.0 fails to parse the history file entries with comma-range specs
-        # (like protobuf in tensorflow-notebook), breaking `mamba env export --from-history`
-        'mamba==2.8.1' \
+        # Install mamba with the same version as the micromamba image pinned above
+        # (they are released together), so dependabot keeps the version up to date
+        "mamba==$(micromamba --version)" \
         "${PYTHON_SPECIFIER}" && \
     # Pin major.minor version of python
     # https://conda.io/projects/conda/en/latest/user-guide/tasks/manage-pkgs.html#preventing-packages-from-updating-pinning


### PR DESCRIPTION
## Describe your changes

The `micromamba` version is pinned, but it was installing the latest version of mamba.
It's a mamba **2.9.0** regression that landed on conda-forge yesterday at 21:09 UTC — ten hours *after* `main`'s last green build (11:24 UTC)
I created an upstream issue: https://github.com/mamba-org/mamba/issues/4374

This PR achieves 2 things:
- makes mamba version the same as micromamba
- keeps it 2.8.1 till the upstream is fixed

This gives us reproducibility (not a strict one, but good enough) for mamba, while keeping Dependabot responsible for updating the version.

## Issue ticket if applicable

<!-- Example - Fix: https://github.com/jupyter/docker-stacks/issues/0 -->

## Checklist (especially for first-time contributors)

- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests
- [ ] I will try not to use force-push to make the review process easier for reviewers
- [ ] I have updated the documentation for significant changes

<!-- markdownlint-disable-file MD041 -->
