### PR TITLE
Support Apple Container in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,38 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
-.PHONY: docs help test
+.PHONY: docs help
 
 SHELL:=bash
 REGISTRY?=quay.io
 OWNER?=jupyter
+# The full image reference, only used in the per-image targets, as it depends on the target name
+IMG=$(REGISTRY)/$(OWNER)/$(notdir $@)
+
+# Use Docker if available, otherwise use Apple's container framework
+CONTAINER_CLI?=$(shell command -v docker > /dev/null 2>&1 && echo docker || echo container)
+ifeq ($(CONTAINER_CLI),docker)
+	CONTAINER_NS:=docker container
+	# Docker shows image sizes by default, Apple's container framework requires the flag
+	IMAGE_LS_FLAGS:=
+	# Docker prompts for confirmation without the flag, Apple's container framework never prompts
+	IMAGE_PRUNE_FLAGS:=--force
+	# Docker lists the image references directly, regardless of the table layout
+	IMAGE_REFS:=docker image ls --format "{{.Repository}}:{{.Tag}}"
+else
+	CONTAINER_NS:=container
+	IMAGE_LS_FLAGS:=--verbose
+	IMAGE_PRUNE_FLAGS:=
+	# Apple's container framework lists the image name and the tag in the first two columns
+	IMAGE_REFS:=container image ls | awk 'NR > 1 { print $$1 ":" $$2 }'
+endif
+
+# List local image references (name:tag) matching the given pattern
+define image_refs
+$(IMAGE_REFS) | grep --extended-regexp "$(1)" | grep --invert-match "<none>"
+endef
+
+# IDs of all the containers, evaluated when a recipe uses it
+ALL_CONTAINERS=$(shell $(CONTAINER_NS) ls --all --quiet)
 
 # Enable BuildKit for Docker build
 export DOCKER_BUILDKIT:=1
@@ -30,6 +58,7 @@ help:
 	@echo "jupyter/docker-stacks"
 	@echo "====================="
 	@echo "Replace % with a stack directory name (e.g., make build/minimal-notebook)"
+	@echo "Container engine being used: $(CONTAINER_CLI) (override with CONTAINER_CLI=docker|container)"
 	@echo
 	@grep -E '^[a-zA-Z0-9_%/-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
@@ -41,15 +70,14 @@ build/%: DOCKER_BUILD_ARGS?=
 build/%: ROOT_IMAGE?=default_root_image
 build/%: PYTHON_VERSION?=3.13
 build/%: ## build the latest image for a stack using the system's architecture
-	docker build $(DOCKER_BUILD_ARGS) --rm --force-rm \
-	  --tag "$(REGISTRY)/$(OWNER)/$(notdir $@)" \
+	$(CONTAINER_CLI) build $(DOCKER_BUILD_ARGS) \
+	  --tag "$(IMG)" \
 	  "./images/$(notdir $@)" \
 	  --build-arg REGISTRY="$(REGISTRY)" \
 	  --build-arg OWNER="$(OWNER)" \
 	  --build-arg ROOT_IMAGE="$(ROOT_IMAGE)" \
 	  --build-arg PYTHON_VERSION="$(PYTHON_VERSION)"
-	@echo -n "Built image size: "
-	@docker images "$(REGISTRY)/$(OWNER)/$(notdir $@):latest" --format "{{.Size}}"
+	@$(CONTAINER_CLI) image ls $(IMAGE_LS_FLAGS) | grep --extended-regexp "^(REPOSITORY|NAME|IMAGE)|^$(IMG)[: ]"
 build-all: $(foreach I, $(ALL_IMAGES), build/$(I)) ## build all stacks
 
 
@@ -63,12 +91,13 @@ check-outdated-all: $(foreach I, $(ALL_IMAGES), check-outdated/$(I)) ## check al
 
 
 
+# `-t` means `--timeout` in Docker and `--time` in Apple's container framework
 cont-stop-all: ## stop all containers
 	@echo "Stopping all containers ..."
-	-docker stop --time 0 $(shell docker ps --all --quiet) 2> /dev/null
+	$(if $(ALL_CONTAINERS),-$(CONTAINER_NS) stop -t 0 $(ALL_CONTAINERS))
 cont-rm-all: ## remove all containers
 	@echo "Removing all containers ..."
-	-docker rm --force $(shell docker ps --all --quiet) 2> /dev/null
+	$(if $(ALL_CONTAINERS),-$(CONTAINER_NS) rm --force $(ALL_CONTAINERS))
 cont-clean-all: cont-stop-all cont-rm-all ## clean all containers (stop + rm)
 
 
@@ -110,32 +139,33 @@ hook-all: $(foreach I, $(ALL_IMAGES), hook/$(I)) ## run post-build hooks for all
 
 img-list: ## list jupyter images
 	@echo "Listing $(OWNER) images ..."
-	docker images "$(OWNER)/*"
-	docker images "*/$(OWNER)/*"
+	-$(CONTAINER_CLI) image ls $(IMAGE_LS_FLAGS) | grep --extended-regexp "^(REPOSITORY|NAME|IMAGE)|(^|/)$(OWNER)/"
 img-rm-dang: ## remove dangling images (tagged None)
 	@echo "Removing dangling images ..."
-	-docker rmi --force $(shell docker images -f "dangling=true" --quiet) 2> /dev/null
+	-$(CONTAINER_CLI) image prune $(IMAGE_PRUNE_FLAGS)
+# The owner is matched as a path component, so that other owners like `jupyterhub` don't match
+img-rm-jupyter: JUPYTER_IMAGES=$(shell $(call image_refs,(^|/)$(OWNER)/))
 img-rm-jupyter: ## remove jupyter images
 	@echo "Removing $(OWNER) images ..."
-	-docker rmi --force $(shell docker images --quiet "$(OWNER)/*") 2> /dev/null
-	-docker rmi --force $(shell docker images --quiet "*/$(OWNER)/*") 2> /dev/null
+	$(if $(JUPYTER_IMAGES),-$(CONTAINER_CLI) image rm --force $(JUPYTER_IMAGES))
 img-rm: img-rm-dang img-rm-jupyter ## remove dangling and jupyter images
 
 
 
 pull/%: ## pull a jupyter image
-	docker pull "$(REGISTRY)/$(OWNER)/$(notdir $@)"
+	$(CONTAINER_CLI) image pull "$(IMG)"
 pull-all: $(foreach I, $(ALL_IMAGES), pull/$(I)) ## pull all images
+push/%: IMG_REFS=$(shell $(call image_refs,^$(IMG):))
 push/%: ## push all tags for a jupyter image
-	docker push --all-tags "$(REGISTRY)/$(OWNER)/$(notdir $@)"
+	for ref in $(IMG_REFS); do $(CONTAINER_CLI) image push "$$ref"; done
 push-all: $(foreach I, $(ALL_IMAGES), push/$(I)) ## push all tagged images
 
 
 
 run-shell/%: ## run a bash in interactive mode in a stack
-	docker run -it --rm "$(REGISTRY)/$(OWNER)/$(notdir $@)" $(SHELL)
+	$(CONTAINER_CLI) run -it --rm "$(IMG)" $(SHELL)
 run-sudo-shell/%: ## run bash in interactive mode as root in a stack
-	docker run -it --rm --user root "$(REGISTRY)/$(OWNER)/$(notdir $@)" $(SHELL)
+	$(CONTAINER_CLI) run -it --rm --user root "$(IMG)" $(SHELL)
 
 
 

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ OWNER?=jupyter
 IMG=$(REGISTRY)/$(OWNER)/$(notdir $@)
 
 # Use Docker if available, otherwise use Apple's container framework
-CONTAINER_CLI?=$(shell command -v docker > /dev/null 2>&1 && echo docker || echo container)
+CONTAINER_CLI?=$(if $(shell command -v docker),docker,container)
 ifeq ($(CONTAINER_CLI),docker)
 	CONTAINER_NS:=docker container
 	# Docker shows image sizes by default, Apple's container framework requires the flag

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ endif
 
 # List local image references (name:tag) matching the given pattern
 define image_refs
-$(IMAGE_REFS) | grep --extended-regexp "$(1)" | grep --invert-match "<none>"
+$(IMAGE_REFS) | grep -E "$(1)" | grep -v "<none>"
 endef
 
 # IDs of all the containers, evaluated when a recipe uses it
@@ -77,7 +77,7 @@ build/%: ## build the latest image for a stack using the system's architecture
 	  --build-arg OWNER="$(OWNER)" \
 	  --build-arg ROOT_IMAGE="$(ROOT_IMAGE)" \
 	  --build-arg PYTHON_VERSION="$(PYTHON_VERSION)"
-	@$(CONTAINER_CLI) image ls $(IMAGE_LS_FLAGS) | grep --extended-regexp "^(REPOSITORY|NAME|IMAGE)|^$(IMG)[: ]"
+	@$(CONTAINER_CLI) image ls $(IMAGE_LS_FLAGS) | grep -E "^(REPOSITORY|NAME|IMAGE)|^$(IMG)[: ]"
 build-all: $(foreach I, $(ALL_IMAGES), build/$(I)) ## build all stacks
 
 
@@ -139,7 +139,7 @@ hook-all: $(foreach I, $(ALL_IMAGES), hook/$(I)) ## run post-build hooks for all
 
 img-list: ## list jupyter images
 	@echo "Listing $(OWNER) images ..."
-	-$(CONTAINER_CLI) image ls $(IMAGE_LS_FLAGS) | grep --extended-regexp "^(REPOSITORY|NAME|IMAGE)|(^|/)$(OWNER)/"
+	-$(CONTAINER_CLI) image ls $(IMAGE_LS_FLAGS) | grep -E "^(REPOSITORY|NAME|IMAGE)|(^|/)$(OWNER)/"
 img-rm-dang: ## remove dangling images (tagged None)
 	@echo "Removing dangling images ..."
 	-$(CONTAINER_CLI) image prune $(IMAGE_PRUNE_FLAGS)


### PR DESCRIPTION
## Describe your changes

There are some differences between Apple Container and Docker.
This tries to use commands that work on both, and customizes where it doesn't.

Note:
1. Makefile is only used for local development, so images aren't affected 
2. Testing/tagging is currently impossible without rewriting all docker api to be purely CLI-based, which I would like to avoid

## Issue ticket if applicable

<!-- Example - Fix: https://github.com/jupyter/docker-stacks/issues/0 -->

## Checklist (especially for first-time contributors)

- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests
- [ ] I will try not to use force-push to make the review process easier for reviewers
- [ ] I have updated the documentation for significant changes

<!-- markdownlint-disable-file MD041 -->
