### PR TITLE
Remove docker/setup-docker-action usage

### DIFF
--- a/.github/actions/create-dev-env/action.yml
+++ b/.github/actions/create-dev-env/action.yml
@@ -16,12 +16,3 @@ runs:
         pip install --upgrade pip
         pip install --upgrade -r requirements-dev.txt
       shell: bash
-
-    # We need to have a recent docker version
-    # More info: https://github.com/jupyter/docker-stacks/pull/2255
-    # Can be removed after Docker Engine is updated
-    # https://github.com/actions/runner-images/issues/11766
-    - name: Set Up Docker 🐳
-      uses: docker/setup-docker-action@77e84dbf09b47d1e29270283c22f16145aa85ca1 # v5.4.0
-      with:
-        set-host: true


### PR DESCRIPTION
## Describe your changes

It was added in https://github.com/jupyter/docker-stacks/pull/2255, but since then, Ubuntu images ship Docker Client 28.0.4, which might be enough for us
https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md

## Issue ticket if applicable

<!-- Example - Fix: https://github.com/jupyter/docker-stacks/issues/0 -->

## Checklist (especially for first-time contributors)

- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests
- [ ] I will try not to use force-push to make the review process easier for reviewers
- [ ] I have updated the documentation for significant changes

<!-- markdownlint-disable-file MD041 -->
