### PR TITLE
Make dependabot work well with ubuntu image

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -42,7 +42,11 @@ updates:
       # Moving to a new Ubuntu version is a manual change
       - dependency-name: ubuntu
         update-types:
-          ["version-update:semver-major", "version-update:semver-minor"]
+          [
+            "version-update:semver-major",
+            "version-update:semver-minor",
+            "version-update:semver-patch",
+          ]
   # Dev dependencies are used to test all the images, so full build is required
   - package-ecosystem: pip
     directory: /

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -37,6 +37,12 @@ updates:
     directory: images/docker-stacks-foundation/
     schedule:
       interval: weekly
+    ignore:
+      # Stay on the current Ubuntu LTS, allowing only digest updates for the root image
+      # Moving to a new Ubuntu version is a manual change
+      - dependency-name: ubuntu
+        update-types:
+          ["version-update:semver-major", "version-update:semver-minor"]
   # Dev dependencies are used to test all the images, so full build is required
   - package-ecosystem: pip
     directory: /

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,8 @@ help:
 
 # Note that `ROOT_IMAGE` and `PYTHON_VERSION` arguments are only applicable to the `docker-stacks-foundation` image
 build/%: DOCKER_BUILD_ARGS?=
-build/%: ROOT_IMAGE?=ubuntu:24.04
+# By default, use the sha-pinned root image from the Dockerfile stage
+build/%: ROOT_IMAGE?=default_root_image
 build/%: PYTHON_VERSION?=3.13
 build/%: ## build the latest image for a stack using the system's architecture
 	docker build $(DOCKER_BUILD_ARGS) --rm --force-rm \

--- a/images/docker-stacks-foundation/Dockerfile
+++ b/images/docker-stacks-foundation/Dockerfile
@@ -1,9 +1,13 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 
+# This build arg allows building the image based on a different root image
+ARG ROOT_IMAGE=default_root_image
+
 # Ubuntu 24.04 (noble)
 # https://hub.docker.com/_/ubuntu/tags?page=1&name=noble
-ARG ROOT_IMAGE=ubuntu:24.04@sha256:c4a8d5503dfb2a3eb8ab5f807da5bc69a85730fb49b5cfca2330194ebcc41c7b
+# Referenced as a build stage, so dependabot is able to keep the version and digest up to date
+FROM ubuntu:24.04@sha256:c4a8d5503dfb2a3eb8ab5f807da5bc69a85730fb49b5cfca2330194ebcc41c7b AS default_root_image
 
 # Micromamba is taken from the official image, pinned by digest for integrity
 # Dependabot keeps this version and digest up to date (`docker` ecosystem covers this directory)


### PR DESCRIPTION
## Describe your changes

Dependabot doesn't resolve `ARG` in `FROM` lines (https://github.com/dependabot/dependabot-core/issues/4597),
so the root image has never been checked for updates -
its digest is pinned since #2450 and has never been bumped.

This PR:

- makes Ubuntu updates visible to dependabot by referencing the pinned image as a build stage
- limits these updates to digest-only, without bumping the Ubuntu version itself
- makes `make` builds use the sha-pinned Ubuntu image by default

It is still possible to customize `ROOT_IMAGE` if needed.

## Issue ticket if applicable

<!-- Example - Fix: https://github.com/jupyter/docker-stacks/issues/0 -->

## Checklist (especially for first-time contributors)

- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests
- [ ] I will try not to use force-push to make the review process easier for reviewers
- [ ] I have updated the documentation for significant changes

<!-- markdownlint-disable-file MD041 -->
