### PR TITLE
Pin doc dependencies

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,9 +1,7 @@
-# ReadTheDocs environment contains old package versions preinstalled
-# So, to ensure we have modern packages, we pin minimum versions of the packages we need
 docutils==0.22
-myst-parser>=5.1.0
-sphinx>=9.1.0
-sphinx-book-theme>=1.4.0
-sphinx-copybutton>=0.5.2
-sphinx-last-updated-by-git>=0.3.8
-sphinxcontrib-mermaid>=2.1.0
+myst-parser==5.1.0
+sphinx==9.1.0
+sphinx-book-theme==1.4.0
+sphinx-copybutton==0.5.2
+sphinx-last-updated-by-git==0.3.8
+sphinxcontrib-mermaid==2.1.0


### PR DESCRIPTION
## Describe your changes

This is to make docs-build reproducible.
dependabot takes care of updating.

This is not as good as hash-pinning, but I think it's good enough for docs.
`requirements-dev` is pinned the same way, so it reduces differences.

## Issue ticket if applicable

<!-- Example - Fix: https://github.com/jupyter/docker-stacks/issues/0 -->

## Checklist (especially for first-time contributors)

- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests
- [ ] I will try not to use force-push to make the review process easier for reviewers
- [ ] I have updated the documentation for significant changes

<!-- markdownlint-disable-file MD041 -->
