### PR TITLE
Do not upgrade installed pip dependencies

### DIFF
--- a/.github/actions/create-dev-env/action.yml
+++ b/.github/actions/create-dev-env/action.yml
@@ -12,9 +12,7 @@ runs:
         cache-dependency-path: requirements-dev.txt
 
     - name: Install Dev Dependencies 📦
-      run: |
-        pip install --upgrade pip
-        pip install --upgrade -r requirements-dev.txt
+      run: pip install -r requirements-dev.txt
       shell: bash
 
     # We need to have a recent docker version

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -30,14 +30,11 @@ jobs:
         with:
           python-version: 3.12
           cache: pip
-          # There is no requirements file for `pre-commit`,
-          # so use the hooks config as the cache key
-          cache-dependency-path: .pre-commit-config.yaml
+          cache-dependency-path: requirements-dev.txt
 
       - name: Install pre-commit 📦
-        run: |
-          pip install --upgrade pip
-          pip install --upgrade pre-commit
+        # Install the version pinned in requirements-dev.txt without the other dev dependencies
+        run: pip install "$(grep '^pre-commit==' requirements-dev.txt)"
 
       - name: Run pre-commit hooks ✅
         run: pre-commit run --all-files --hook-stage manual

--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -67,9 +67,7 @@ jobs:
           cache-dependency-path: docs/requirements.txt
 
       - name: Install Doc Dependencies 📦
-        run: |
-          pip install --upgrade pip
-          pip install --upgrade -r docs/requirements.txt
+        run: pip install -r docs/requirements.txt
 
       - name: Build Documentation 📖
         run: make docs

--- a/docs/contributing/dev-setup.md
+++ b/docs/contributing/dev-setup.md
@@ -20,7 +20,7 @@ git clone https://github.com/jupyter/docker-stacks.git
 cd docker-stacks
 
 # Install Python development dependencies
-pip install --upgrade -r requirements-dev.txt
+pip install -r requirements-dev.txt
 
 # Install pre-commit hooks (runs linters automatically on git commit)
 pre-commit install --install-hooks

--- a/docs/contributing/lint.md
+++ b/docs/contributing/lint.md
@@ -13,9 +13,9 @@ To achieve this, use the generic task to install all Python development dependen
 
 ```sh
 # Install all development dependencies for the project
-pip install --upgrade -r requirements-dev.txt
+pip install -r requirements-dev.txt
 # It can also be installed directly
-pip install pre-commit
+pip install "$(grep '^pre-commit==' requirements-dev.txt)"
 ```
 
 Then the git hooks scripts configured for the project in `.pre-commit-config.yaml` need to be installed in the local git repository.


### PR DESCRIPTION
## Describe your changes

`pip install --upgrade pip` might upgrade to a vulnerable version
`pip install --upgrade -r requirements-dev.txt` - upgrade here doesn't make sense, since we pinned all the dependencies

In the future we might add hash-pinning, but it will still be without `--upgrade`.

## Issue ticket if applicable

<!-- Example - Fix: https://github.com/jupyter/docker-stacks/issues/0 -->

## Checklist (especially for first-time contributors)

- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests
- [ ] I will try not to use force-push to make the review process easier for reviewers
- [ ] I have updated the documentation for significant changes

<!-- markdownlint-disable-file MD041 -->
